### PR TITLE
Test procfs against previous go versions as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 language: go
 
 go:
+- 1.7.x
+- 1.8.x
+- 1.9.x
 - 1.10.x
 - 1.x
 


### PR DESCRIPTION
Procfs is a library and not a standalone binary. It should work against
older go versions as well.