### PR TITLE
Don't build sysreadfile for app engine

### DIFF
--- a/internal/util/sysreadfile_linux.go
+++ b/internal/util/sysreadfile_linux.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build !windows !appengine
 
 package util
 


### PR DESCRIPTION
Google App Engine does not allow compiling with `import "syscall"`. See discussion in https://github.com/prometheus/client_golang/issues/549.