### PR TITLE
Remove spurious log line from XFS stats parser

### DIFF
--- a/xfs/parse.go
+++ b/xfs/parse.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"log"
 	"strconv"
 	"strings"
 )
@@ -273,7 +272,6 @@ func vnodeStats(us []uint32) (VnodeStats, error) {
 	// stats versions.  Therefore, 7 or 8 elements may appear in
 	// this slice.
 	l := len(us)
-	log.Println(l)
 	if l != 7 && l != 8 {
 		return VnodeStats{}, fmt.Errorf("incorrect number of values for XFS vnode stats: %d", l)
 	}


### PR DESCRIPTION
Silly mistake on my part.