### PR TITLE
Add parser for sysfs devices/system/cpu/...

### DIFF
--- a/internal/util/parse.go
+++ b/internal/util/parse.go
@@ -51,6 +51,7 @@ func ParseUint64s(ss []string) ([]uint64, error) {
 	return us, nil
 }
 
+// ReadUintFromFile reads a file and attempts to parse a uint64 from it.
 func ReadUintFromFile(path string) (uint64, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -63,7 +64,7 @@ func ReadUintFromFile(path string) (uint64, error) {
 	return value, nil
 }
 
-// sysReadFile is a simplified ioutil.ReadFile that invokes syscall.Read directly.
+// SysReadFile is a simplified ioutil.ReadFile that invokes syscall.Read directly.
 // https://github.com/prometheus/node_exporter/pull/728/files
 func SysReadFile(file string) ([]byte, error) {
 	f, err := os.Open(file)

--- a/internal/util/parse.go
+++ b/internal/util/parse.go
@@ -13,7 +13,11 @@
 
 package util
 
-import "strconv"
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
 
 // ParseUint32s parses a slice of strings into a slice of uint32s.
 func ParseUint32s(ss []string) ([]uint32, error) {
@@ -43,4 +47,16 @@ func ParseUint64s(ss []string) ([]uint64, error) {
 	}
 
 	return us, nil
+}
+
+func ReadUintFromFile(path string) (uint64, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return value, nil
 }

--- a/internal/util/parse.go
+++ b/internal/util/parse.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -62,10 +63,10 @@ func ReadUintFromFile(path string) (uint64, error) {
 
 // SysReadFile is a simplified ioutil.ReadFile that invokes syscall.Read directly.
 // https://github.com/prometheus/node_exporter/pull/728/files
-func SysReadFile(file string) ([]byte, error) {
+func SysReadFile(file string) (string, error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer f.Close()
 
@@ -77,8 +78,8 @@ func SysReadFile(file string) ([]byte, error) {
 	b := make([]byte, 128)
 	n, err := syscall.Read(int(f.Fd()), b)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return b[:n], nil
+	return string(bytes.TrimSpace(b[:n])), nil
 }

--- a/internal/util/parse.go
+++ b/internal/util/parse.go
@@ -57,11 +57,7 @@ func ReadUintFromFile(path string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	value, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return value, nil
+	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 }
 
 // SysReadFile is a simplified ioutil.ReadFile that invokes syscall.Read directly.

--- a/sysfs/fixtures.ttar
+++ b/sysfs/fixtures.ttar
@@ -401,6 +401,67 @@ Mode: 775
 Path: fixtures/devices/system/cpu/cpu0/cpufreq
 SymlinkTo: ../cpufreq/policy0
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/devices/system/cpu/cpu1
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/devices/system/cpu/cpu1/cpufreq
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/cpuinfo_cur_freq
+Lines: 1
+1200195
+Mode: 400
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/cpuinfo_max_freq
+Lines: 1
+3300000
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/cpuinfo_min_freq
+Lines: 1
+1200000
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/cpuinfo_transition_latency
+Lines: 1
+4294967295
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/related_cpus
+Lines: 1
+1
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/scaling_available_governors
+Lines: 1
+performance powersave
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/scaling_driver
+Lines: 1
+intel_pstate
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/scaling_governor
+Lines: 1
+powersave
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/scaling_max_freq
+Lines: 1
+3300000
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/scaling_min_freq
+Lines: 1
+1200000
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu1/cpufreq/scaling_setspeed
+Lines: 1
+<unsupported>
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/devices/system/cpu/cpufreq
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/fixtures.ttar
+++ b/sysfs/fixtures.ttar
@@ -389,6 +389,87 @@ Lines: 1
 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/devices/system
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/devices/system/cpu
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/devices/system/cpu/cpu0
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpu0/cpufreq
+SymlinkTo: ../cpufreq/policy0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/devices/system/cpu/cpufreq
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/devices/system/cpu/cpufreq/policy0
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/affected_cpus
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/cpuinfo_max_freq
+Lines: 1
+2400000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/cpuinfo_min_freq
+Lines: 1
+800000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/cpuinfo_transition_latency
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/related_cpus
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/scaling_available_governors
+Lines: 1
+performance powersave
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/scaling_cur_freq
+Lines: 1
+1219917
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/scaling_driver
+Lines: 1
+intel_pstate
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/scaling_governor
+Lines: 1
+powersave
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/scaling_max_freq
+Lines: 1
+2400000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/scaling_min_freq
+Lines: 1
+800000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/devices/system/cpu/cpufreq/policy0/scaling_setspeed
+Lines: 1
+<unsupported>
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/devices/system/cpu/cpufreq/policy1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/fs
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -20,7 +20,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"syscall"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // NetClassIface contains info from files in /sys/class/net/<iface>
@@ -109,7 +110,7 @@ func (nc NetClass) parseNetClassIface(devicePath string) (*NetClassIface, error)
 			panic(fmt.Errorf("field %s does not have a filename tag", fieldType.Name))
 		}
 
-		fileContents, err := sysReadFile(devicePath + "/" + fieldType.Tag.Get("fileName"))
+		fileContents, err := util.SysReadFile(devicePath + "/" + fieldType.Tag.Get("fileName"))
 
 		if err != nil {
 			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
@@ -148,27 +149,4 @@ func (nc NetClass) parseNetClassIface(devicePath string) (*NetClassIface, error)
 	}
 
 	return &interfaceClass, nil
-}
-
-// sysReadFile is a simplified ioutil.ReadFile that invokes syscall.Read directly.
-// https://github.com/prometheus/node_exporter/pull/728/files
-func sysReadFile(file string) ([]byte, error) {
-	f, err := os.Open(file)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	// On some machines, hwmon drivers are broken and return EAGAIN.  This causes
-	// Go's ioutil.ReadFile implementation to poll forever.
-	//
-	// Since we either want to read data or bail immediately, do the simplest
-	// possible read using syscall directly.
-	b := make([]byte, 128)
-	n, err := syscall.Read(int(f.Fd()), b)
-	if err != nil {
-		return nil, err
-	}
-
-	return b[:n], nil
 }

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -110,7 +110,7 @@ func (nc NetClass) parseNetClassIface(devicePath string) (*NetClassIface, error)
 			panic(fmt.Errorf("field %s does not have a filename tag", fieldType.Name))
 		}
 
-		fileContents, err := util.SysReadFile(devicePath + "/" + fieldType.Tag.Get("fileName"))
+		value, err := util.SysReadFile(devicePath + "/" + fieldType.Tag.Get("fileName"))
 
 		if err != nil {
 			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
@@ -118,7 +118,6 @@ func (nc NetClass) parseNetClassIface(devicePath string) (*NetClassIface, error)
 			}
 			return nil, fmt.Errorf("could not access file %s: %s", fieldType.Tag.Get("fileName"), err)
 		}
-		value := strings.TrimSpace(string(fileContents))
 
 		switch fieldValue.Kind() {
 		case reflect.String:

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -24,9 +24,15 @@ import (
 
 // SystemCpuCpufreq contains stats from devices/system/cpu/cpu[0-9]*/cpufreq/...
 type SystemCpuCpufreq struct {
-	CurrentFrequency uint64
-	MinimumFrequency uint64
-	MaximumFrequency uint64
+	CurrentFrequency   uint64
+	MinimumFrequency   uint64
+	MaximumFrequency   uint64
+	TransitionLatency  uint64
+	AvailableGovernors string
+	Driver             string
+	Govenor            string
+	RelatedCpus        string
+	SetSpeed           string
 }
 
 // SystemCpufreq is a collection of SystemCpuCpufreq for every CPU.
@@ -86,17 +92,52 @@ func parseCpufreqCpuinfo(prefix string, cpuPath string) (SystemCpuCpufreq, error
 	if err != nil {
 		return SystemCpuCpufreq{}, err
 	}
-	minimum, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_min_freq"))
-	if err != nil {
-		return SystemCpuCpufreq{}, err
-	}
 	maximum, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_max_freq"))
 	if err != nil {
 		return SystemCpuCpufreq{}, err
 	}
+	minimum, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_min_freq"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	transitionLatency, err := util.ReadUintFromFile(filepath.Join(cpuPath, "cpuinfo_transition_latency"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	fileContents, err := util.SysReadFile(filepath.Join(cpuPath, "scaling_available_governors"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	availableGovernors := strings.TrimSpace(string(fileContents))
+	fileContents, err = util.SysReadFile(filepath.Join(cpuPath, "scaling_driver"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	driver := strings.TrimSpace(string(fileContents))
+	fileContents, err = util.SysReadFile(filepath.Join(cpuPath, "scaling_governor"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	governor := strings.TrimSpace(string(fileContents))
+	fileContents, err = util.SysReadFile(filepath.Join(cpuPath, "related_cpus"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	relatedCpus := strings.TrimSpace(string(fileContents))
+	fileContents, err = util.SysReadFile(filepath.Join(cpuPath, "scaling_setspeed"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	setSpeed := strings.TrimSpace(string(fileContents))
 	return SystemCpuCpufreq{
-		CurrentFrequency: current,
-		MinimumFrequency: minimum,
-		MaximumFrequency: maximum,
+		CurrentFrequency:   current,
+		MaximumFrequency:   maximum,
+		MinimumFrequency:   minimum,
+		TransitionLatency:  transitionLatency,
+		AvailableGovernors: availableGovernors,
+		Driver:             driver,
+		Govenor:            governor,
+		RelatedCpus:        relatedCpus,
+		SetSpeed:           setSpeed,
 	}, nil
 }

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -37,7 +37,7 @@ type SystemCPUCpufreq struct {
 }
 
 // SystemCpufreq is a collection of SystemCPUCpufreq for every CPU.
-type SystemCpufreq map[string]SystemCPUCpufreq
+type SystemCpufreq []SystemCPUCpufreq
 
 // TODO: Add topology support.
 
@@ -87,7 +87,7 @@ func (fs FS) NewSystemCpufreq() (SystemCpufreq, error) {
 			return SystemCpufreq{}, err
 		}
 		cpufreq.Name = cpuNum
-		systemCpufreq[cpuNum] = *cpufreq
+		systemCpufreq = append(systemCpufreq, *cpufreq)
 	}
 
 	return systemCpufreq, nil

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -1,0 +1,102 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// SystemCpuCpufreq contains stats from devices/system/cpu/cpu[0-9]*/cpufreq/...
+type SystemCpuCpufreq struct {
+	CurrentFrequency uint64
+	MinimumFrequency uint64
+	MaximumFrequency uint64
+}
+
+// SystemCpufreq is a collection of SystemCpuCpufreq for every CPU.
+type SystemCpufreq map[string]SystemCpuCpufreq
+
+// TODO: Add topology support.
+
+// TODO: Add thermal_throttle support.
+
+// NewSystemCpufreq returns CPU frequency metrics for all CPUs.
+func NewSystemCpufreq() (SystemCpufreq, error) {
+	fs, err := NewFS(DefaultMountPoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return fs.NewSystemCpufreq()
+}
+
+// NewSystemCpufreq returns CPU frequency metrics for all CPUs.
+func (fs FS) NewSystemCpufreq() (SystemCpufreq, error) {
+	cpus, err := filepath.Glob(fs.Path("devices/system/cpu/cpu[0-9]*"))
+	if err != nil {
+		return SystemCpufreq{}, err
+	}
+
+	systemCpufreq := SystemCpufreq{}
+	for _, cpu := range cpus {
+		cpuName := filepath.Base(cpu)
+		cpuNum := strings.TrimPrefix(cpuName, "cpu")
+
+		cpufreq := SystemCpuCpufreq{}
+		cpuCpufreqPath := filepath.Join(cpu, "cpufreq")
+		if _, err := os.Stat(cpuCpufreqPath); os.IsNotExist(err) {
+			continue
+		} else {
+			if _, err = os.Stat(filepath.Join(cpuCpufreqPath, "scaling_cur_freq")); err == nil {
+				cpufreq, err = parseCpufreqCpuinfo("scaling", cpuCpufreqPath)
+			} else if _, err = os.Stat(filepath.Join(cpuCpufreqPath, "cpuinfo_cur_freq")); err == nil {
+				// Older kernels have metrics named `cpuinfo_...`.
+				cpufreq, err = parseCpufreqCpuinfo("cpuinfo", cpuCpufreqPath)
+			} else {
+				return SystemCpufreq{}, fmt.Errorf("CPU %v is missing cpufreq", cpu)
+			}
+			if err != nil {
+				return SystemCpufreq{}, err
+			}
+			systemCpufreq[cpuNum] = cpufreq
+		}
+	}
+
+	return systemCpufreq, nil
+}
+
+func parseCpufreqCpuinfo(prefix string, cpuPath string) (SystemCpuCpufreq, error) {
+	current, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_cur_freq"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	minimum, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_min_freq"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	maximum, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_max_freq"))
+	if err != nil {
+		return SystemCpuCpufreq{}, err
+	}
+	return SystemCpuCpufreq{
+		CurrentFrequency: current,
+		MinimumFrequency: minimum,
+		MaximumFrequency: maximum,
+	}, nil
+}

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -22,8 +22,8 @@ import (
 	"github.com/prometheus/procfs/internal/util"
 )
 
-// SystemCpuCpufreq contains stats from devices/system/cpu/cpu[0-9]*/cpufreq/...
-type SystemCpuCpufreq struct {
+// SystemCPUCpufreq contains stats from devices/system/cpu/cpu[0-9]*/cpufreq/...
+type SystemCPUCpufreq struct {
 	CurrentFrequency   uint64
 	MinimumFrequency   uint64
 	MaximumFrequency   uint64
@@ -35,8 +35,8 @@ type SystemCpuCpufreq struct {
 	SetSpeed           string
 }
 
-// SystemCpufreq is a collection of SystemCpuCpufreq for every CPU.
-type SystemCpufreq map[string]SystemCpuCpufreq
+// SystemCpufreq is a collection of SystemCPUCpufreq for every CPU.
+type SystemCpufreq map[string]SystemCPUCpufreq
 
 // TODO: Add topology support.
 
@@ -64,7 +64,7 @@ func (fs FS) NewSystemCpufreq() (SystemCpufreq, error) {
 		cpuName := filepath.Base(cpu)
 		cpuNum := strings.TrimPrefix(cpuName, "cpu")
 
-		cpufreq := SystemCpuCpufreq{}
+		cpufreq := SystemCPUCpufreq{}
 		cpuCpufreqPath := filepath.Join(cpu, "cpufreq")
 		if _, err := os.Stat(cpuCpufreqPath); os.IsNotExist(err) {
 			continue
@@ -87,49 +87,49 @@ func (fs FS) NewSystemCpufreq() (SystemCpufreq, error) {
 	return systemCpufreq, nil
 }
 
-func parseCpufreqCpuinfo(prefix string, cpuPath string) (SystemCpuCpufreq, error) {
+func parseCpufreqCpuinfo(prefix string, cpuPath string) (SystemCPUCpufreq, error) {
 	current, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_cur_freq"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	maximum, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_max_freq"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	minimum, err := util.ReadUintFromFile(filepath.Join(cpuPath, prefix+"_min_freq"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	transitionLatency, err := util.ReadUintFromFile(filepath.Join(cpuPath, "cpuinfo_transition_latency"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	fileContents, err := util.SysReadFile(filepath.Join(cpuPath, "scaling_available_governors"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	availableGovernors := strings.TrimSpace(string(fileContents))
 	fileContents, err = util.SysReadFile(filepath.Join(cpuPath, "scaling_driver"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	driver := strings.TrimSpace(string(fileContents))
 	fileContents, err = util.SysReadFile(filepath.Join(cpuPath, "scaling_governor"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	governor := strings.TrimSpace(string(fileContents))
 	fileContents, err = util.SysReadFile(filepath.Join(cpuPath, "related_cpus"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	relatedCpus := strings.TrimSpace(string(fileContents))
 	fileContents, err = util.SysReadFile(filepath.Join(cpuPath, "scaling_setspeed"))
 	if err != nil {
-		return SystemCpuCpufreq{}, err
+		return SystemCPUCpufreq{}, err
 	}
 	setSpeed := strings.TrimSpace(string(fileContents))
-	return SystemCpuCpufreq{
+	return SystemCPUCpufreq{
 		CurrentFrequency:   current,
 		MaximumFrequency:   maximum,
 		MinimumFrequency:   minimum,

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -68,20 +68,23 @@ func (fs FS) NewSystemCpufreq() (SystemCpufreq, error) {
 		cpuCpufreqPath := filepath.Join(cpu, "cpufreq")
 		if _, err := os.Stat(cpuCpufreqPath); os.IsNotExist(err) {
 			continue
-		} else {
-			if _, err = os.Stat(filepath.Join(cpuCpufreqPath, "scaling_cur_freq")); err == nil {
-				cpufreq, err = parseCpufreqCpuinfo("scaling", cpuCpufreqPath)
-			} else if _, err = os.Stat(filepath.Join(cpuCpufreqPath, "cpuinfo_cur_freq")); err == nil {
-				// Older kernels have metrics named `cpuinfo_...`.
-				cpufreq, err = parseCpufreqCpuinfo("cpuinfo", cpuCpufreqPath)
-			} else {
-				return SystemCpufreq{}, fmt.Errorf("CPU %v is missing cpufreq", cpu)
-			}
-			if err != nil {
-				return SystemCpufreq{}, err
-			}
-			systemCpufreq[cpuNum] = cpufreq
 		}
+		if err != nil {
+			return SystemCpufreq{}, err
+		}
+
+		if _, err = os.Stat(filepath.Join(cpuCpufreqPath, "scaling_cur_freq")); err == nil {
+			cpufreq, err = parseCpufreqCpuinfo("scaling", cpuCpufreqPath)
+		} else if _, err = os.Stat(filepath.Join(cpuCpufreqPath, "cpuinfo_cur_freq")); err == nil {
+			// Older kernels have metrics named `cpuinfo_...`.
+			cpufreq, err = parseCpufreqCpuinfo("cpuinfo", cpuCpufreqPath)
+		} else {
+			return SystemCpufreq{}, fmt.Errorf("CPU %v is missing cpufreq", cpu)
+		}
+		if err != nil {
+			return SystemCpufreq{}, err
+		}
+		systemCpufreq[cpuNum] = cpufreq
 	}
 
 	return systemCpufreq, nil

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -91,13 +91,13 @@ func (fs FS) NewSystemCpufreq() ([]SystemCPUCpufreq, error) {
 }
 
 func parseCpufreqCpuinfo(prefix string, cpuPath string) (*SystemCPUCpufreq, error) {
-	uintFiles := [4]string{
+	uintFiles := []string{
 		prefix + "_cur_freq",
 		prefix + "_max_freq",
 		prefix + "_min_freq",
 		"cpuinfo_transition_latency",
 	}
-	var uintOut [4]uint64
+	uintOut := make([]uint64, len(uintFiles))
 
 	for i, f := range uintFiles {
 		v, err := util.ReadUintFromFile(filepath.Join(cpuPath, f))
@@ -108,14 +108,14 @@ func parseCpufreqCpuinfo(prefix string, cpuPath string) (*SystemCPUCpufreq, erro
 		uintOut[i] = v
 	}
 
-	stringFiles := [5]string{
+	stringFiles := []string{
 		"scaling_available_governors",
 		"scaling_driver",
 		"scaling_governor",
 		"related_cpus",
 		"scaling_setspeed",
 	}
-	var stringOut [5]string
+	stringOut := make([]string, len(stringFiles))
 	var err error
 
 	for i, f := range stringFiles {

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -116,14 +116,13 @@ func parseCpufreqCpuinfo(prefix string, cpuPath string) (*SystemCPUCpufreq, erro
 		"scaling_setspeed",
 	}
 	var stringOut [5]string
+	var err error
 
 	for i, f := range stringFiles {
-		fileContents, err := util.SysReadFile(filepath.Join(cpuPath, f))
+		stringOut[i], err = util.SysReadFile(filepath.Join(cpuPath, f))
 		if err != nil {
 			return &SystemCPUCpufreq{}, err
 		}
-
-		stringOut[i] = strings.TrimSpace(string(fileContents))
 	}
 
 	return &SystemCPUCpufreq{

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -126,14 +126,14 @@ func parseCpufreqCpuinfo(prefix string, cpuPath string) (*SystemCPUCpufreq, erro
 	}
 
 	return &SystemCPUCpufreq{
-		CurrentFrequency: uintOut[0],
-		MaximumFrequency: uintOut[1],
-		MinimumFrequency: uintOut[2],
-		TransitionLatency: uintOut[3],
+		CurrentFrequency:   uintOut[0],
+		MaximumFrequency:   uintOut[1],
+		MinimumFrequency:   uintOut[2],
+		TransitionLatency:  uintOut[3],
 		AvailableGovernors: stringOut[0],
-		Driver: stringOut[1],
-		Govenor: stringOut[2],
-		RelatedCpus: stringOut[3],
-		SetSpeed: stringOut[4],
+		Driver:             stringOut[1],
+		Govenor:            stringOut[2],
+		RelatedCpus:        stringOut[3],
+		SetSpeed:           stringOut[4],
 	}, nil
 }

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -32,15 +32,27 @@ func TestNewSystemCpufreq(t *testing.T) {
 	systemCpufreq := SystemCpufreq{
 		// Ubuntu 16.04 (4.15.0-20-generic), has `scaling_cur_freq` file.
 		"0": {
-			CurrentFrequency: 1219917,
-			MinimumFrequency: 800000,
-			MaximumFrequency: 2400000,
+			CurrentFrequency:   1219917,
+			MinimumFrequency:   800000,
+			MaximumFrequency:   2400000,
+			TransitionLatency:  0,
+			AvailableGovernors: "performance powersave",
+			Driver:             "intel_pstate",
+			Govenor:            "powersave",
+			RelatedCpus:        "0",
+			SetSpeed:           "<unsupported>",
 		},
 		// RHEL 7.3 (3.10.0-514.26.2.el7), missing `scaling_cur_freq` file.
 		"1": {
-			CurrentFrequency: 1200195,
-			MinimumFrequency: 1200000,
-			MaximumFrequency: 3300000,
+			CurrentFrequency:   1200195,
+			MinimumFrequency:   1200000,
+			MaximumFrequency:   3300000,
+			TransitionLatency:  4294967295,
+			AvailableGovernors: "performance powersave",
+			Driver:             "intel_pstate",
+			Govenor:            "powersave",
+			RelatedCpus:        "1",
+			SetSpeed:           "<unsupported>",
 		},
 	}
 

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -31,7 +31,7 @@ func TestNewSystemCpufreq(t *testing.T) {
 
 	systemCpufreq := SystemCpufreq{
 		// Ubuntu 16.04 (4.15.0-20-generic), has `scaling_cur_freq` file.
-		"0": {
+		{
 			Name:               "0",
 			CurrentFrequency:   1219917,
 			MinimumFrequency:   800000,
@@ -44,7 +44,7 @@ func TestNewSystemCpufreq(t *testing.T) {
 			SetSpeed:           "<unsupported>",
 		},
 		// RHEL 7.3 (3.10.0-514.26.2.el7), missing `scaling_cur_freq` file.
-		"1": {
+		{
 			Name:               "1",
 			CurrentFrequency:   1200195,
 			MinimumFrequency:   1200000,

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -32,6 +32,7 @@ func TestNewSystemCpufreq(t *testing.T) {
 	systemCpufreq := SystemCpufreq{
 		// Ubuntu 16.04 (4.15.0-20-generic), has `scaling_cur_freq` file.
 		"0": {
+			Name:               "0",
 			CurrentFrequency:   1219917,
 			MinimumFrequency:   800000,
 			MaximumFrequency:   2400000,
@@ -44,6 +45,7 @@ func TestNewSystemCpufreq(t *testing.T) {
 		},
 		// RHEL 7.3 (3.10.0-514.26.2.el7), missing `scaling_cur_freq` file.
 		"1": {
+			Name:               "1",
 			CurrentFrequency:   1200195,
 			MinimumFrequency:   1200000,
 			MaximumFrequency:   3300000,

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -30,10 +30,17 @@ func TestNewSystemCpufreq(t *testing.T) {
 	}
 
 	systemCpufreq := SystemCpufreq{
+		// Ubuntu 16.04 (4.15.0-20-generic), has `scaling_cur_freq` file.
 		"0": {
 			CurrentFrequency: 1219917,
 			MinimumFrequency: 800000,
 			MaximumFrequency: 2400000,
+		},
+		// RHEL 7.3 (3.10.0-514.26.2.el7), missing `scaling_cur_freq` file.
+		"1": {
+			CurrentFrequency: 1200195,
+			MinimumFrequency: 1200000,
+			MaximumFrequency: 3300000,
 		},
 	}
 

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewSystemCpufreq(t *testing.T) {
+	fs, err := NewFS("fixtures")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := fs.NewSystemCpufreq()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	systemCpufreq := SystemCpufreq{
+		"0": {
+			CurrentFrequency: 1219917,
+			MinimumFrequency: 800000,
+			MaximumFrequency: 2400000,
+		},
+	}
+
+	if !reflect.DeepEqual(systemCpufreq, c) {
+		t.Errorf("Result not correct: want %v, have %v", systemCpufreq, c)
+	}
+}

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -29,7 +29,7 @@ func TestNewSystemCpufreq(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	systemCpufreq := []SystemCPUCpufreq{
+	systemCpufreq := []SystemCPUCpufreqStats{
 		// Ubuntu 16.04 (4.15.0-20-generic), has `scaling_cur_freq` file.
 		{
 			Name:               "0",

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -29,7 +29,7 @@ func TestNewSystemCpufreq(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	systemCpufreq := SystemCpufreq{
+	systemCpufreq := []SystemCPUCpufreq{
 		// Ubuntu 16.04 (4.15.0-20-generic), has `scaling_cur_freq` file.
 		{
 			Name:               "0",


### PR DESCRIPTION
* Add parser for `devices/system/cpu/cpu*/cpufreq/...`.
* Add helper `util.ReadUintFromFile()`.
* Move `sysReadFile()` helper from `sysfs` to `internal/util`.

Signed-off-by: Ben Kochie <superq@gmail.com>