### PR TITLE
Fix #62 by switching all limits to int64

### DIFF
--- a/fixtures/26231/limits
+++ b/fixtures/26231/limits
@@ -8,7 +8,7 @@ Max resident set          unlimited            unlimited            bytes
 Max processes             62898                62898                processes
 Max open files            2048                 4096                 files
 Max locked memory         65536                65536                bytes
-Max address space         unlimited            unlimited            bytes
+Max address space         8589934592           unlimited            bytes
 Max file locks            unlimited            unlimited            locks
 Max pending signals       62898                62898                signals
 Max msgqueue size         819200               819200               bytes

--- a/proc_limits.go
+++ b/proc_limits.go
@@ -13,46 +13,46 @@ import (
 // http://man7.org/linux/man-pages/man2/getrlimit.2.html.
 type ProcLimits struct {
 	// CPU time limit in seconds.
-	CPUTime int
+	CPUTime int64
 	// Maximum size of files that the process may create.
-	FileSize int
+	FileSize int64
 	// Maximum size of the process's data segment (initialized data,
 	// uninitialized data, and heap).
-	DataSize int
+	DataSize int64
 	// Maximum size of the process stack in bytes.
-	StackSize int
+	StackSize int64
 	// Maximum size of a core file.
-	CoreFileSize int
+	CoreFileSize int64
 	// Limit of the process's resident set in pages.
-	ResidentSet int
+	ResidentSet int64
 	// Maximum number of processes that can be created for the real user ID of
 	// the calling process.
-	Processes int
+	Processes int64
 	// Value one greater than the maximum file descriptor number that can be
 	// opened by this process.
-	OpenFiles int
+	OpenFiles int64
 	// Maximum number of bytes of memory that may be locked into RAM.
-	LockedMemory int
+	LockedMemory int64
 	// Maximum size of the process's virtual memory address space in bytes.
-	AddressSpace int
+	AddressSpace int64
 	// Limit on the combined number of flock(2) locks and fcntl(2) leases that
 	// this process may establish.
-	FileLocks int
+	FileLocks int64
 	// Limit of signals that may be queued for the real user ID of the calling
 	// process.
-	PendingSignals int
+	PendingSignals int64
 	// Limit on the number of bytes that can be allocated for POSIX message
 	// queues for the real user ID of the calling process.
-	MsqqueueSize int
+	MsqqueueSize int64
 	// Limit of the nice priority set using setpriority(2) or nice(2).
-	NicePriority int
+	NicePriority int64
 	// Limit of the real-time priority set using sched_setscheduler(2) or
 	// sched_setparam(2).
-	RealtimePriority int
+	RealtimePriority int64
 	// Limit (in microseconds) on the amount of CPU time that a process
 	// scheduled under a real-time scheduling policy may consume without making
 	// a blocking system call.
-	RealtimeTimeout int
+	RealtimeTimeout int64
 }
 
 const (
@@ -125,13 +125,13 @@ func (p Proc) NewLimits() (ProcLimits, error) {
 	return l, s.Err()
 }
 
-func parseInt(s string) (int, error) {
+func parseInt(s string) (int64, error) {
 	if s == limitsUnlimited {
 		return -1, nil
 	}
-	i, err := strconv.ParseInt(s, 10, 32)
+	i, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("couldn't parse value %s: %s", s, err)
 	}
-	return int(i), nil
+	return i, nil
 }

--- a/proc_limits_test.go
+++ b/proc_limits_test.go
@@ -15,14 +15,14 @@ func TestNewLimits(t *testing.T) {
 
 	for _, test := range []struct {
 		name string
-		want int
-		have int
+		want int64
+		have int64
 	}{
 		{name: "cpu time", want: -1, have: l.CPUTime},
 		{name: "open files", want: 2048, have: l.OpenFiles},
 		{name: "msgqueue size", want: 819200, have: l.MsqqueueSize},
 		{name: "nice priority", want: 0, have: l.NicePriority},
-		{name: "address space", want: -1, have: l.AddressSpace},
+		{name: "address space", want: 8589934592, have: l.AddressSpace},
 	} {
 		if test.want != test.have {
 			t.Errorf("want %s %d, have %d", test.name, test.want, test.have)


### PR DESCRIPTION
Fix #62 by switching all limits to int64 and telling ParseInt to return a 64-bit value.