### PR TITLE
net_class: Split device discovery

### DIFF
--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -19,12 +19,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 
 	"github.com/prometheus/procfs/internal/util"
 )
+
+const netclassPath = "class/net"
 
 // NetClassIface contains info from files in /sys/class/net/<iface>
 // for single interface (iface).
@@ -72,26 +75,42 @@ func NewNetClass() (NetClass, error) {
 	return fs.NewNetClass()
 }
 
-// NewNetClass returns info for all net interfaces (iface) read from /sys/class/net/<iface>.
-func (fs FS) NewNetClass() (NetClass, error) {
-	path := fs.Path("class/net")
+// NetClassDevices scans /sys/class/net for devices and returns them as a list of names.
+func (fs FS) NetClassDevices() ([]string, error) {
+	var res []string
+	path := fs.Path(netclassPath)
 
 	devices, err := ioutil.ReadDir(path)
 	if err != nil {
-		return NetClass{}, fmt.Errorf("cannot access %s dir %s", path, err)
+		return res, fmt.Errorf("cannot access %s dir %s", path, err)
 	}
 
-	netClass := NetClass{}
 	for _, deviceDir := range devices {
 		if deviceDir.Mode().IsRegular() {
 			continue
 		}
-		interfaceClass, err := netClass.parseNetClassIface(path + "/" + deviceDir.Name())
+		res = append(res, deviceDir.Name())
+	}
+
+	return res, nil
+}
+
+// NewNetClass returns info for all net interfaces (iface) read from /sys/class/net/<iface>.
+func (fs FS) NewNetClass() (NetClass, error) {
+	devices, err := fs.NetClassDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	path := fs.Path(netclassPath)
+	netClass := NetClass{}
+	for _, deviceDir := range devices {
+		interfaceClass, err := netClass.parseNetClassIface(filepath.Join(path, deviceDir))
 		if err != nil {
 			return nil, err
 		}
-		interfaceClass.Name = deviceDir.Name()
-		netClass[deviceDir.Name()] = *interfaceClass
+		interfaceClass.Name = deviceDir
+		netClass[deviceDir] = *interfaceClass
 	}
 	return netClass, nil
 }

--- a/sysfs/net_class_test.go
+++ b/sysfs/net_class_test.go
@@ -20,6 +20,25 @@ import (
 	"testing"
 )
 
+func TestNewNetClassDevices(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	devices, err := fs.NetClassDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(devices) != 1 {
+		t.Errorf("Unexpected number of devices, want %d, have %d", 1, len(devices))
+	}
+	if devices[0] != "eth0" {
+		t.Errorf("Found unexpected device, want %s, have %s", "eth0", devices[0])
+	}
+}
+
 func TestNewNetClass(t *testing.T) {
 	fs, err := NewFS(sysTestFixtures)
 	if err != nil {


### PR DESCRIPTION
This splits the discovery of device/interfaces out from the main
`NewNetClass()` function.

I want to do this b/c on systems that have a lot of devices in
`/sys/class/net/*` calling `parseNetClassIface` in serial takes a lot of
time. On my system with 55 devices it currently takes about 150ms.

By splitting the device discovery I can call `parseNetClassIface` using
a worker pool and process them much faster. `NewNetClass` is updated to
use the new `NetClassDevices()` method so its behaviour does not change.