### PR TITLE
Add second maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,1 +1,2 @@
-* Tobias Schmidt <tobidt@gmail.com>
+* Tobias Schmidt <tobidt@gmail.com> @grobie
+* Johannes 'fish' Ziemke <github@freigeist.org> @discordianfish


### PR DESCRIPTION
Add Johannes 'fish' Ziemke <github@freigeist.org> @discordianfish as a
maintainer.

Signed-off-by: Ben Kochie <superq@gmail.com>