### PR TITLE
Makefile: fix update_fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ include Makefile.common
 	./ttar -C $(dir $*) -x -f $*.ttar
 	touch $@
 
-update_fixtures: fixtures.ttar sysfs/fixtures.ttar
-
-%fixtures.ttar: %/fixtures
-	rm -v $(dir $*)fixtures/.unpacked
-	./ttar -C $(dir $*) -c -f $*fixtures.ttar fixtures/
+update_fixtures:
+	rm -vf fixtures/.unpacked
+	./ttar -c -f fixtures.ttar fixtures/
+	rm -vf sysfs/fixtures/.unpacked
+	./ttar -C sysfs/ -c -f sysfs/fixtures.ttar fixtures/
 
 .PHONY: build
 build:

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -529,7 +529,3 @@ Path: fixtures/symlinktargets/xyz
 Lines: 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/.unpacked
-Lines: 0
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This fixes generation of the root dir fixtures.ttar file using
the update_fixtures target.  The problem is that the Makefile
wildcard '%' does not match against an empty string, so
"%fixtures.ttar" matches "sysfs/fixtures.ttar" but not "fixtures.ttar".

Signed-off-by: Paul Gier <pgier@redhat.com>