### PR TITLE
override default "build" target to fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,8 @@ update_fixtures: fixtures.ttar sysfs/fixtures.ttar
 	rm -v $(dir $*)fixtures/.unpacked
 	./ttar -C $(dir $*) -c -f $*fixtures.ttar fixtures/
 
+.PHONY: build
+build:
+
 .PHONY: test
 test: fixtures/.unpacked sysfs/fixtures/.unpacked common-test


### PR DESCRIPTION
This fixes the default "make" and "make build" commands failing due to
lack of a .promu.yml file.  Overrides the "build" target with
basic "go build".

Signed-off-by: Paul Gier <pgier@redhat.com>