### PR TITLE
FEAT: add basic support for /proc/<pid>/io counters.

### DIFF
--- a/fixtures/26231/io
+++ b/fixtures/26231/io
@@ -1,0 +1,7 @@
+rchar: 750339
+wchar: 818609
+syscr: 7405
+syscw: 5245
+read_bytes: 1024
+write_bytes: 2048
+cancelled_write_bytes: -1024

--- a/proc_stat_io.go
+++ b/proc_stat_io.go
@@ -1,0 +1,54 @@
+package procfs
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+// ProcIO models the content of /proc/<pid>/io.
+type ProcIO struct {
+	// Chars read.
+	RChar uint64
+	// Chars written.
+	WChar uint64
+	// Read syscalls.
+	SyscR uint64
+	// Write syscalls.
+	SyscW uint64
+	// Bytes read.
+	ReadBytes uint64
+	// Bytes written.
+	WriteBytes uint64
+	// Bytes written, but taking into account truncation. See
+	// Documentation/filesystems/proc.txt in the kernel sources for
+	// detailed explanation.
+	CancelledWriteBytes int64
+}
+
+// NewIO creates a new ProcIO instance from a given Proc instance.
+func (p Proc) NewIO() (ProcIO, error) {
+	pio := ProcIO{}
+
+	f, err := p.open("io")
+	if err != nil {
+		return pio, err
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return pio, err
+	}
+
+	ioFormat := "rchar: %d\nwchar: %d\nsyscr: %d\nsyscw: %d\n" +
+		"read_bytes: %d\nwrite_bytes: %d\n" +
+		"cancelled_write_bytes: %d\n"
+
+	_, err = fmt.Sscanf(string(data), ioFormat, &pio.RChar, &pio.WChar, &pio.SyscR,
+		&pio.SyscW, &pio.ReadBytes, &pio.WriteBytes, &pio.CancelledWriteBytes)
+	if err != nil {
+		return pio, err
+	}
+
+	return pio, nil
+}

--- a/proc_stat_io_test.go
+++ b/proc_stat_io_test.go
@@ -1,0 +1,49 @@
+package procfs
+
+import "testing"
+
+func TestProcIO(t *testing.T) {
+	fs, err := NewFS("fixtures")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := fs.NewProc(26231)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := p.NewIO()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		want uint64
+		got  uint64
+	}{
+		{name: "RChar", want: 750339, got: s.RChar},
+		{name: "WChar", want: 818609, got: s.WChar},
+		{name: "SyscR", want: 7405, got: s.SyscR},
+		{name: "SyscW", want: 5245, got: s.SyscW},
+		{name: "ReadBytes", want: 1024, got: s.ReadBytes},
+		{name: "WriteBytes", want: 2048, got: s.WriteBytes},
+	} {
+		if test.want != test.got {
+			t.Errorf("want %s %d, got %d", test.name, test.want, test.got)
+		}
+	}
+
+	for _, test := range []struct {
+		name string
+		want int64
+		got  int64
+	}{
+		{name: "CancelledWriteBytes", want: -1024, got: s.CancelledWriteBytes},
+	} {
+		if test.want != test.got {
+			t.Errorf("want %s %d, got %d", test.name, test.want, test.got)
+		}
+	}
+}


### PR DESCRIPTION
May be useful when one tries to track per-process IO.