### PR TITLE
Collect cpufreq in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
     - run: make style check_license vet staticcheck
   no-style-test:
     steps:
-    - run: go get golang.org/x/sync/errgroup
+    - run: go get -t ./...
     - run: make check_license vet staticcheck
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ commands:
     - run: make style check_license vet staticcheck
   no-style-test:
     steps:
+    - run: go get golang.org/x/sync/errgroup
     - run: make check_license vet staticcheck
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/prometheus/procfs
+
+require golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Use wait group to collect the cpufreq data in parallel.

Signed-off-by: Ben Kochie <superq@gmail.com>