### PR TITLE
Support Proc.Cwd() and Proc.RootDir()

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -15,6 +15,9 @@ Lines: 1
 vim
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/26231/cwd
+SymlinkTo: /usr/bin
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/26231/exe
 SymlinkTo: /usr/bin/vim
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -111,6 +114,9 @@ SymlinkTo: mnt:[4026531840]
 Path: fixtures/26231/ns/net
 SymlinkTo: net:[4026531993]
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/26231/root
+SymlinkTo: /
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/26231/stat
 Lines: 1
 26231 (vim) R 5392 7446 5392 34835 7446 4218880 32533 309516 26 82 1677 44 158 99 20 0 1 0 82375 56274944 1981 18446744073709551615 4194304 6294284 140736914091744 140736914087944 139965136429984 0 0 12288 1870679807 0 0 0 17 0 0 0 31 0 0 8391624 8481048 16420864 140736914093252 140736914093279 140736914093279 140736914096107 0
@@ -127,6 +133,9 @@ Path: fixtures/26232/comm
 Lines: 1
 ata_sff
 Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/26232/cwd
+SymlinkTo: /does/not/exist
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/26232/fd
 Mode: 755
@@ -166,6 +175,9 @@ Max nice priority         0                    0
 Max realtime priority     0                    0                    
 Max realtime timeout      unlimited            unlimited            us        
 Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/26232/root
+SymlinkTo: /does/not/exist
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/26232/stat
 Lines: 1
@@ -443,4 +455,8 @@ Mode: 644
 Path: fixtures/symlinktargets/xyz
 Lines: 0
 Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/.unpacked
+Lines: 0
+Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/proc.go
+++ b/proc.go
@@ -156,6 +156,26 @@ func (p Proc) Executable() (string, error) {
 	return exe, err
 }
 
+// Cwd returns the absolute path to the current working directory of the process.
+func (p Proc) Cwd() (string, error) {
+	wd, err := os.Readlink(p.path("cwd"))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+
+	return wd, err
+}
+
+// RootDir returns the absolute path to the process's root directory (as set by chroot)
+func (p Proc) RootDir() (string, error) {
+	rdir, err := os.Readlink(p.path("root"))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+
+	return rdir, err
+}
+
 // FileDescriptors returns the currently open file descriptors of a process.
 func (p Proc) FileDescriptors() ([]uintptr, error) {
 	names, err := p.fileDescriptors()

--- a/proc_test.go
+++ b/proc_test.go
@@ -111,7 +111,63 @@ func TestExecutable(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(tt.want, exe) {
-			t.Errorf("want absolute path to cmdline %v, have %v", tt.want, exe)
+			t.Errorf("want absolute path to exe %v, have %v", tt.want, exe)
+		}
+	}
+}
+
+func TestCwd(t *testing.T) {
+	for _, tt := range []struct {
+		process    int
+		want       string
+		brokenLink bool
+	}{
+		{process: 26231, want: "/usr/bin"},
+		{process: 26232, want: "/does/not/exist", brokenLink: true},
+		{process: 26233, want: ""},
+	} {
+		p, err := FS("fixtures").NewProc(tt.process)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wd, err := p.Cwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(tt.want, wd) {
+			if wd == "" && tt.brokenLink {
+				// Allow the result to be empty when can't os.Readlink broken links
+				continue
+			}
+			t.Errorf("want absolute path to cwd %v, have %v", tt.want, wd)
+		}
+	}
+}
+
+func TestRoot(t *testing.T) {
+	for _, tt := range []struct {
+		process    int
+		want       string
+		brokenLink bool
+	}{
+		{process: 26231, want: "/"},
+		{process: 26232, want: "/does/not/exist", brokenLink: true},
+		{process: 26233, want: ""},
+	} {
+		p, err := FS("fixtures").NewProc(tt.process)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rdir, err := p.RootDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(tt.want, rdir) {
+			if rdir == "" && tt.brokenLink {
+				// Allow the result to be empty when can't os.Readlink broken links
+				continue
+			}
+			t.Errorf("want absolute path to rootdir %v, have %v", tt.want, rdir)
 		}
 	}
 }


### PR DESCRIPTION
Addressing @grobie, as per contributing guidelines for trivial improvement.

The PR implements reading /proc/pid/cwd and /proc/pid/root similar to how /proc/pid/exe is implemented.

Naming is inspired by https://talks.golang.org/2014/names.slide and golang standard library.