### PR TITLE
Add new package sysfs

### DIFF
--- a/sysfs/doc.go
+++ b/sysfs/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sysfs provides functions to retrieve system and kernel metrics
+// from the pseudo-filesystem sys.
+package sysfs

--- a/sysfs/fixtures/fs/xfs/sda1/stats/stats
+++ b/sysfs/fixtures/fs/xfs/sda1/stats/stats
@@ -1,0 +1,1 @@
+extent_alloc 1 0 0 0

--- a/sysfs/fixtures/fs/xfs/sdb1/stats/stats
+++ b/sysfs/fixtures/fs/xfs/sdb1/stats/stats
@@ -1,0 +1,1 @@
+extent_alloc 2 0 0 0

--- a/sysfs/fs.go
+++ b/sysfs/fs.go
@@ -1,0 +1,46 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FS represents the pseudo-filesystem sys, which provides an interface to
+// kernel data structures.
+type FS string
+
+// DefaultMountPoint is the common mount point of the sys filesystem.
+const DefaultMountPoint = "/sys"
+
+// NewFS returns a new FS mounted under the given mountPoint. It will error
+// if the mount point can't be read.
+func NewFS(mountPoint string) (FS, error) {
+	info, err := os.Stat(mountPoint)
+	if err != nil {
+		return "", fmt.Errorf("could not read %s: %s", mountPoint, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("mount point %s is not a directory", mountPoint)
+	}
+
+	return FS(mountPoint), nil
+}
+
+// Path returns the path of the given subsystem relative to the sys root.
+func (fs FS) Path(p ...string) string {
+	return filepath.Join(append([]string{string(fs)}, p...)...)
+}

--- a/sysfs/fs.go
+++ b/sysfs/fs.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/prometheus/procfs/xfs"
 )
 
 // FS represents the pseudo-filesystem sys, which provides an interface to
@@ -43,4 +45,38 @@ func NewFS(mountPoint string) (FS, error) {
 // Path returns the path of the given subsystem relative to the sys root.
 func (fs FS) Path(p ...string) string {
 	return filepath.Join(append([]string{string(fs)}, p...)...)
+}
+
+// XFSStats retrieves XFS filesystem runtime statistics for each mounted XFS
+// filesystem.  Only available on kernel 4.4+.  On older kernels, an empty
+// slice of *xfs.Stats will be returned.
+func (fs FS) XFSStats() ([]*xfs.Stats, error) {
+	matches, err := filepath.Glob(fs.Path("fs/xfs/*/stats/stats"))
+	if err != nil {
+		return nil, err
+	}
+
+	stats := make([]*xfs.Stats, 0, len(matches))
+	for _, m := range matches {
+		f, err := os.Open(m)
+		if err != nil {
+			return nil, err
+		}
+
+		// "*" used in glob above indicates the name of the filesystem.
+		name := filepath.Base(filepath.Dir(filepath.Dir(m)))
+
+		// File must be closed after parsing, regardless of success or
+		// failure.  Defer is not used because of the loop.
+		s, err := xfs.ParseStats(f)
+		_ = f.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		s.Name = name
+		stats = append(stats, s)
+	}
+
+	return stats, nil
 }

--- a/sysfs/fs_test.go
+++ b/sysfs/fs_test.go
@@ -24,3 +24,43 @@ func TestNewFS(t *testing.T) {
 		t.Error("want NewFS to fail if mount point is not a directory")
 	}
 }
+
+func TestFSXFSStats(t *testing.T) {
+	stats, err := FS("fixtures").XFSStats()
+	if err != nil {
+		t.Fatalf("failed to parse XFS stats: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		allocated uint32
+	}{
+		{
+			name:      "sda1",
+			allocated: 1,
+		},
+		{
+			name:      "sdb1",
+			allocated: 2,
+		},
+	}
+
+	const expect = 2
+
+	if l := len(stats); l != expect {
+		t.Fatalf("unexpected number of XFS stats: %d", l)
+	}
+	if l := len(tests); l != expect {
+		t.Fatalf("unexpected number of tests: %d", l)
+	}
+
+	for i, tt := range tests {
+		if want, got := tt.name, stats[i].Name; want != got {
+			t.Errorf("unexpected stats name:\nwant: %q\nhave: %q", want, got)
+		}
+
+		if want, got := tt.allocated, stats[i].ExtentAllocation.ExtentsAllocated; want != got {
+			t.Errorf("unexpected extents allocated:\nwant: %d\nhave: %d", want, got)
+		}
+	}
+}

--- a/sysfs/fs_test.go
+++ b/sysfs/fs_test.go
@@ -1,0 +1,26 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysfs
+
+import "testing"
+
+func TestNewFS(t *testing.T) {
+	if _, err := NewFS("foobar"); err == nil {
+		t.Error("want NewFS to fail for non-existing mount point")
+	}
+
+	if _, err := NewFS("doc.go"); err == nil {
+		t.Error("want NewFS to fail if mount point is not a directory")
+	}
+}

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -22,6 +22,11 @@ package xfs
 // kernel source. Most counters are uint32s (same data types used in
 // xfs_stats.h), but some of the "extended precision stats" are uint64s.
 type Stats struct {
+	// The name of the filesystem used to source these statistics.
+	// If empty, this indicates aggregated statistics for all XFS
+	// filesystems on the host.
+	Name string
+
 	ExtentAllocation   ExtentAllocationStats
 	AllocationBTree    BTreeStats
 	BlockMapping       BlockMappingStats


### PR DESCRIPTION
I just copied and pasted `procfs.FS` and created `sysfs.FS`.  This is where functions that rely on `/sys` can live, as discussed on:

https://groups.google.com/forum/#!topic/prometheus-developers/ys1LjSlKwGw

/cc @grobie @SuperQ, since you both preferred a separate package in the same repository.