### PR TITLE
netclass: parse only directories

### DIFF
--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -80,6 +80,9 @@ func (fs FS) NewNetClass() (NetClass, error) {
 
 	netClass := NetClass{}
 	for _, deviceDir := range devices {
+		if !deviceDir.IsDir() {
+			continue
+		}
 		interfaceClass, err := netClass.parseNetClassIface(path + "/" + deviceDir.Name())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
e.g. /sys/class/net/bonding_masters is legitimate file and should be skipped
related to https://github.com/prometheus/node_exporter/pull/851