### PR TITLE
Feature: Add check_license.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,8 @@ sysfs/fixtures/.unpacked: sysfs/fixtures.ttar
 	./ttar -C sysfs -x -f sysfs/fixtures.ttar
 	touch $@
 
-.PHONY: fmt lint test ci
+check_license:
+	@echo ">> checking license header"
+	@./scripts/check_license.sh
+
+.PHONY: check_license fmt lint test ci

--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+licRes=$(
+for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
+	head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)" || echo -e "  ${file}"
+done;)
+if [ -n "${licRes}" ]; then
+	echo -e "license header checking failed:\n${licRes}"
+	exit 255
+fi


### PR DESCRIPTION
As described in issue #37 there is no automated script to check that all
source files contain a license header.

Prometheus already has a script provided by @jonboulle and I have simply
copied that script and applied it to this code base.

Example output:
```
github.com/prometheus/procfs on  feat-add-license-check [+]
➜ make check_license
>> checking license header
-e license header checking failed:
-e   ./fs.go
-e   ./fs_test.go
-e   ./ipvs.go
...
```

All credit to @jonboulle for the initial script.

This closes #37