### PR TITLE
Update build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+
+jobs:
+  test:
+    docker:
+    - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/prometheus/procfs
+
+    steps:
+    - checkout
+    - run: make style check_license vet test staticcheck
+
+workflows:
+  version: 2
+  node_exporter:
+    jobs:
+    - test:
+        filters:
+          tags:
+            only: /.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,8 @@ sudo: false
 language: go
 
 go:
-- 1.7.x
-- 1.8.x
 - 1.9.x
 - 1.10.x
-- 1.x
 
 go_import_path: github.com/prometheus/procfs
 


### PR DESCRIPTION
* Remove Go 1.x to avoid `go fmt` issue with 1.11.
* Add circleci 2 config.
* Drop Go 1.7 and 1.8 (https://github.com/dominikh/go-tools/issues/296)

Signed-off-by: Ben Kochie <bjk@gitlab.com>