### PR TITLE
mountstats: Add support for UDP NFS mounts

### DIFF
--- a/mountstats.go
+++ b/mountstats.go
@@ -39,8 +39,11 @@ const (
 	statVersion10 = "1.0"
 	statVersion11 = "1.1"
 
-	fieldTransport10Len = 10
-	fieldTransport11Len = 13
+	fieldTransport10TCPLen = 10
+	fieldTransport10UDPLen = 7
+
+	fieldTransport11TCPLen = 13
+	fieldTransport11UDPLen = 10
 )
 
 // A Mount is a device mount parsed from /proc/[pid]/mountstats.
@@ -186,6 +189,8 @@ type NFSOperationStats struct {
 // A NFSTransportStats contains statistics for the NFS mount RPC requests and
 // responses.
 type NFSTransportStats struct {
+	// The transport protocol used for the NFS mount.
+	Protocol string
 	// The local port used for the NFS mount.
 	Port uint64
 	// Number of times the client has had to establish a connection from scratch
@@ -360,7 +365,7 @@ func parseMountStatsNFS(s *bufio.Scanner, statVersion string) (*MountStatsNFS, e
 				return nil, fmt.Errorf("not enough information for NFS transport stats: %v", ss)
 			}
 
-			tstats, err := parseNFSTransportStats(ss[2:], statVersion)
+			tstats, err := parseNFSTransportStats(ss[1:], statVersion)
 			if err != nil {
 				return nil, err
 			}
@@ -522,13 +527,33 @@ func parseNFSOperationStats(s *bufio.Scanner) ([]NFSOperationStats, error) {
 // parseNFSTransportStats parses a NFSTransportStats line using an input set of
 // integer fields matched to a specific stats version.
 func parseNFSTransportStats(ss []string, statVersion string) (*NFSTransportStats, error) {
+	// Extract the protocol field. It is the only string value in the line
+	protocol := ss[0]
+	ss = ss[1:]
+
 	switch statVersion {
 	case statVersion10:
-		if len(ss) != fieldTransport10Len {
+		var expectedLength int
+		if protocol == "tcp" {
+			expectedLength = fieldTransport10TCPLen
+		} else if protocol == "udp" {
+			expectedLength = fieldTransport10UDPLen
+		} else {
+			return nil, fmt.Errorf("invalid NFS protocol \"%s\" in stats 1.0 statement: %v", protocol, ss)
+		}
+		if len(ss) != expectedLength {
 			return nil, fmt.Errorf("invalid NFS transport stats 1.0 statement: %v", ss)
 		}
 	case statVersion11:
-		if len(ss) != fieldTransport11Len {
+		var expectedLength int
+		if protocol == "tcp" {
+			expectedLength = fieldTransport11TCPLen
+		} else if protocol == "udp" {
+			expectedLength = fieldTransport11UDPLen
+		} else {
+			return nil, fmt.Errorf("invalid NFS protocol \"%s\" in stats 1.1 statement: %v", protocol, ss)
+		}
+		if len(ss) != expectedLength {
 			return nil, fmt.Errorf("invalid NFS transport stats 1.1 statement: %v", ss)
 		}
 	default:
@@ -536,12 +561,13 @@ func parseNFSTransportStats(ss []string, statVersion string) (*NFSTransportStats
 	}
 
 	// Allocate enough for v1.1 stats since zero value for v1.1 stats will be okay
-	// in a v1.0 response.
+	// in a v1.0 response. Since the stat length is bigger for TCP stats, we use
+	// the TCP length here.
 	//
 	// Note: slice length must be set to length of v1.1 stats to avoid a panic when
 	// only v1.0 stats are present.
 	// See: https://github.com/prometheus/node_exporter/issues/571.
-	ns := make([]uint64, fieldTransport11Len)
+	ns := make([]uint64, fieldTransport11TCPLen)
 	for i, s := range ss {
 		n, err := strconv.ParseUint(s, 10, 64)
 		if err != nil {
@@ -551,7 +577,18 @@ func parseNFSTransportStats(ss []string, statVersion string) (*NFSTransportStats
 		ns[i] = n
 	}
 
+	// The fields differ depending on the transport protocol (TCP or UDP)
+	// From https://utcc.utoronto.ca/%7Ecks/space/blog/linux/NFSMountstatsXprt
+	//
+	// For the udp RPC transport there is no connection count, connect idle time,
+	// or idle time (fields #3, #4, and #5); all other fields are the same. So
+	// we set them to 0 here.
+	if protocol == "udp" {
+		ns = append(ns[:2], append(make([]uint64, 3), ns[2:]...)...)
+	}
+
 	return &NFSTransportStats{
+		Protocol:                 protocol,
 		Port:                     ns[0],
 		Bind:                     ns[1],
 		Connect:                  ns[2],

--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -103,7 +103,12 @@ func TestMountStats(t *testing.T) {
 			invalid: true,
 		},
 		{
-			name: "NFSv3 device with transport stats version 1.0 OK",
+			name:    "NFSv3 device with bad transport protocol",
+			s:       "device 192.168.1.1:/srv mounted on /mnt/nfs with fstype nfs4 statvers=1.1\nxprt: tcpx 0 0 0 0 0 0 0 0 0 0",
+			invalid: true,
+		},
+		{
+			name: "NFSv3 device using TCP with transport stats version 1.0 OK",
 			s:    "device 192.168.1.1:/srv mounted on /mnt/nfs with fstype nfs statvers=1.0\nxprt: tcp 1 2 3 4 5 6 7 8 9 10",
 			mounts: []*Mount{{
 				Device: "192.168.1.1:/srv",
@@ -112,6 +117,7 @@ func TestMountStats(t *testing.T) {
 				Stats: &MountStatsNFS{
 					StatVersion: "1.0",
 					Transport: NFSTransportStats{
+						Protocol:                 "tcp",
 						Port:                     1,
 						Bind:                     2,
 						Connect:                  3,
@@ -122,6 +128,93 @@ func TestMountStats(t *testing.T) {
 						BadTransactionIDs:        8,
 						CumulativeActiveRequests: 9,
 						CumulativeBacklog:        10,
+						MaximumRPCSlotsUsed:      0, // these three are not
+						CumulativeSendingQueue:   0, // present in statvers=1.0
+						CumulativePendingQueue:   0, //
+					},
+				},
+			}},
+		},
+		{
+			name: "NFSv3 device using UDP with transport stats version 1.0 OK",
+			s:    "device 192.168.1.1:/srv mounted on /mnt/nfs with fstype nfs statvers=1.0\nxprt: udp 1 2 3 4 5 6 7",
+			mounts: []*Mount{{
+				Device: "192.168.1.1:/srv",
+				Mount:  "/mnt/nfs",
+				Type:   "nfs",
+				Stats: &MountStatsNFS{
+					StatVersion: "1.0",
+					Transport: NFSTransportStats{
+						Protocol:                 "udp",
+						Port:                     1,
+						Bind:                     2,
+						Connect:                  0,
+						ConnectIdleTime:          0,
+						IdleTime:                 0,
+						Sends:                    3,
+						Receives:                 4,
+						BadTransactionIDs:        5,
+						CumulativeActiveRequests: 6,
+						CumulativeBacklog:        7,
+						MaximumRPCSlotsUsed:      0, // these three are not
+						CumulativeSendingQueue:   0, // present in statvers=1.0
+						CumulativePendingQueue:   0, //
+					},
+				},
+			}},
+		},
+		{
+			name: "NFSv3 device using TCP with transport stats version 1.1 OK",
+			s:    "device 192.168.1.1:/srv mounted on /mnt/nfs with fstype nfs statvers=1.1\nxprt: tcp 1 2 3 4 5 6 7 8 9 10 11 12 13",
+			mounts: []*Mount{{
+				Device: "192.168.1.1:/srv",
+				Mount:  "/mnt/nfs",
+				Type:   "nfs",
+				Stats: &MountStatsNFS{
+					StatVersion: "1.1",
+					Transport: NFSTransportStats{
+						Protocol:                 "tcp",
+						Port:                     1,
+						Bind:                     2,
+						Connect:                  3,
+						ConnectIdleTime:          4,
+						IdleTime:                 5 * time.Second,
+						Sends:                    6,
+						Receives:                 7,
+						BadTransactionIDs:        8,
+						CumulativeActiveRequests: 9,
+						CumulativeBacklog:        10,
+						MaximumRPCSlotsUsed:      11,
+						CumulativeSendingQueue:   12,
+						CumulativePendingQueue:   13,
+					},
+				},
+			}},
+		},
+		{
+			name: "NFSv3 device using UDP with transport stats version 1.1 OK",
+			s:    "device 192.168.1.1:/srv mounted on /mnt/nfs with fstype nfs statvers=1.1\nxprt: udp 1 2 3 4 5 6 7 8 9 10",
+			mounts: []*Mount{{
+				Device: "192.168.1.1:/srv",
+				Mount:  "/mnt/nfs",
+				Type:   "nfs",
+				Stats: &MountStatsNFS{
+					StatVersion: "1.1",
+					Transport: NFSTransportStats{
+						Protocol:                 "udp",
+						Port:                     1,
+						Bind:                     2,
+						Connect:                  0, // these three are not
+						ConnectIdleTime:          0, // present for UDP
+						IdleTime:                 0, //
+						Sends:                    3,
+						Receives:                 4,
+						BadTransactionIDs:        5,
+						CumulativeActiveRequests: 6,
+						CumulativeBacklog:        7,
+						MaximumRPCSlotsUsed:      8,
+						CumulativeSendingQueue:   9,
+						CumulativePendingQueue:   10,
 					},
 				},
 			}},
@@ -212,6 +305,7 @@ func TestMountStats(t *testing.T) {
 							},
 						},
 						Transport: NFSTransportStats{
+							Protocol:                 "tcp",
 							Port:                     832,
 							Connect:                  1,
 							IdleTime:                 11 * time.Second,


### PR DESCRIPTION
Ok, this took a lot longer than I actually thought. :)

## Overview

The goal was to support parsing of NFS xprt mountstats for UDP mounts. Because the format of the `xprt` line in `/proc/self/mountstats` differs between TCP and UDP, getting stats for UDP mount points was not possible before and led to the following error in the prometheus node exporter:

```
failed to parse mountstats: invalid NFS transport stats 1.1 statement: [740 1 881477 875055 5946 2888414103 286261 16 258752 2080886]
```

See also issue #99 for reference.

## Details

The difference of the `xprt` line between TCP and UDP is described here: https://utcc.utoronto.ca/~cks/space/blog/linux/NFSMountstatsXprt

> For the udp RPC transport there is no connection count, connect idle time, or idle time (fields 3, 4 and 5); all other fields are the same.

The `statvers` bump from `1.0` to `1.1` had the same impact to both TCP and UDP, see this kernel commit for reference: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=15a4520621824a3c2eb2de2d1f3984bc1663d3c8. The difference between `statvers=1.0` and `statvers=1.1` are the three last fields (11-13 for TCP and 8-10 for UDP). To make it more clear, here is how the lines are supposed to look like, with the numbering taken from the link above:

```
TCP statvers=1.0: 1 2 3 4 5 6 7 8 9 10
TCP statvers=1.1: 1 2 3 4 5 6 7 8 9 10 11 12 13
UDP statvers=1.0: 1 2       6 7 8 9 10
UDP statvers=1.1: 1 2       6 7 8 9 10 11 12 13
```

In the struct, all field that are missing in the respective `xprt` line are set to 0

This led to the following code changes:

I added a new fields `protocol` to the `NFSTransportStats` struct that is either `tcp` or `udp`. In the struct, the fields are the same for TCP and UDP, with the fields 3-5 being set to 0 for UDP.

Closes #99

Ping @grobie @SuperQ 

I'm also working on incorporating the changes into the prometheus node exporter and got a first version working, but I want to wait for this pull request to be done before continuing.
