### PR TITLE
Add 'States' function to return the state for each process of the system

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -23,6 +23,19 @@ func (p Procs) Len() int           { return len(p) }
 func (p Procs) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 func (p Procs) Less(i, j int) bool { return p[i].PID < p[j].PID }
 
+// States returns a map of string, representing the state for each process
+func (p Procs) States() (map[Proc]string, error) {
+	procsState := make(map[Proc]string)
+	for _, proc := range p {
+		s, err := proc.NewStat()
+		if err != nil {
+			return nil, err
+		}
+		procsState[proc] = s.State
+	}
+	return procsState, nil
+}
+
 // Self returns a process for the current process read via /proc/self.
 func Self() (Proc, error) {
 	fs, err := NewFS(DefaultMountPoint)

--- a/proc_test.go
+++ b/proc_test.go
@@ -6,6 +6,31 @@ import (
 	"testing"
 )
 
+func TestProcsStates(t *testing.T) {
+	procs, err := FS("fixtures").AllProcs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	states, err := procs.States()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, p := range procs {
+		_, ok := states[p]
+		if !ok {
+			t.Errorf("Can't find %v pid", p.PID)
+		}
+		s, err := p.NewStat()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s.State != states[p] {
+			t.Errorf("State for pid %v differ. Want %v, have %v", p.PID, s.State, states[p])
+		}
+	}
+}
+
 func TestSelf(t *testing.T) {
 	fs := FS("fixtures")
 


### PR DESCRIPTION
This PR is link to offer a metric with the number of process by state. 
So, this PR add a function named `States` which returns a map of state as string by `Proc`.
Adding unit test also.