### PR TITLE
adding mdstat-parser to procfs

### DIFF
--- a/fixtures/mdstat
+++ b/fixtures/mdstat
@@ -1,0 +1,26 @@
+Personalities : [linear] [multipath] [raid0] [raid1] [raid6] [raid5] [raid4] [raid10]
+md3 : active raid6 sda1[8] sdh1[7] sdg1[6] sdf1[5] sde1[11] sdd1[3] sdc1[10] sdb1[9]
+      5853468288 blocks super 1.2 level 6, 64k chunk, algorithm 2 [8/8] [UUUUUUUU]
+      
+md127 : active raid1 sdi2[0] sdj2[1]
+      312319552 blocks [2/2] [UU]
+      
+md0 : active raid1 sdk[2](S) sdi1[0] sdj1[1]
+      248896 blocks [2/2] [UU]
+      
+md4 : inactive raid1 sda3[0] sdb3[1]
+      4883648 blocks [2/2] [UU]
+
+md6 : active raid1 sdb2[2] sda2[0]
+      195310144 blocks [2/1] [U_]
+      [=>...................]  recovery =  8.5% (16775552/195310144) finish=17.0min speed=259783K/sec
+
+md8 : active raid1 sdb1[1] sda1[0]
+      195310144 blocks [2/2] [UU]
+      [=>...................]  resync =  8.5% (16775552/195310144) finish=17.0min speed=259783K/sec
+
+md7 : active raid6 sdb1[0] sde1[3] sdd1[2] sdc1[1]
+      7813735424 blocks super 1.2 level 6, 512k chunk, algorithm 2 [4/3] [U_UU]
+      bitmap: 0/30 pages [0KB], 65536KB chunk
+
+unused devices: <none>

--- a/mdstat.go
+++ b/mdstat.go
@@ -1,0 +1,158 @@
+package procfs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	statuslineRE = regexp.MustCompile(`(\d+) blocks .*\[(\d+)/(\d+)\] \[[U_]+\]`)
+	buildlineRE  = regexp.MustCompile(`\((\d+)/\d+\)`)
+)
+
+// MDStat holds info parsed from /proc/mdstat.
+type MDStat struct {
+	// Name of the device.
+	Name string
+	// activity-state of the device.
+	ActivityState string
+	// Number of active disks.
+	DisksActive int64
+	// Total number of disks the device consists of.
+	DisksTotal int64
+	// Number of blocks the device holds.
+	BlocksTotal int64
+	// Number of blocks on the device that are in sync.
+	BlocksSynced int64
+}
+
+// ParseMDStat parses an mdstat-file and returns a struct with the relevant infos.
+func (fs FS) ParseMDStat() (mdstates []MDStat, err error) {
+	mdStatusFilePath := path.Join(string(fs), "mdstat")
+	content, err := ioutil.ReadFile(mdStatusFilePath)
+	if err != nil {
+		return []MDStat{}, fmt.Errorf("error parsing %s: %s", mdStatusFilePath, err)
+	}
+
+	mdStatusFile := string(content)
+
+	lines := strings.Split(mdStatusFile, "\n")
+	var currentMD string
+
+	// Each md has at least the deviceline, statusline and one empty line afterwards
+	// so we will have probably something of the order len(lines)/3 devices
+	// so we use that for preallocation.
+	estimateMDs := len(lines) / 3
+	mdStates := make([]MDStat, 0, estimateMDs)
+
+	for i, l := range lines {
+		if l == "" {
+			// Skip entirely empty lines.
+			continue
+		}
+
+		if l[0] == ' ' {
+			// Those lines are not the beginning of a md-section.
+			continue
+		}
+
+		if strings.HasPrefix(l, "Personalities") || strings.HasPrefix(l, "unused") {
+			// We aren't interested in lines with general info.
+			continue
+		}
+
+		mainLine := strings.Split(l, " ")
+		if len(mainLine) < 3 {
+			return mdStates, fmt.Errorf("error parsing mdline: %s", l)
+		}
+		currentMD = mainLine[0]      // name of md-device
+		activityState := mainLine[2] // activity status of said md-device
+
+		if len(lines) <= i+3 {
+			return mdStates, fmt.Errorf("error parsing %s: entry for %s has fewer lines than expected", mdStatusFilePath, currentMD)
+		}
+
+		active, total, size, err := evalStatusline(lines[i+1]) // parse statusline, always present
+		if err != nil {
+			return mdStates, fmt.Errorf("error parsing %s: %s", mdStatusFilePath, err)
+		}
+
+		//
+		// Now get the number of synced blocks.
+		//
+
+		// Get the line number of the syncing-line.
+		var j int
+		if strings.Contains(lines[i+2], "bitmap") { // then skip the bitmap line
+			j = i + 3
+		} else {
+			j = i + 2
+		}
+
+		// If device is syncing at the moment, get the number of currently synced bytes,
+		// otherwise that number equals the size of the device.
+		syncedBlocks := size
+		if strings.Contains(lines[j], "recovery") || strings.Contains(lines[j], "resync") {
+			syncedBlocks, err = evalBuildline(lines[j])
+			if err != nil {
+				return mdStates, fmt.Errorf("error parsing %s: %s", mdStatusFilePath, err)
+			}
+		}
+
+		mdStates = append(mdStates, MDStat{currentMD, activityState, active, total, size, syncedBlocks})
+
+	}
+
+	return mdStates, nil
+}
+
+func evalStatusline(statusline string) (active, total, size int64, err error) {
+	matches := statuslineRE.FindStringSubmatch(statusline)
+
+	// +1 to make it more obvious that the whole string containing the info is also returned as matches[0].
+	if len(matches) != 3+1 {
+		return 0, 0, 0, fmt.Errorf("unexpected number matches found in statusline: %s", statusline)
+	}
+
+	size, err = strconv.ParseInt(matches[1], 10, 64)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("%s in statusline: %s", err, statusline)
+	}
+
+	total, err = strconv.ParseInt(matches[2], 10, 64)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("%s in statusline: %s", err, statusline)
+	}
+
+	active, err = strconv.ParseInt(matches[3], 10, 64)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("%s in statusline: %s", err, statusline)
+	}
+
+	return active, total, size, nil
+}
+
+// Gets the size that has already been synced out of the sync-line.
+func evalBuildline(buildline string) (int64, error) {
+	matches := buildlineRE.FindStringSubmatch(buildline)
+
+	// +1 to make it more obvious that the whole string containing the info is also returned as matches[0].
+	if len(matches) < 1+1 {
+		return 0, fmt.Errorf("too few matches found in buildline: %s", buildline)
+	}
+
+	if len(matches) > 1+1 {
+		return 0, fmt.Errorf("too many matches found in buildline: %s", buildline)
+	}
+
+	syncedSize, err := strconv.ParseInt(matches[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s in buildline: %s", err, buildline)
+	}
+
+	return syncedSize, nil
+}

--- a/mdstat_test.go
+++ b/mdstat_test.go
@@ -1,0 +1,33 @@
+package procfs
+
+import (
+	"testing"
+)
+
+func TestMDStat(t *testing.T) {
+	fs := FS("fixtures")
+	mdStates, err := fs.ParseMDStat()
+	if err != nil {
+		t.Fatalf("parsing of reference-file failed entirely: %s", err)
+	}
+
+	refs := map[string]MDStat{
+		"md3":   MDStat{"md3", "active", 8, 8, 5853468288, 5853468288},
+		"md127": MDStat{"md127", "active", 2, 2, 312319552, 312319552},
+		"md0":   MDStat{"md0", "active", 2, 2, 248896, 248896},
+		"md4":   MDStat{"md4", "inactive", 2, 2, 4883648, 4883648},
+		"md6":   MDStat{"md6", "active", 1, 2, 195310144, 16775552},
+		"md8":   MDStat{"md8", "active", 2, 2, 195310144, 16775552},
+		"md7":   MDStat{"md7", "active", 3, 4, 7813735424, 7813735424},
+	}
+
+	for _, md := range mdStates {
+		if md != refs[md.Name] {
+			t.Errorf("failed parsing md-device %s correctly: want %v, got %v", md.Name, refs[md.Name], md)
+		}
+	}
+
+	if len(mdStates) != len(refs) {
+		t.Errorf("expected number of parsed md-device to be %s, but was %s", len(refs), len(mdStates))
+	}
+}


### PR DESCRIPTION
Adding functionality used in node_exporter's mdadm-exporter to procfs, including unittest for the parsing-functionality.