### PR TITLE
ProcStat VSize is unsigned

### DIFF
--- a/proc_stat.go
+++ b/proc_stat.go
@@ -95,7 +95,7 @@ type ProcStat struct {
 	// in clock ticks.
 	Starttime uint64
 	// Virtual memory size in bytes.
-	VSize int
+	VSize uint
 	// Resident set size in pages.
 	RSS int
 
@@ -164,7 +164,7 @@ func (p Proc) NewStat() (ProcStat, error) {
 }
 
 // VirtualMemory returns the virtual memory size in bytes.
-func (s ProcStat) VirtualMemory() int {
+func (s ProcStat) VirtualMemory() uint {
 	return s.VSize
 }
 

--- a/proc_stat_test.go
+++ b/proc_stat_test.go
@@ -38,7 +38,7 @@ func TestProcStat(t *testing.T) {
 		{name: "user time", want: 1677, have: int(s.UTime)},
 		{name: "system time", want: 44, have: int(s.STime)},
 		{name: "start time", want: 82375, have: int(s.Starttime)},
-		{name: "virtual memory size", want: 56274944, have: s.VSize},
+		{name: "virtual memory size", want: 56274944, have: int(s.VSize)},
 		{name: "resident set size", want: 1981, have: s.RSS},
 	} {
 		if test.want != test.have {
@@ -71,7 +71,7 @@ func TestProcStatVirtualMemory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want, have := 56274944, s.VirtualMemory(); want != have {
+	if want, have := 56274944, int(s.VirtualMemory()); want != have {
 		t.Errorf("want virtual memory %d, have %d", want, have)
 	}
 }


### PR DESCRIPTION
see `man 5 proc`

This should fix the integer overflow of this field on 32bit platforms.

See also https://github.com/ncabatoff/process-exporter/issues/80