### PR TITLE
Fix typo in proc.go.

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -41,7 +41,7 @@ func NewProc(pid int) (Proc, error) {
 	return fs.NewProc(pid)
 }
 
-// AllProcs returns a list of all currently avaible processes under /proc.
+// AllProcs returns a list of all currently available processes under /proc.
 func AllProcs() (Procs, error) {
 	fs, err := NewFS(DefaultMountPoint)
 	if err != nil {
@@ -71,7 +71,7 @@ func (fs FS) NewProc(pid int) (Proc, error) {
 	return Proc{PID: pid, fs: fs}, nil
 }
 
-// AllProcs returns a list of all currently avaible processes.
+// AllProcs returns a list of all currently available processes.
 func (fs FS) AllProcs() (Procs, error) {
 	d, err := os.Open(fs.Path())
 	if err != nil {


### PR DESCRIPTION
@grobie: Fix typo in proc.go.