### PR TITLE
Adjust CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,24 @@
 version: 2.1
 
 commands:
-  linux:
+  default:
     steps:
     - run: make style check_license vet test staticcheck
-  windows:
+  no-style:
+    steps:
+    - run: make check_license vet test staticcheck
+  no-test:
     steps:
     - run: make style check_license vet staticcheck
+  no-style-test:
+    steps:
+    - run: make check_license vet staticcheck
 
 jobs:
   test:
     parameters:
+      command:
+        type: string
       go_version:
         type: string
       os:
@@ -23,25 +31,29 @@ jobs:
     working_directory: /go/src/github.com/prometheus/procfs
     steps:
     - checkout
-    - << parameters.os >>
+    - << parameters.command >>
 
 workflows:
   version: 2
   procfs:
     jobs:
     - test:
+        command: no-style-test
         name: linux-1-10
         os: linux
         go_version: "1.10"
     - test:
+        command: default
         name: linux-1-11
         os: linux
         go_version: "1.11"
     - test:
+        command: no-style-test
         name: windows-1-10
         os: windows
         go_version: "1.10"
     - test:
+        command: no-test
         name: windows-1-11
         os: windows
         go_version: "1.11"

--- a/xfs/parse.go
+++ b/xfs/parse.go
@@ -43,15 +43,15 @@ func ParseStats(r io.Reader) (*Stats, error) {
 		fieldXpc         = "xpc"
 
 		// Unimplemented at this time due to lack of documentation.
-		fieldPushAil = "push_ail"
-		fieldXstrat  = "xstrat"
-		fieldAbtb2   = "abtb2"
-		fieldAbtc2   = "abtc2"
-		fieldBmbt2   = "bmbt2"
-		fieldIbt2    = "ibt2"
-		fieldFibt2   = "fibt2"
-		fieldQm      = "qm"
-		fieldDebug   = "debug"
+		// fieldPushAil = "push_ail"
+		// fieldXstrat  = "xstrat"
+		// fieldAbtb2   = "abtb2"
+		// fieldAbtc2   = "abtc2"
+		// fieldBmbt2   = "bmbt2"
+		// fieldIbt2    = "ibt2"
+		// fieldFibt2   = "fibt2"
+		// fieldQm      = "qm"
+		// fieldDebug   = "debug"
 	)
 
 	var xfss Stats


### PR DESCRIPTION
* Split command out as separate param from OS.
* Don't run `style` check on Go 1.10.

Signed-off-by: Ben Kochie <superq@gmail.com>