### PR TITLE
bcache: fix vet and unconvert issues.

### DIFF
--- a/bcache/get.go
+++ b/bcache/get.go
@@ -61,7 +61,7 @@ func dehumanize(hbytes []byte) (uint64, error) {
 	mul := float64(1)
 	var (
 		mant float64
-		err error
+		err  error
 	)
 	// If lastByte is beyond the range of ASCII digits, it must be a
 	// multiplier.
@@ -93,7 +93,7 @@ func dehumanize(hbytes []byte) (uint64, error) {
 			'Z': ZiB,
 			'Y': YiB,
 		}
-		mul = float64(multipliers[rune(lastByte)])
+		mul = multipliers[rune(lastByte)]
 		mant, err = parsePseudoFloat(string(hbytes))
 		if err != nil {
 			return 0, err
@@ -139,10 +139,10 @@ func (p *parser) readValue(fileName string) uint64 {
 }
 
 // ParsePriorityStats parses lines from the priority_stats file.
-func parsePriorityStats(line string, ps *PriorityStats) (error) {
+func parsePriorityStats(line string, ps *PriorityStats) error {
 	var (
 		value uint64
-		err error
+		err   error
 	)
 	switch {
 	case strings.HasPrefix(line, "Unused:"):

--- a/bcache/get_test.go
+++ b/bcache/get_test.go
@@ -14,8 +14,8 @@
 package bcache
 
 import (
-	"testing"
 	"math"
+	"testing"
 )
 
 func TestDehumanizeTests(t *testing.T) {
@@ -45,8 +45,8 @@ func TestDehumanizeTests(t *testing.T) {
 			out: 2024,
 		},
 		{
-			in:  []byte(""),
-			out: 0,
+			in:      []byte(""),
+			out:     0,
 			invalid: true,
 		},
 	}
@@ -59,7 +59,7 @@ func TestDehumanizeTests(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if got != tst.out {
-			t.Errorf("dehumanize: '%s', want %f, got %f", tst.in, tst.out, got)
+			t.Errorf("dehumanize: '%s', want %d, got %d", tst.in, tst.out, got)
 		}
 	}
 }
@@ -84,7 +84,7 @@ func TestParsePseudoFloatTests(t *testing.T) {
 	}
 	for _, tst := range parsePseudoFloatTests {
 		got, err := parsePseudoFloat(tst.in)
-		if err != nil || math.Abs(got - tst.out) > 0.0001 {
+		if err != nil || math.Abs(got-tst.out) > 0.0001 {
 			t.Errorf("parsePseudoFloat: %s, want %f, got %f", tst.in, tst.out, got)
 		}
 	}
@@ -92,23 +92,23 @@ func TestParsePseudoFloatTests(t *testing.T) {
 
 func TestPriorityStats(t *testing.T) {
 	var want = PriorityStats{
-		UnusedPercent: 99,
+		UnusedPercent:   99,
 		MetadataPercent: 5,
 	}
 	var (
-		in string
+		in     string
 		gotErr error
-		got PriorityStats
+		got    PriorityStats
 	)
 	in = "Metadata:       5%"
 	gotErr = parsePriorityStats(in, &got)
 	if gotErr != nil || got.MetadataPercent != want.MetadataPercent {
-		t.Errorf("parsePriorityStats: '%s', want %f, got %f", in, want.MetadataPercent, got.MetadataPercent)
+		t.Errorf("parsePriorityStats: '%s', want %d, got %d", in, want.MetadataPercent, got.MetadataPercent)
 	}
 
 	in = "Unused:         99%"
 	gotErr = parsePriorityStats(in, &got)
 	if gotErr != nil || got.UnusedPercent != want.UnusedPercent {
-		t.Errorf("parsePriorityStats: '%s', want %f, got %f", in, want.UnusedPercent, got.UnusedPercent)
+		t.Errorf("parsePriorityStats: '%s', want %d, got %d", in, want.UnusedPercent, got.UnusedPercent)
 	}
 }


### PR DESCRIPTION
Hi @grobie,

*gometalinter* found some trivial issues in *bcache*, and I am fixing them here.
`gofmt` did some aesthetic changes too.

See,
```
$ gometalinter --disable=megacheck --disable=gocyclo --disable=errcheck ./...
bcache/bcache.go:32:6:warning: type name will be used as bcache.BcacheStats by other packages, and that stutters; consider calling this Stats (golint)
bcache/get.go:96:16:warning: unnecessary conversion (unconvert)
bcache/get_test.go:62::error: arg tst.out for printf verb %f of wrong type: uint64 (vet)
bcache/get_test.go:106::error: arg want.MetadataPercent for printf verb %f of wrong type: uint64 (vet)
bcache/get_test.go:112::error: arg want.UnusedPercent for printf verb %f of wrong type: uint64 (vet)
```

After my commit there is just one left, but this is not a trivial one.
```
gometalinter --disable=megacheck --disable=gocyclo --disable=errcheck ./...
bcache/bcache.go:32:6:warning: type name will be used as bcache.BcacheStats by other packages, and that stutters; consider calling this Stats (golint)
```