### PR TITLE
moved FS methods to fs.go

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -38,3 +38,48 @@ func (fs FS) open(p string) (*os.File, error) {
 func (fs FS) readlink(p string) (string, error) {
 	return os.Readlink(path.Join(string(fs), p))
 }
+
+// Self returns a process for the current process.
+func (fs FS) Self() (Proc, error) {
+	p, err := fs.readlink("self")
+	if err != nil {
+		return Proc{}, err
+	}
+	pid, err := strconv.Atoi(strings.Replace(p, string(fs), "", -1))
+	if err != nil {
+		return Proc{}, err
+	}
+	return fs.NewProc(pid)
+}
+
+// NewProc returns a process for the given pid.
+func (fs FS) NewProc(pid int) (Proc, error) {
+	if _, err := fs.stat(strconv.Itoa(pid)); err != nil {
+		return Proc{}, err
+	}
+	return Proc{PID: pid, fs: fs}, nil
+}
+
+// AllProcs returns a list of all currently avaible processes.
+func (fs FS) AllProcs() (Procs, error) {
+	d, err := fs.open("")
+	if err != nil {
+		return Procs{}, err
+	}
+	defer d.Close()
+
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return Procs{}, fmt.Errorf("could not read %s: %s", d.Name(), err)
+	}
+
+	p := Procs{}
+	for _, n := range names {
+		pid, err := strconv.ParseInt(n, 10, 64)
+		if err != nil {
+			continue
+		}
+		p = append(p, Proc{PID: int(pid), fs: fs})
+	}
+	return p, nil
+}

--- a/proc.go
+++ b/proc.go
@@ -51,52 +51,6 @@ func AllProcs() (Procs, error) {
 	return fs.AllProcs()
 }
 
-// Self returns a process for the current process.
-func (fs FS) Self() (Proc, error) {
-	p, err := fs.readlink("self")
-	if err != nil {
-		return Proc{}, err
-	}
-	pid, err := strconv.Atoi(strings.Replace(p, string(fs), "", -1))
-	if err != nil {
-		return Proc{}, err
-	}
-	return fs.NewProc(pid)
-}
-
-// NewProc returns a process for the given pid.
-func (fs FS) NewProc(pid int) (Proc, error) {
-	if _, err := fs.stat(strconv.Itoa(pid)); err != nil {
-		return Proc{}, err
-	}
-	return Proc{PID: pid, fs: fs}, nil
-}
-
-// AllProcs returns a list of all currently avaible processes.
-func (fs FS) AllProcs() (Procs, error) {
-	d, err := fs.open("")
-	if err != nil {
-		return Procs{}, err
-	}
-	defer d.Close()
-
-	names, err := d.Readdirnames(-1)
-	if err != nil {
-		return Procs{}, fmt.Errorf("could not read %s: %s", d.Name(), err)
-	}
-
-	p := Procs{}
-	for _, n := range names {
-		pid, err := strconv.ParseInt(n, 10, 64)
-		if err != nil {
-			continue
-		}
-		p = append(p, Proc{PID: int(pid), fs: fs})
-	}
-
-	return p, nil
-}
-
 // CmdLine returns the command line of a process.
 func (p Proc) CmdLine() ([]string, error) {
 	f, err := p.open("cmdline")


### PR DESCRIPTION
@grobie @armen Minor. Moving FS related methods which were located on proc.go instead of fs.go
