### PR TITLE
Better App Engine build tags fix

### DIFF
--- a/internal/util/sysreadfile.go
+++ b/internal/util/sysreadfile.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows !appengine
+// +build linux,!appengine
 
 package util
 

--- a/internal/util/sysreadfile_compat.go
+++ b/internal/util/sysreadfile_compat.go
@@ -22,5 +22,5 @@ import (
 // SysReadFile is here implemented as a noop for builds that do not support
 // the read syscall. For example Windows, or Linux on Google App Engine.
 func SysReadFile(file string) (string, error) {
-	return "", fmt.Errorf("Not supported on this platform")
+	return "", fmt.Errorf("not supported on this platform")
 }

--- a/internal/util/sysreadfile_compat.go
+++ b/internal/util/sysreadfile_compat.go
@@ -1,0 +1,26 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux,appengine !linux
+
+package util
+
+import (
+	"fmt"
+)
+
+// SysReadFile is here implemented as a noop for builds that do not support
+// the read syscall. For example Windows, or Linux on Google App Engine.
+func SysReadFile(file string) (string, error) {
+	return "", fmt.Errorf("Not supported on this platform")
+}

--- a/internal/util/sysreadfile_compat.go
+++ b/internal/util/sysreadfile_compat.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
This fixes the patch from #143.
The "full implementation" is in `sysreadfile.go`, and is used for Linux (but not on App Engine), and `sysreadfile_compat.go` provides a fallback implementation for other platforms.

ping @SuperQ @beorn7 @brian-brazil.