### PR TITLE
Initial support for parsing /proc/net/arp

### DIFF
--- a/arp.go
+++ b/arp.go
@@ -75,7 +75,6 @@ func parseARPEntries(file io.Reader) ([]ARPEntry, error) {
 }
 
 func parseARPEntry(columns []string) (ARPEntry, error) {
-
 	ip := net.ParseIP(columns[0])
 	mac := net.HardwareAddr(columns[3])
 

--- a/arp.go
+++ b/arp.go
@@ -53,14 +53,21 @@ func parseARPEntries(file io.Reader) ([]ARPEntry, error) {
 
 	for scanner.Scan() {
 		columns := strings.Fields(scanner.Text())
+		width := len(columns)
+		expectedDataWidth := 6
+		expectedHeaderWidth := 9
 
-		if columns[0] != "IP" {
+		if width == expectedHeaderWidth {
+			break
+		} else if width == expectedDataWidth {
 			entry, err := parseARPEntry(columns)
 			if err != nil {
 				return []ARPEntry{}, fmt.Errorf("failed to parse ARP entry: %s", err)
 			}
 
 			entries = append(entries, entry)
+		} else {
+			return []ARPEntry{}, fmt.Errorf("%d columns were detected, but %d were expected", width, expectedDataWidth)
 		}
 	}
 
@@ -68,12 +75,6 @@ func parseARPEntries(file io.Reader) ([]ARPEntry, error) {
 }
 
 func parseARPEntry(columns []string) (ARPEntry, error) {
-	width := len(columns)
-	expectedWidth := 6
-
-	if width != expectedWidth {
-		return ARPEntry{}, fmt.Errorf("%d columns were detected, but %d were expected", width, expectedWidth)
-	}
 
 	ip := net.ParseIP(columns[0])
 	mac := net.HardwareAddr(columns[3])

--- a/arp.go
+++ b/arp.go
@@ -35,6 +35,8 @@ type ARPEntry struct {
 	Device string
 }
 
+// GatherARPEntries retrieves all the ARP entries, parse the relevant columns,
+// and then return a slice of ARPEntry's.
 func (fs FS) GatherARPEntries() ([]ARPEntry, error) {
 	file, err := os.Open(fs.Path("net/arp"))
 	if err != nil {
@@ -45,8 +47,6 @@ func (fs FS) GatherARPEntries() ([]ARPEntry, error) {
 	return parseARPEntries(file)
 }
 
-// GatherARPEntries retrieves all the ARP entries, parse the relevant columns,
-// and then return a slice of ARPEntry's.
 func parseARPEntries(file io.Reader) ([]ARPEntry, error) {
 	scanner := bufio.NewScanner(file)
 	entries := make([]ARPEntry, 0)

--- a/arp.go
+++ b/arp.go
@@ -52,7 +52,11 @@ func GatherARPEntries() ([]ARPEntry, error) {
 
 	for scanner.Scan() {
 		columns := strings.Fields(scanner.Text())
-		entry := parseARPEntry(columns)
+		entry, err := parseARPEntry(columns)
+		if err != nil {
+			fmt.Errorf("Failed to parse ARP entry: %s", err)
+		}
+
 		entries = append(entries, entry)
 	}
 

--- a/arp.go
+++ b/arp.go
@@ -64,7 +64,7 @@ func parseARPEntries(file io.Reader) ([]ARPEntry, error) {
 		}
 	}
 
-	return entries, nil
+	return entries, scanner.Err()
 }
 
 func parseARPEntry(columns []string) (ARPEntry, error) {

--- a/arp.go
+++ b/arp.go
@@ -1,0 +1,71 @@
+// Copyright 2018 The Prometheus Authors
+// Copyright 2018 Sam Kottler <shkottler@gmail.com>
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"strings"
+)
+
+type ARPEntry struct {
+	// IP address
+	IPAddr net.IP
+	// MAC address
+	HWAddr net.HardwareAddr
+	// Name of the device
+	Device string
+}
+
+// GatherARPEntries retrieves all the ARP entries, parse the relevant columns,
+// and then return a slice of ARPEntry's.
+func GatherARPEntries() ([]ARPEntry, error) {
+	fs, err := NewFS(DefaultMountPoint)
+
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(fs.Path("net/arp"))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	entries := make([]ARPEntry, 0)
+
+	for scanner.Scan() {
+		columns := strings.Fields(scanner.Text())
+		entry := parseARPEntry(columns)
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func parseARPEntry(columns []string) ARPEntry {
+	ip := net.ParseIP(columns[0])
+	mac := net.HardwareAddr(columns[3])
+
+	entry := ARPEntry{
+		IPAddr: ip,
+		HWAddr: mac,
+		Device: columns[5],
+	}
+
+	return entry
+}

--- a/arp.go
+++ b/arp.go
@@ -52,7 +52,7 @@ func parseARPEntries(file io.Reader) ([]ARPEntry, error) {
 	for scanner.Scan() {
 		columns := strings.Fields(scanner.Text())
 
-		if columns[0] != "IP Address" {
+		if columns[0] != "IP" {
 			entry, err := parseARPEntry(columns)
 			if err != nil {
 				return []ARPEntry{}, fmt.Errorf("Failed to parse ARP entry: %s", err)

--- a/arp.go
+++ b/arp.go
@@ -51,12 +51,15 @@ func parseARPEntries(file io.Reader) ([]ARPEntry, error) {
 
 	for scanner.Scan() {
 		columns := strings.Fields(scanner.Text())
-		entry, err := parseARPEntry(columns)
-		if err != nil {
-			return []ARPEntry{}, fmt.Errorf("Failed to parse ARP entry: %s", err)
-		}
 
-		entries = append(entries, entry)
+		if columns[0] != "IP Address" {
+			entry, err := parseARPEntry(columns)
+			if err != nil {
+				return []ARPEntry{}, fmt.Errorf("Failed to parse ARP entry: %s", err)
+			}
+
+			entries = append(entries, entry)
+		}
 	}
 
 	return entries, nil

--- a/arp.go
+++ b/arp.go
@@ -80,5 +80,5 @@ func parseARPEntry(columns []string) (ARPEntry, error) {
 		Device: columns[5],
 	}
 
-	return entry
+	return entry, nil
 }

--- a/arp.go
+++ b/arp.go
@@ -57,7 +57,7 @@ func parseARPEntries(file io.Reader) ([]ARPEntry, error) {
 		if columns[0] != "IP" {
 			entry, err := parseARPEntry(columns)
 			if err != nil {
-				return []ARPEntry{}, fmt.Errorf("Failed to parse ARP entry: %s", err)
+				return []ARPEntry{}, fmt.Errorf("failed to parse ARP entry: %s", err)
 			}
 
 			entries = append(entries, entry)

--- a/arp.go
+++ b/arp.go
@@ -67,7 +67,7 @@ func parseARPEntry(columns []string) (ARPEntry, error) {
 	width := len(columns)
 	expectedWidth := 6
 
-	if width < expectedWidth {
+	if width != expectedWidth {
 		return ARPEntry{}, fmt.Errorf("%s columns were detected, but %s were expected", width, expectedWidth)
 	}
 

--- a/arp.go
+++ b/arp.go
@@ -1,6 +1,6 @@
 // Copyright 2018 The Prometheus Authors
 // Copyright 2018 Sam Kottler <shkottler@gmail.com>
-
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/arp.go
+++ b/arp.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 )
 
+// ARPEntry contains a single row of the columnar data represented in
+// /proc/net/arp.
 type ARPEntry struct {
 	// IP address
 	IPAddr net.IP

--- a/arp.go
+++ b/arp.go
@@ -17,6 +17,7 @@ package procfs
 
 import (
 	"bufio"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -45,6 +46,7 @@ func GatherARPEntries() ([]ARPEntry, error) {
 		return nil, err
 	}
 	defer file.Close()
+
 	scanner := bufio.NewScanner(file)
 	entries := make([]ARPEntry, 0)
 
@@ -57,7 +59,14 @@ func GatherARPEntries() ([]ARPEntry, error) {
 	return entries, nil
 }
 
-func parseARPEntry(columns []string) ARPEntry {
+func parseARPEntry(columns []string) (ARPEntry, error) {
+	width := len(columns)
+	expectedWidth := 6
+
+	if width < expectedWidth {
+		return ARPEntry{}, fmt.Errorf("%s columns were detected, but %s were expected", width, expectedWidth)
+	}
+
 	ip := net.ParseIP(columns[0])
 	mac := net.HardwareAddr(columns[3])
 

--- a/arp_test.go
+++ b/arp_test.go
@@ -1,4 +1,5 @@
-// Copyright 2017 The Prometheus Authors
+// Copyright 2018 The Prometheus Authors
+// Copyright 2018 Sam Kottler <shkottler@gmail.com>
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/arp_test.go
+++ b/arp_test.go
@@ -14,6 +14,7 @@
 package procfs
 
 import (
+	"net"
 	"testing"
 )
 
@@ -25,5 +26,13 @@ func TestARP(t *testing.T) {
 
 	if want, got := "192.168.224.1", arpFile[0].IPAddr.String(); want != got {
 		t.Errorf("want 192.168.224.1, got %s", got)
+	}
+
+	if want, got := net.HardwareAddr("00:50:56:c0:00:08").String(), arpFile[0].HWAddr.String(); want != got {
+		t.Errorf("want 00:50:56:c0:00:08, got %s", got)
+	}
+
+	if want, got := "ens33", arpFile[0].Device; want != got {
+		t.Errorf("want ens33, got %s", got)
 	}
 }

--- a/arp_test.go
+++ b/arp_test.go
@@ -1,0 +1,29 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"testing"
+)
+
+func TestARP(t *testing.T) {
+	arpFile, err := FS("fixtures/arp/valid").GatherARPEntries()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, got := "192.168.224.254", arpFile[0].IPAddr.String(); want != got {
+		t.Errorf("want 192.168.224.254, got %s", got)
+	}
+}

--- a/arp_test.go
+++ b/arp_test.go
@@ -23,7 +23,7 @@ func TestARP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want, got := "192.168.224.254", arpFile[0].IPAddr.String(); want != got {
-		t.Errorf("want 192.168.224.254, got %s", got)
+	if want, got := "192.168.224.1", arpFile[0].IPAddr.String(); want != got {
+		t.Errorf("want 192.168.224.1, got %s", got)
 	}
 }

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -189,6 +189,21 @@ Lines: 2
 #!/bin/cat /proc/self/stat
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/arp
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/arp/valid
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/arp/valid/net
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/arp/valid/net/arp
+Lines: 2
+IP address       HW type     Flags       HW address            Mask     Device
+192.168.224.1    0x1         0x2         00:50:56:c0:00:08     *        ens33
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/buddyinfo
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/fixtures.ttar
+++ b/sysfs/fixtures.ttar
@@ -855,9 +855,3 @@ Lines: 1
 extent_alloc 2 0 0 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: fixtures/net
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: fixtures/net/arp
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/fixtures.ttar
+++ b/sysfs/fixtures.ttar
@@ -855,3 +855,9 @@ Lines: 1
 extent_alloc 2 0 0 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/net
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/net/arp
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This introduces ARP support for this package. Ultimately this will be used to keep track of more complex neighbor state for IPv6 support, but in the meantime should lay the foundation for removing `/proc` parsing logic from `collector/arp_linux.go` in `node_exporter`.

/cc https://github.com/prometheus/node_exporter/pull/540 where this was originally discussed
/cc https://github.com/prometheus/node_exporter/issues/535