### PR TITLE
Update Travis to Go 1.6.4 and 1.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: go
 go:
-    - 1.5
-    - 1.6
+    - 1.6.4
+    - 1.7.4


### PR DESCRIPTION
golint no longer appears to build on Go 1.5, so CI will now only check
against Go 1.6.4 and 1.7.4 since they are the most current stable
release and the last stable release.