### PR TITLE
Add support for /sys/class/thermal/thermal_zone

### DIFF
--- a/internal/util/parse.go
+++ b/internal/util/parse.go
@@ -57,3 +57,17 @@ func ReadUintFromFile(path string) (uint64, error) {
 	}
 	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
 }
+
+// ParseBool parses a string into a boolean pointer.
+func ParseBool(b string) *bool {
+	var truth bool
+	switch b {
+	case "enabled":
+		truth = true
+	case "disabled":
+		truth = false
+	default:
+		return nil
+	}
+	return &truth
+}

--- a/sysfs/class_thermal.go
+++ b/sysfs/class_thermal.go
@@ -1,0 +1,81 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sysfs
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// ClassThermalZoneStats contains info from files in /sys/class/thermal/thermal_zone<zone>
+// for a single <zone>.
+// https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt
+type ClassThermalZoneStats struct {
+	Name    string  // The name of the zone from the directory structure.
+	Type    string  // The type of thermal zone.
+	Temp    uint64  // Temperature in millidegree Celsius.
+	Mode    *string // Optional: One of the predefined values in [enabled, disabled].
+	Policy  string  // One of the various thermal governors used for a particular zone.
+	Passive *uint64 // Optional: millidegrees Celsius. (0 for disabled, > 1000 for enabled+value)
+}
+
+// NewClassThermalZoneStats returns Thermal Zone metrics for all zones.
+func (fs FS) NewClassThermalZoneStats() ([]ClassThermalZoneStats, error) {
+	zones, err := filepath.Glob(fs.Path("class/thermal/thermal_zone[0-9]*"))
+	if err != nil {
+		return []ClassThermalZoneStats{}, err
+	}
+
+	var zoneStats = ClassThermalZoneStats{}
+	stats := make([]ClassThermalZoneStats, len(zones))
+	for i, zone := range zones {
+		zoneName := strings.TrimPrefix(filepath.Base(zone), "thermal_zone")
+
+		zoneStats, err = parseClassThermalZone(zone)
+		if err != nil {
+			return []ClassThermalZoneStats{}, err
+		}
+		zoneStats.Name = zoneName
+		stats[i] = zoneStats
+	}
+	return stats, nil
+}
+
+func parseClassThermalZone(zone string) (ClassThermalZoneStats, error) {
+	// Required attributes.
+	zoneType, err := util.SysReadFile(filepath.Join(zone, "type"))
+	if err != nil {
+		return ClassThermalZoneStats{}, err
+	}
+	zonePolicy, err := util.SysReadFile(filepath.Join(zone, "policy"))
+	if err != nil {
+		return ClassThermalZoneStats{}, err
+	}
+	zoneTemp, err := util.ReadUintFromFile(filepath.Join(zone, "temp"))
+	if err != nil {
+		return ClassThermalZoneStats{}, err
+	}
+
+	// Optional attributes.
+
+	return ClassThermalZoneStats{
+		Type:   zoneType,
+		Policy: zonePolicy,
+		Temp:   zoneTemp,
+	}, nil
+}

--- a/sysfs/class_thermal_test.go
+++ b/sysfs/class_thermal_test.go
@@ -18,6 +18,8 @@ package sysfs
 import (
 	"reflect"
 	"testing"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 func TestClassThermalZoneStats(t *testing.T) {
@@ -31,12 +33,25 @@ func TestClassThermalZoneStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	enabled := util.ParseBool("enabled")
+	passive := uint64(0)
+
 	classThermalZoneStats := []ClassThermalZoneStats{
 		{
-			Name:   "0",
-			Type:   "bcm2835_thermal",
-			Policy: "step_wise",
-			Temp:   49925,
+			Name:    "0",
+			Type:    "bcm2835_thermal",
+			Policy:  "step_wise",
+			Temp:    49925,
+			Mode:    nil,
+			Passive: nil,
+		},
+		{
+			Name:    "1",
+			Type:    "acpitz",
+			Policy:  "step_wise",
+			Temp:    44000,
+			Mode:    enabled,
+			Passive: &passive,
 		},
 	}
 

--- a/sysfs/class_thermal_test.go
+++ b/sysfs/class_thermal_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sysfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestClassThermalZoneStats(t *testing.T) {
+	fs, err := NewFS("fixtures")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	thermalTest, err := fs.NewClassThermalZoneStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	classThermalZoneStats := []ClassThermalZoneStats{
+		{
+			Name:   "0",
+			Type:   "bcm2835_thermal",
+			Policy: "step_wise",
+			Temp:   49925,
+		},
+	}
+
+	if !reflect.DeepEqual(classThermalZoneStats, thermalTest) {
+		t.Errorf("Result not correct: want %v, have %v", classThermalZoneStats, thermalTest)
+	}
+}

--- a/sysfs/fixtures.ttar
+++ b/sysfs/fixtures.ttar
@@ -158,6 +158,34 @@ Lines: 1
 bcm2835_thermal
 Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/class/thermal/thermal_zone1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/class/thermal/thermal_zone1/mode
+Lines: 1
+enabled
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/class/thermal/thermal_zone1/passive
+Lines: 1
+0
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/class/thermal/thermal_zone1/policy
+Lines: 1
+step_wise
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/class/thermal/thermal_zone1/temp
+Lines: 1
+44000
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/class/thermal/thermal_zone1/type
+Lines: 1
+acpitz
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/devices
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/fixtures.ttar
+++ b/sysfs/fixtures.ttar
@@ -137,6 +137,27 @@ Lines: 1
 1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/class/thermal
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/class/thermal/thermal_zone0
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/class/thermal/thermal_zone0/policy
+Lines: 1
+step_wise
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/class/thermal/thermal_zone0/temp
+Lines: 1
+49925
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/class/thermal/thermal_zone0/type
+Lines: 1
+bcm2835_thermal
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/devices
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
* Add support for temp readings from `/sys/class/thermal/thermal_zone*`.

Closes: https://github.com/prometheus/procfs/issues/46

Signed-off-by: Ben Kochie <superq@gmail.com>