### PR TITLE
Rebuild fixtures every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,8 @@ lint:
 	go get github.com/golang/lint/golint
 	golint *.go
 
-test: sysfs/fixtures/.unpacked
+test:
+	cd sysfs && rm -rf fixtures && tar xzf fixtures.tar.gz
 	go test -v ./...
-
-sysfs/fixtures/.unpacked: sysfs/fixtures.tar.gz
-	cd sysfs && tar xzf fixtures.tar.gz
-	touch $@
 
 .PHONY: fmt lint test ci


### PR DESCRIPTION
With sysfs/fixtures/.unpacked as a build target, developers have to
remember to delete sysfs/fixtures whenever fixtures.tar.gz changes
(e.g., because they switched to a different branch).

With this patch, the fixtures directory is rebuilt every time a
test is run.