### PR TITLE
use FS struct for proc and sys mount points in submodules

### DIFF
--- a/bcache/get.go
+++ b/bcache/get.go
@@ -26,31 +26,31 @@ import (
 	"github.com/prometheus/procfs/sysfs"
 )
 
-// Bcache represents the pseudo-filesystem proc, which provides an interface to
+// Handle represents the pseudo-filesystem proc, which provides an interface to
 // kernel data structures.
-type Bcache struct {
+type Handle struct {
 	sysfs *sysfs.FS
 }
 
 // DefaultSysMountPoint is the common mount point of the sys filesystem.
 const DefaultSysMountPoint = "/sys"
 
-// NewBcache returns a new Bcache using the given sys fs mount point. It will error
+// New returns a new Bcache using the given sys fs mount point. It will error
 // if the mount point can't be read.
-func NewBcache(mountPoint string) (Bcache, error) {
+func New(mountPoint string) (Handle, error) {
 	if strings.TrimSpace(mountPoint) == "" {
 		mountPoint = DefaultSysMountPoint
 	}
 	fs, err := sysfs.NewFS(mountPoint)
 	if err != nil {
-		return Bcache{}, err
+		return Handle{}, err
 	}
-	return Bcache{&fs}, nil
+	return Handle{&fs}, nil
 }
 
 // Stats retrieves bcache runtime statistics for each bcache.
-func (b Bcache) Stats() ([]*Stats, error) {
-	matches, err := filepath.Glob(b.sysfs.Path("fs/bcache/*-*"))
+func (h Handle) Stats() ([]*Stats, error) {
+	matches, err := filepath.Glob(h.sysfs.Path("fs/bcache/*-*"))
 	if err != nil {
 		return nil, err
 	}

--- a/bcache/get.go
+++ b/bcache/get.go
@@ -23,13 +23,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/prometheus/procfs/internal/util"
+	"github.com/prometheus/procfs/internal/fs"
 )
 
 // FS represents the pseudo-filesystem proc, which provides an interface to
 // kernel data structures.
 type FS struct {
-	sys *util.FS
+	sys *fs.FS
 }
 
 // DefaultSysMountPoint is the common mount point of the sys filesystem.
@@ -41,7 +41,7 @@ func NewFS(mountPoint string) (FS, error) {
 	if strings.TrimSpace(mountPoint) == "" {
 		mountPoint = DefaultSysMountPoint
 	}
-	fs, err := util.NewFS(mountPoint)
+	fs, err := fs.NewFS(mountPoint)
 	if err != nil {
 		return FS{}, err
 	}

--- a/bcache/get.go
+++ b/bcache/get.go
@@ -32,14 +32,11 @@ type FS struct {
 	sys *fs.FS
 }
 
-// DefaultSysMountPoint is the common mount point of the sys filesystem.
-const DefaultSysMountPoint = "/sys"
-
 // NewFS returns a new Bcache using the given sys fs mount point. It will error
 // if the mount point can't be read.
 func NewFS(mountPoint string) (FS, error) {
 	if strings.TrimSpace(mountPoint) == "" {
-		mountPoint = DefaultSysMountPoint
+		mountPoint = fs.DefaultSysMountPoint
 	}
 	fs, err := fs.NewFS(mountPoint)
 	if err != nil {

--- a/bcache/get.go
+++ b/bcache/get.go
@@ -23,34 +23,34 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/prometheus/procfs/sysfs"
+	"github.com/prometheus/procfs/internal/util"
 )
 
-// Handle represents the pseudo-filesystem proc, which provides an interface to
+// FS represents the pseudo-filesystem proc, which provides an interface to
 // kernel data structures.
-type Handle struct {
-	sysfs *sysfs.FS
+type FS struct {
+	sys *util.FS
 }
 
 // DefaultSysMountPoint is the common mount point of the sys filesystem.
 const DefaultSysMountPoint = "/sys"
 
-// New returns a new Bcache using the given sys fs mount point. It will error
+// NewFS returns a new Bcache using the given sys fs mount point. It will error
 // if the mount point can't be read.
-func New(mountPoint string) (Handle, error) {
+func NewFS(mountPoint string) (FS, error) {
 	if strings.TrimSpace(mountPoint) == "" {
 		mountPoint = DefaultSysMountPoint
 	}
-	fs, err := sysfs.NewFS(mountPoint)
+	fs, err := util.NewFS(mountPoint)
 	if err != nil {
-		return Handle{}, err
+		return FS{}, err
 	}
-	return Handle{&fs}, nil
+	return FS{&fs}, nil
 }
 
 // Stats retrieves bcache runtime statistics for each bcache.
-func (h Handle) Stats() ([]*Stats, error) {
-	matches, err := filepath.Glob(h.sysfs.Path("fs/bcache/*-*"))
+func (fs FS) Stats() ([]*Stats, error) {
+	matches, err := filepath.Glob(fs.sys.Path("fs/bcache/*-*"))
 	if err != nil {
 		return nil, err
 	}

--- a/bcache/get_test.go
+++ b/bcache/get_test.go
@@ -19,7 +19,11 @@ import (
 )
 
 func TestFSBcacheStats(t *testing.T) {
-	stats, err := ReadStats("../fixtures/sys")
+	bcache, err := NewBcache("../fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access bcache fs: %v", err)
+	}
+	stats, err := bcache.Stats()
 	if err != nil {
 		t.Fatalf("failed to parse bcache stats: %v", err)
 	}

--- a/bcache/get_test.go
+++ b/bcache/get_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestFSBcacheStats(t *testing.T) {
-	bcache, err := New("../fixtures/sys")
+	bcache, err := NewFS("../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access bcache fs: %v", err)
 	}

--- a/bcache/get_test.go
+++ b/bcache/get_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestFSBcacheStats(t *testing.T) {
-	bcache, err := NewBcache("../fixtures/sys")
+	bcache, err := New("../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access bcache fs: %v", err)
 	}

--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -95,24 +95,18 @@ type FS struct {
 	sys  *fs.FS
 }
 
-// DefaultProcMountPoint is the common mount point of the proc filesystem.
-const DefaultProcMountPoint = "/proc"
-
-// DefaultSysMountPoint is the common mount point of the sys filesystem.
-const DefaultSysMountPoint = "/sys"
-
 // NewFS returns a new XFS mounted under the given mountPoint. It will error
 // if the mount point can't be read.
 func NewFS(procMountPoint string, sysMountPoint string) (FS, error) {
 	if strings.TrimSpace(procMountPoint) == "" {
-		procMountPoint = DefaultProcMountPoint
+		procMountPoint = fs.DefaultProcMountPoint
 	}
 	procfs, err := fs.NewFS(procMountPoint)
 	if err != nil {
 		return FS{}, err
 	}
 	if strings.TrimSpace(sysMountPoint) == "" {
-		sysMountPoint = DefaultSysMountPoint
+		sysMountPoint = fs.DefaultSysMountPoint
 	}
 	sysfs, err := fs.NewFS(sysMountPoint)
 	if err != nil {

--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/prometheus/procfs/internal/util"
+	"github.com/prometheus/procfs/internal/fs"
 )
 
 // Info contains identifying information for a block device such as a disk drive
@@ -91,8 +91,8 @@ const (
 // FS represents the pseudo-filesystems proc and sys, which provides an
 // interface to kernel data structures.
 type FS struct {
-	proc *util.FS
-	sys  *util.FS
+	proc *fs.FS
+	sys  *fs.FS
 }
 
 // DefaultProcMountPoint is the common mount point of the proc filesystem.
@@ -107,14 +107,14 @@ func NewFS(procMountPoint string, sysMountPoint string) (FS, error) {
 	if strings.TrimSpace(procMountPoint) == "" {
 		procMountPoint = DefaultProcMountPoint
 	}
-	procfs, err := util.NewFS(procMountPoint)
+	procfs, err := fs.NewFS(procMountPoint)
 	if err != nil {
 		return FS{}, err
 	}
 	if strings.TrimSpace(sysMountPoint) == "" {
 		sysMountPoint = DefaultSysMountPoint
 	}
-	sysfs, err := util.NewFS(sysMountPoint)
+	sysfs, err := fs.NewFS(sysMountPoint)
 	if err != nil {
 		return FS{}, err
 	}

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 func TestDiskstats(t *testing.T) {
-	blockdevice, err := NewBlockDevice("../fixtures/proc", "../fixtures/sys")
+	blockdevice, err := New("../fixtures/proc", "../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access blockdevice fs: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestDiskstats(t *testing.T) {
 }
 
 func TestBlockDevice(t *testing.T) {
-	blockdevice, err := NewBlockDevice("../fixtures/proc", "../fixtures/sys")
+	blockdevice, err := New("../fixtures/proc", "../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access blockdevice fs: %v", err)
 	}

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -24,7 +24,7 @@ const (
 )
 
 func TestDiskstats(t *testing.T) {
-	blockdevice, err := New("../fixtures/proc", "../fixtures/sys")
+	blockdevice, err := NewFS(procfsFixtures, sysfsFixtures)
 	if err != nil {
 		t.Fatalf("failed to access blockdevice fs: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestDiskstats(t *testing.T) {
 }
 
 func TestBlockDevice(t *testing.T) {
-	blockdevice, err := New("../fixtures/proc", "../fixtures/sys")
+	blockdevice, err := NewFS("../fixtures/proc", "../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access blockdevice fs: %v", err)
 	}

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -24,7 +24,11 @@ const (
 )
 
 func TestDiskstats(t *testing.T) {
-	diskstats, err := ReadProcDiskstats(procfsFixtures)
+	blockdevice, err := NewBlockDevice("../fixtures/proc", "../fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access blockdevice fs: %v", err)
+	}
+	diskstats, err := blockdevice.ProcDiskstats()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +54,11 @@ func TestDiskstats(t *testing.T) {
 }
 
 func TestBlockDevice(t *testing.T) {
-	devices, err := ListSysBlockDevices(sysfsFixtures)
+	blockdevice, err := NewBlockDevice("../fixtures/proc", "../fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access blockdevice fs: %v", err)
+	}
+	devices, err := blockdevice.SysBlockDevices()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +69,7 @@ func TestBlockDevice(t *testing.T) {
 	if devices[0] != "dm-0" {
 		t.Errorf(failMsgFormat, "Incorrect device name", "dm-0", devices[0])
 	}
-	device0stats, count, err := ReadSysBlockDeviceStat(sysfsFixtures, devices[0])
+	device0stats, count, err := blockdevice.SysBlockDeviceStat(devices[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +82,7 @@ func TestBlockDevice(t *testing.T) {
 	if device0stats.WeightedIOTicks != 6088971 {
 		t.Errorf(failMsgFormat, "Incorrect time in queue", 6088971, device0stats.WeightedIOTicks)
 	}
-	device1stats, count, err := ReadSysBlockDeviceStat(sysfsFixtures, devices[1])
+	device1stats, count, err := blockdevice.SysBlockDeviceStat(devices[1])
 	if count != 15 {
 		t.Errorf(failMsgFormat, "Incorrect number of stats read", 15, count)
 	}

--- a/buddyinfo.go
+++ b/buddyinfo.go
@@ -43,7 +43,7 @@ func NewBuddyInfo() ([]BuddyInfo, error) {
 
 // NewBuddyInfo reads the buddyinfo statistics from the specified `proc` filesystem.
 func (fs FS) NewBuddyInfo() ([]BuddyInfo, error) {
-	file, err := os.Open(fs.Path("buddyinfo"))
+	file, err := os.Open(fs.proc.Path("buddyinfo"))
 	if err != nil {
 		return nil, err
 	}

--- a/buddyinfo_test.go
+++ b/buddyinfo_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestBuddyInfo(t *testing.T) {
-	buddyInfo, err := FS("fixtures/proc/").NewBuddyInfo()
+	buddyInfo, err := getProcFixtures(t).NewBuddyInfo()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fs.go
+++ b/fs.go
@@ -24,7 +24,7 @@ type FS struct {
 }
 
 // DefaultMountPoint is the common mount point of the proc filesystem.
-const DefaultMountPoint = "/proc"
+const DefaultMountPoint = fs.DefaultProcMountPoint
 
 // NewFS returns a new proc FS mounted under the given proc mountPoint. It will error
 // if the mount point dirctory can't be read or is a file.

--- a/fs.go
+++ b/fs.go
@@ -13,12 +13,14 @@
 
 package procfs
 
-import "github.com/prometheus/procfs/internal/util"
+import (
+	"github.com/prometheus/procfs/internal/fs"
+)
 
 // FS represents the pseudo-filesystem sys, which provides an interface to
 // kernel data structures.
 type FS struct {
-	proc util.FS
+	proc fs.FS
 }
 
 // DefaultMountPoint is the common mount point of the proc filesystem.
@@ -27,7 +29,7 @@ const DefaultMountPoint = "/proc"
 // NewFS returns a new proc FS mounted under the given proc mountPoint. It will error
 // if the mount point dirctory can't be read or is a file.
 func NewFS(mountPoint string) (FS, error) {
-	fs, err := util.NewFS(mountPoint)
+	fs, err := fs.NewFS(mountPoint)
 	if err != nil {
 		return FS{}, err
 	}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -19,6 +19,14 @@ import (
 	"path/filepath"
 )
 
+const (
+	// DefaultProcMountPoint is the common mount point of the proc filesystem.
+	DefaultProcMountPoint = "/proc"
+
+	// DefaultSysMountPoint is the common mount point of the sys filesystem.
+	DefaultSysMountPoint = "/sys"
+)
+
 // FS represents a pseudo-filesystem, normally /proc or /sys, which provides an
 // interface to kernel data structures.
 type FS string

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package fs
 
 import (
 	"fmt"
@@ -19,8 +19,8 @@ import (
 	"path/filepath"
 )
 
-// FS represents the pseudo-filesystem sys, which provides an interface to
-// kernel data structures.
+// FS represents a pseudo-filesystem, normally /proc or /sys, which provides an
+// interface to kernel data structures.
 type FS string
 
 // NewFS returns a new FS mounted under the given mountPoint. It will error
@@ -37,7 +37,8 @@ func NewFS(mountPoint string) (FS, error) {
 	return FS(mountPoint), nil
 }
 
-// Path returns the path of the given subsystem relative to the sys root.
+// Path appends the given path elements to the filesystem path, adding separators
+// as necessary.
 func (fs FS) Path(p ...string) string {
 	return filepath.Join(append([]string{string(fs)}, p...)...)
 }

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package fs
 
 import "testing"
 

--- a/internal/util/fs_test.go
+++ b/internal/util/fs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package procfs
+package util
 
 import "testing"
 
 const (
-	procTestFixtures = "fixtures/proc"
+	sysTestFixtures = "../../fixtures/sys"
 )
 
 func TestNewFS(t *testing.T) {
@@ -24,16 +24,11 @@ func TestNewFS(t *testing.T) {
 		t.Error("want NewFS to fail for non-existing mount point")
 	}
 
-	if _, err := NewFS("procfs.go"); err == nil {
+	if _, err := NewFS("doc.go"); err == nil {
 		t.Error("want NewFS to fail if mount point is not a directory")
 	}
-	getProcFixtures(t)
-}
 
-func getProcFixtures(t *testing.T) FS {
-	fs, err := NewFS(procTestFixtures)
-	if err != nil {
-		t.Fatal(err)
+	if _, err := NewFS(sysTestFixtures); err != nil {
+		t.Error("want NewFS to succeed if mount point exists")
 	}
-	return fs
 }

--- a/ipvs.go
+++ b/ipvs.go
@@ -74,7 +74,7 @@ func NewIPVSStats() (IPVSStats, error) {
 
 // NewIPVSStats reads the IPVS statistics from the specified `proc` filesystem.
 func (fs FS) NewIPVSStats() (IPVSStats, error) {
-	file, err := os.Open(fs.Path("net/ip_vs_stats"))
+	file, err := os.Open(fs.proc.Path("net/ip_vs_stats"))
 	if err != nil {
 		return IPVSStats{}, err
 	}
@@ -143,7 +143,7 @@ func NewIPVSBackendStatus() ([]IPVSBackendStatus, error) {
 
 // NewIPVSBackendStatus reads and returns the status of all (virtual,real) server pairs from the specified `proc` filesystem.
 func (fs FS) NewIPVSBackendStatus() ([]IPVSBackendStatus, error) {
-	file, err := os.Open(fs.Path("net/ip_vs"))
+	file, err := os.Open(fs.proc.Path("net/ip_vs"))
 	if err != nil {
 		return nil, err
 	}

--- a/ipvs_test.go
+++ b/ipvs_test.go
@@ -159,7 +159,11 @@ var (
 )
 
 func TestIPVSStats(t *testing.T) {
-	stats, err := FS(procTestFixtures).NewIPVSStats()
+	fs, err := NewFS(procTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats, err := fs.NewIPVSStats()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +217,7 @@ func TestParseIPPortIPv6(t *testing.T) {
 }
 
 func TestIPVSBackendStatus(t *testing.T) {
-	backendStats, err := FS(procTestFixtures).NewIPVSBackendStatus()
+	backendStats, err := getProcFixtures(t).NewIPVSBackendStatus()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mdstat.go
+++ b/mdstat.go
@@ -44,7 +44,7 @@ type MDStat struct {
 
 // ParseMDStat parses an mdstat-file and returns a struct with the relevant infos.
 func (fs FS) ParseMDStat() (mdstates []MDStat, err error) {
-	mdStatusFilePath := fs.Path("mdstat")
+	mdStatusFilePath := fs.proc.Path("mdstat")
 	content, err := ioutil.ReadFile(mdStatusFilePath)
 	if err != nil {
 		return []MDStat{}, fmt.Errorf("error parsing %s: %s", mdStatusFilePath, err)

--- a/mdstat_test.go
+++ b/mdstat_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMDStat(t *testing.T) {
-	mdStates, err := FS(procTestFixtures).ParseMDStat()
+	mdStates, err := getProcFixtures(t).ParseMDStat()
 	if err != nil {
 		t.Fatalf("parsing of reference-file failed entirely: %s", err)
 	}

--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -344,7 +344,7 @@ func TestMountStats(t *testing.T) {
 		if tt.s != "" {
 			mounts, err = parseMountStats(strings.NewReader(tt.s))
 		} else {
-			proc, e := FS(procTestFixtures).NewProc(26231)
+			proc, e := getProcFixtures(t).NewProc(26231)
 			if e != nil {
 				t.Fatalf("failed to create proc: %v", err)
 			}

--- a/net_dev.go
+++ b/net_dev.go
@@ -59,7 +59,7 @@ func NewNetDev() (NetDev, error) {
 
 // NewNetDev returns kernel/system statistics read from /proc/net/dev.
 func (fs FS) NewNetDev() (NetDev, error) {
-	return newNetDev(fs.Path("net/dev"))
+	return newNetDev(fs.proc.Path("net/dev"))
 }
 
 // NewNetDev returns kernel/system statistics read from /proc/[pid]/net/dev.

--- a/net_dev_test.go
+++ b/net_dev_test.go
@@ -60,7 +60,7 @@ func TestNewNetDev(t *testing.T) {
 }
 
 func TestProcNewNetDev(t *testing.T) {
-	p, err := FS(procTestFixtures).NewProc(26231)
+	p, err := getProcFixtures(t).NewProc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/prometheus/procfs"
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // ReplyCache models the "rc" line.
@@ -269,32 +269,32 @@ type ServerRPCStats struct {
 	V4Ops          V4Ops
 }
 
-// Handle represents the pseudo-filesystem proc, which provides an interface to
+// FS represents the pseudo-filesystem proc, which provides an interface to
 // kernel data structures.
-type Handle struct {
-	procfs *procfs.FS
+type FS struct {
+	proc *util.FS
 }
 
 // DefaultMountPoint is the common mount point of the proc filesystem.
 const DefaultMountPoint = "/proc"
 
-// New returns a new FS mounted under the given mountPoint. It will error
+// NewFS returns a new FS mounted under the given mountPoint. It will error
 // if the mount point can't be read.
-func New(mountPoint string) (Handle, error) {
+func NewFS(mountPoint string) (FS, error) {
 	if strings.TrimSpace(mountPoint) == "" {
 		mountPoint = DefaultMountPoint
 	}
-	fs, err := procfs.NewFS(mountPoint)
+	fs, err := util.NewFS(mountPoint)
 	if err != nil {
-		return Handle{}, err
+		return FS{}, err
 	}
-	return Handle{&fs}, nil
+	return FS{&fs}, nil
 }
 
 // ClientRPCStats retrieves NFS client RPC statistics
 // from proc/net/rpc/nfs.
-func (h Handle) ClientRPCStats() (*ClientRPCStats, error) {
-	f, err := os.Open(h.procfs.Path("net/rpc/nfs"))
+func (fs FS) ClientRPCStats() (*ClientRPCStats, error) {
+	f, err := os.Open(fs.proc.Path("net/rpc/nfs"))
 	if err != nil {
 		return nil, err
 	}
@@ -305,8 +305,8 @@ func (h Handle) ClientRPCStats() (*ClientRPCStats, error) {
 
 // ServerRPCStats retrieves NFS daemon RPC statistics
 // from proc/net/rpc/nfsd.
-func (h Handle) ServerRPCStats() (*ServerRPCStats, error) {
-	f, err := os.Open(h.procfs.Path("net/rpc/nfsd"))
+func (fs FS) ServerRPCStats() (*ServerRPCStats, error) {
+	f, err := os.Open(fs.proc.Path("net/rpc/nfsd"))
 	if err != nil {
 		return nil, err
 	}

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -275,14 +275,11 @@ type FS struct {
 	proc *fs.FS
 }
 
-// DefaultMountPoint is the common mount point of the proc filesystem.
-const DefaultMountPoint = "/proc"
-
 // NewFS returns a new FS mounted under the given mountPoint. It will error
 // if the mount point can't be read.
 func NewFS(mountPoint string) (FS, error) {
 	if strings.TrimSpace(mountPoint) == "" {
-		mountPoint = DefaultMountPoint
+		mountPoint = fs.DefaultProcMountPoint
 	}
 	fs, err := fs.NewFS(mountPoint)
 	if err != nil {

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -269,32 +269,32 @@ type ServerRPCStats struct {
 	V4Ops          V4Ops
 }
 
-// NFS represents the pseudo-filesystem proc, which provides an interface to
+// Handle represents the pseudo-filesystem proc, which provides an interface to
 // kernel data structures.
-type NFS struct {
+type Handle struct {
 	procfs *procfs.FS
 }
 
 // DefaultMountPoint is the common mount point of the proc filesystem.
 const DefaultMountPoint = "/proc"
 
-// NewNFS returns a new FS mounted under the given mountPoint. It will error
+// New returns a new FS mounted under the given mountPoint. It will error
 // if the mount point can't be read.
-func NewNFS(mountPoint string) (NFS, error) {
+func New(mountPoint string) (Handle, error) {
 	if strings.TrimSpace(mountPoint) == "" {
 		mountPoint = DefaultMountPoint
 	}
 	fs, err := procfs.NewFS(mountPoint)
 	if err != nil {
-		return NFS{}, err
+		return Handle{}, err
 	}
-	return NFS{&fs}, nil
+	return Handle{&fs}, nil
 }
 
 // ClientRPCStats retrieves NFS client RPC statistics
 // from proc/net/rpc/nfs.
-func (nfs NFS) ClientRPCStats() (*ClientRPCStats, error) {
-	f, err := os.Open(nfs.procfs.Path("net/rpc/nfs"))
+func (h Handle) ClientRPCStats() (*ClientRPCStats, error) {
+	f, err := os.Open(h.procfs.Path("net/rpc/nfs"))
 	if err != nil {
 		return nil, err
 	}
@@ -305,8 +305,8 @@ func (nfs NFS) ClientRPCStats() (*ClientRPCStats, error) {
 
 // ServerRPCStats retrieves NFS daemon RPC statistics
 // from proc/net/rpc/nfsd.
-func (nfs NFS) ServerRPCStats() (*ServerRPCStats, error) {
-	f, err := os.Open(nfs.procfs.Path("net/rpc/nfsd"))
+func (h Handle) ServerRPCStats() (*ServerRPCStats, error) {
+	f, err := os.Open(h.procfs.Path("net/rpc/nfsd"))
 	if err != nil {
 		return nil, err
 	}

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/prometheus/procfs/internal/util"
+	"github.com/prometheus/procfs/internal/fs"
 )
 
 // ReplyCache models the "rc" line.
@@ -272,7 +272,7 @@ type ServerRPCStats struct {
 // FS represents the pseudo-filesystem proc, which provides an interface to
 // kernel data structures.
 type FS struct {
-	proc *util.FS
+	proc *fs.FS
 }
 
 // DefaultMountPoint is the common mount point of the proc filesystem.
@@ -284,7 +284,7 @@ func NewFS(mountPoint string) (FS, error) {
 	if strings.TrimSpace(mountPoint) == "" {
 		mountPoint = DefaultMountPoint
 	}
-	fs, err := util.NewFS(mountPoint)
+	fs, err := fs.NewFS(mountPoint)
 	if err != nil {
 		return FS{}, err
 	}

--- a/proc.go
+++ b/proc.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/prometheus/procfs/internal/util"
+	"github.com/prometheus/procfs/internal/fs"
 )
 
 // Proc provides information about a running process.
@@ -29,7 +29,7 @@ type Proc struct {
 	// The process ID.
 	PID int
 
-	fs util.FS
+	fs fs.FS
 }
 
 // Procs represents a list of Proc structs.

--- a/proc.go
+++ b/proc.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // Proc provides information about a running process.
@@ -27,7 +29,7 @@ type Proc struct {
 	// The process ID.
 	PID int
 
-	fs FS
+	fs util.FS
 }
 
 // Procs represents a list of Proc structs.
@@ -66,11 +68,11 @@ func AllProcs() (Procs, error) {
 
 // Self returns a process for the current process.
 func (fs FS) Self() (Proc, error) {
-	p, err := os.Readlink(fs.Path("self"))
+	p, err := os.Readlink(fs.proc.Path("self"))
 	if err != nil {
 		return Proc{}, err
 	}
-	pid, err := strconv.Atoi(strings.Replace(p, string(fs), "", -1))
+	pid, err := strconv.Atoi(strings.Replace(p, string(fs.proc), "", -1))
 	if err != nil {
 		return Proc{}, err
 	}
@@ -79,15 +81,15 @@ func (fs FS) Self() (Proc, error) {
 
 // NewProc returns a process for the given pid.
 func (fs FS) NewProc(pid int) (Proc, error) {
-	if _, err := os.Stat(fs.Path(strconv.Itoa(pid))); err != nil {
+	if _, err := os.Stat(fs.proc.Path(strconv.Itoa(pid))); err != nil {
 		return Proc{}, err
 	}
-	return Proc{PID: pid, fs: fs}, nil
+	return Proc{PID: pid, fs: fs.proc}, nil
 }
 
 // AllProcs returns a list of all currently available processes.
 func (fs FS) AllProcs() (Procs, error) {
-	d, err := os.Open(fs.Path())
+	d, err := os.Open(fs.proc.Path())
 	if err != nil {
 		return Procs{}, err
 	}
@@ -104,7 +106,7 @@ func (fs FS) AllProcs() (Procs, error) {
 		if err != nil {
 			continue
 		}
-		p = append(p, Proc{PID: int(pid), fs: fs})
+		p = append(p, Proc{PID: int(pid), fs: fs.proc})
 	}
 
 	return p, nil

--- a/proc_io_test.go
+++ b/proc_io_test.go
@@ -16,7 +16,7 @@ package procfs
 import "testing"
 
 func TestProcIO(t *testing.T) {
-	p, err := FS(procTestFixtures).NewProc(26231)
+	p, err := getProcFixtures(t).NewProc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/proc_limits_test.go
+++ b/proc_limits_test.go
@@ -16,7 +16,7 @@ package procfs
 import "testing"
 
 func TestNewLimits(t *testing.T) {
-	p, err := FS(procTestFixtures).NewProc(26231)
+	p, err := getProcFixtures(t).NewProc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/proc_ns_test.go
+++ b/proc_ns_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestNewNamespaces(t *testing.T) {
-	p, err := FS(procTestFixtures).NewProc(26231)
+	p, err := getProcFixtures(t).NewProc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/proc_psi.go
+++ b/proc_psi.go
@@ -64,7 +64,7 @@ func NewPSIStatsForResource(resource string) (PSIStats, error) {
 
 // NewPSIStatsForResource reads pressure stall information from /proc/pressure/<resource>
 func (fs FS) NewPSIStatsForResource(resource string) (PSIStats, error) {
-	file, err := os.Open(fs.Path(fmt.Sprintf("%s/%s", "pressure", resource)))
+	file, err := os.Open(fs.proc.Path(fmt.Sprintf("%s/%s", "pressure", resource)))
 	if err != nil {
 		return PSIStats{}, fmt.Errorf("psi_stats: unavailable for %s", resource)
 	}

--- a/proc_psi_test.go
+++ b/proc_psi_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestPSIStats(t *testing.T) {
 	t.Run("fake", func(*testing.T) {
-		stats, err := FS(procTestFixtures).NewPSIStatsForResource("fake")
+		stats, err := getProcFixtures(t).NewPSIStatsForResource("fake")
 		if err == nil {
 			t.Fatal("fake resource does not have PSI statistics")
 		}
@@ -31,7 +31,7 @@ func TestPSIStats(t *testing.T) {
 	})
 
 	t.Run("cpu", func(t *testing.T) {
-		stats, err := FS(procTestFixtures).NewPSIStatsForResource("cpu")
+		stats, err := getProcFixtures(t).NewPSIStatsForResource("cpu")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -68,7 +68,7 @@ func TestPSIStats(t *testing.T) {
 
 	for _, resource := range res {
 		t.Run(resource, func(t *testing.T) {
-			stats, err := FS(procTestFixtures).NewPSIStatsForResource(resource)
+			stats, err := getProcFixtures(t).NewPSIStatsForResource(resource)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/proc_stat.go
+++ b/proc_stat.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // Originally, this USER_HZ value was dynamically retrieved via a sysconf call
@@ -99,7 +101,7 @@ type ProcStat struct {
 	// Resident set size in pages.
 	RSS int
 
-	fs FS
+	proc util.FS
 }
 
 // NewStat returns the current status information of the process.
@@ -118,7 +120,7 @@ func (p Proc) NewStat() (ProcStat, error) {
 	var (
 		ignore int
 
-		s = ProcStat{PID: p.PID, fs: p.fs}
+		s = ProcStat{PID: p.PID, proc: p.fs}
 		l = bytes.Index(data, []byte("("))
 		r = bytes.LastIndex(data, []byte(")"))
 	)
@@ -175,7 +177,8 @@ func (s ProcStat) ResidentMemory() int {
 
 // StartTime returns the unix timestamp of the process in seconds.
 func (s ProcStat) StartTime() (float64, error) {
-	stat, err := s.fs.NewStat()
+	fs := FS{proc: s.proc}
+	stat, err := fs.NewStat()
 	if err != nil {
 		return 0, err
 	}

--- a/proc_stat.go
+++ b/proc_stat.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/prometheus/procfs/internal/util"
+	"github.com/prometheus/procfs/internal/fs"
 )
 
 // Originally, this USER_HZ value was dynamically retrieved via a sysconf call
@@ -101,7 +101,7 @@ type ProcStat struct {
 	// Resident set size in pages.
 	RSS int
 
-	proc util.FS
+	proc fs.FS
 }
 
 // NewStat returns the current status information of the process.

--- a/proc_stat_test.go
+++ b/proc_stat_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestProcStat(t *testing.T) {
-	p, err := FS(procTestFixtures).NewProc(26231)
+	p, err := getProcFixtures(t).NewProc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,11 @@ func TestProcStatCPUTime(t *testing.T) {
 }
 
 func testProcStat(pid int) (ProcStat, error) {
-	p, err := FS(procTestFixtures).NewProc(pid)
+	fs, err := NewFS(procTestFixtures)
+	if err != nil {
+		return ProcStat{}, err
+	}
+	p, err := fs.NewProc(pid)
 	if err != nil {
 		return ProcStat{}, err
 	}

--- a/proc_test.go
+++ b/proc_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestSelf(t *testing.T) {
-	fs := FS(procTestFixtures)
+	fs := getProcFixtures(t)
 
 	p1, err := fs.NewProc(26231)
 	if err != nil {
@@ -37,7 +37,7 @@ func TestSelf(t *testing.T) {
 }
 
 func TestAllProcs(t *testing.T) {
-	procs, err := FS(procTestFixtures).AllProcs()
+	procs, err := getProcFixtures(t).AllProcs()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestCmdLine(t *testing.T) {
 		{process: 26232, want: []string{}},
 		{process: 26233, want: []string{"com.github.uiautomator"}},
 	} {
-		p1, err := FS(procTestFixtures).NewProc(tt.process)
+		p1, err := getProcFixtures(t).NewProc(tt.process)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -80,7 +80,7 @@ func TestComm(t *testing.T) {
 		{process: 26231, want: "vim"},
 		{process: 26232, want: "ata_sff"},
 	} {
-		p1, err := FS(procTestFixtures).NewProc(tt.process)
+		p1, err := getProcFixtures(t).NewProc(tt.process)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -102,7 +102,7 @@ func TestExecutable(t *testing.T) {
 		{process: 26231, want: "/usr/bin/vim"},
 		{process: 26232, want: ""},
 	} {
-		p, err := FS(procTestFixtures).NewProc(tt.process)
+		p, err := getProcFixtures(t).NewProc(tt.process)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -126,7 +126,7 @@ func TestCwd(t *testing.T) {
 		{process: 26232, want: "/does/not/exist", brokenLink: true},
 		{process: 26233, want: ""},
 	} {
-		p, err := FS(procTestFixtures).NewProc(tt.process)
+		p, err := getProcFixtures(t).NewProc(tt.process)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -154,7 +154,7 @@ func TestRoot(t *testing.T) {
 		{process: 26232, want: "/does/not/exist", brokenLink: true},
 		{process: 26233, want: ""},
 	} {
-		p, err := FS(procTestFixtures).NewProc(tt.process)
+		p, err := getProcFixtures(t).NewProc(tt.process)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -173,7 +173,7 @@ func TestRoot(t *testing.T) {
 }
 
 func TestFileDescriptors(t *testing.T) {
-	p1, err := FS(procTestFixtures).NewProc(26231)
+	p1, err := getProcFixtures(t).NewProc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestFileDescriptors(t *testing.T) {
 }
 
 func TestFileDescriptorTargets(t *testing.T) {
-	p1, err := FS(procTestFixtures).NewProc(26231)
+	p1, err := getProcFixtures(t).NewProc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestFileDescriptorTargets(t *testing.T) {
 }
 
 func TestFileDescriptorsLen(t *testing.T) {
-	p1, err := FS(procTestFixtures).NewProc(26231)
+	p1, err := getProcFixtures(t).NewProc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stat.go
+++ b/stat.go
@@ -153,7 +153,7 @@ func parseSoftIRQStat(line string) (SoftIRQStat, uint64, error) {
 func (fs FS) NewStat() (Stat, error) {
 	// See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 
-	f, err := os.Open(fs.Path("stat"))
+	f, err := os.Open(fs.proc.Path("stat"))
 	if err != nil {
 		return Stat{}, err
 	}

--- a/stat_test.go
+++ b/stat_test.go
@@ -16,7 +16,7 @@ package procfs
 import "testing"
 
 func TestStat(t *testing.T) {
-	s, err := FS(procTestFixtures).NewStat()
+	s, err := getProcFixtures(t).NewStat()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sysfs/class_power_supply.go
+++ b/sysfs/class_power_supply.go
@@ -114,7 +114,7 @@ func NewPowerSupplyClass() (PowerSupplyClass, error) {
 
 // NewPowerSupplyClass returns info for all power supplies read from /sys/class/power_supply/.
 func (fs FS) NewPowerSupplyClass() (PowerSupplyClass, error) {
-	path := fs.Path("class/power_supply")
+	path := fs.sys.Path("class/power_supply")
 
 	powerSupplyDirs, err := ioutil.ReadDir(path)
 	if err != nil {

--- a/sysfs/class_thermal.go
+++ b/sysfs/class_thermal.go
@@ -37,7 +37,7 @@ type ClassThermalZoneStats struct {
 
 // NewClassThermalZoneStats returns Thermal Zone metrics for all zones.
 func (fs FS) NewClassThermalZoneStats() ([]ClassThermalZoneStats, error) {
-	zones, err := filepath.Glob(fs.Path("class/thermal/thermal_zone[0-9]*"))
+	zones, err := filepath.Glob(fs.sys.Path("class/thermal/thermal_zone[0-9]*"))
 	if err != nil {
 		return []ClassThermalZoneStats{}, err
 	}

--- a/sysfs/fs.go
+++ b/sysfs/fs.go
@@ -14,13 +14,13 @@
 package sysfs
 
 import (
-	"github.com/prometheus/procfs/internal/util"
+	"github.com/prometheus/procfs/internal/fs"
 )
 
 // FS represents the pseudo-filesystem sys, which provides an interface to
 // kernel data structures.
 type FS struct {
-	sys util.FS
+	sys fs.FS
 }
 
 // DefaultMountPoint is the common mount point of the sys filesystem.
@@ -29,7 +29,7 @@ const DefaultMountPoint = "/sys"
 // NewFS returns a new FS mounted under the given mountPoint. It will error
 // if the mount point can't be read.
 func NewFS(mountPoint string) (FS, error) {
-	fs, err := util.NewFS(mountPoint)
+	fs, err := fs.NewFS(mountPoint)
 	if err != nil {
 		return FS{}, err
 	}

--- a/sysfs/fs.go
+++ b/sysfs/fs.go
@@ -14,14 +14,14 @@
 package sysfs
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // FS represents the pseudo-filesystem sys, which provides an interface to
 // kernel data structures.
-type FS string
+type FS struct {
+	sys util.FS
+}
 
 // DefaultMountPoint is the common mount point of the sys filesystem.
 const DefaultMountPoint = "/sys"
@@ -29,18 +29,9 @@ const DefaultMountPoint = "/sys"
 // NewFS returns a new FS mounted under the given mountPoint. It will error
 // if the mount point can't be read.
 func NewFS(mountPoint string) (FS, error) {
-	info, err := os.Stat(mountPoint)
+	fs, err := util.NewFS(mountPoint)
 	if err != nil {
-		return "", fmt.Errorf("could not read %s: %s", mountPoint, err)
+		return FS{}, err
 	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("mount point %s is not a directory", mountPoint)
-	}
-
-	return FS(mountPoint), nil
-}
-
-// Path returns the path of the given subsystem relative to the sys root.
-func (fs FS) Path(p ...string) string {
-	return filepath.Join(append([]string{string(fs)}, p...)...)
+	return FS{fs}, nil
 }

--- a/sysfs/fs.go
+++ b/sysfs/fs.go
@@ -24,7 +24,7 @@ type FS struct {
 }
 
 // DefaultMountPoint is the common mount point of the sys filesystem.
-const DefaultMountPoint = "/sys"
+const DefaultMountPoint = fs.DefaultSysMountPoint
 
 // NewFS returns a new FS mounted under the given mountPoint. It will error
 // if the mount point can't be read.

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -78,7 +78,7 @@ func NewNetClass() (NetClass, error) {
 // NetClassDevices scans /sys/class/net for devices and returns them as a list of names.
 func (fs FS) NetClassDevices() ([]string, error) {
 	var res []string
-	path := fs.Path(netclassPath)
+	path := fs.sys.Path(netclassPath)
 
 	devices, err := ioutil.ReadDir(path)
 	if err != nil {
@@ -102,7 +102,7 @@ func (fs FS) NewNetClass() (NetClass, error) {
 		return nil, err
 	}
 
-	path := fs.Path(netclassPath)
+	path := fs.sys.Path(netclassPath)
 	netClass := NetClass{}
 	for _, deviceDir := range devices {
 		interfaceClass, err := netClass.parseNetClassIface(filepath.Join(path, deviceDir))

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -60,7 +60,7 @@ func NewSystemCpufreq() ([]SystemCPUCpufreqStats, error) {
 func (fs FS) NewSystemCpufreq() ([]SystemCPUCpufreqStats, error) {
 	var g errgroup.Group
 
-	cpus, err := filepath.Glob(fs.Path("devices/system/cpu/cpu[0-9]*"))
+	cpus, err := filepath.Glob(fs.sys.Path("devices/system/cpu/cpu[0-9]*"))
 	if err != nil {
 		return nil, err
 	}

--- a/xfrm.go
+++ b/xfrm.go
@@ -97,7 +97,7 @@ func NewXfrmStat() (XfrmStat, error) {
 
 // NewXfrmStat reads the xfrm_stat statistics from the 'proc' filesystem.
 func (fs FS) NewXfrmStat() (XfrmStat, error) {
-	file, err := os.Open(fs.Path("net/xfrm_stat"))
+	file, err := os.Open(fs.proc.Path("net/xfrm_stat"))
 	if err != nil {
 		return XfrmStat{}, err
 	}

--- a/xfrm_test.go
+++ b/xfrm_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestXfrmStats(t *testing.T) {
-	xfrmStats, err := FS(procTestFixtures).NewXfrmStat()
+	xfrmStats, err := getProcFixtures(t).NewXfrmStat()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/xfs/parse_test.go
+++ b/xfs/parse_test.go
@@ -424,7 +424,7 @@ func TestParseStats(t *testing.T) {
 			stats, err = xfs.ParseStats(strings.NewReader(tt.s))
 		}
 		if tt.fs {
-			xfs, err := xfs.NewXFS("../fixtures/proc", "../fixtures/sys")
+			xfs, err := xfs.New("../fixtures/proc", "../fixtures/sys")
 			if err != nil {
 				t.Fatalf("failed to access xfs fs: %v", err)
 			}

--- a/xfs/parse_test.go
+++ b/xfs/parse_test.go
@@ -424,7 +424,7 @@ func TestParseStats(t *testing.T) {
 			stats, err = xfs.ParseStats(strings.NewReader(tt.s))
 		}
 		if tt.fs {
-			xfs, err := xfs.New("../fixtures/proc", "../fixtures/sys")
+			xfs, err := xfs.NewFS("../fixtures/proc", "../fixtures/sys")
 			if err != nil {
 				t.Fatalf("failed to access xfs fs: %v", err)
 			}

--- a/xfs/parse_test.go
+++ b/xfs/parse_test.go
@@ -429,6 +429,9 @@ func TestParseStats(t *testing.T) {
 				t.Fatalf("failed to access xfs fs: %v", err)
 			}
 			stats, err = xfs.ProcStat()
+			if err != nil {
+				t.Fatalf("failed to gather xfs stats: %v", err)
+			}
 		}
 
 		if tt.invalid && err == nil {

--- a/xfs/parse_test.go
+++ b/xfs/parse_test.go
@@ -424,7 +424,11 @@ func TestParseStats(t *testing.T) {
 			stats, err = xfs.ParseStats(strings.NewReader(tt.s))
 		}
 		if tt.fs {
-			stats, err = xfs.ReadProcStat("../fixtures/proc")
+			xfs, err := xfs.NewXFS("../fixtures/proc", "../fixtures/sys")
+			if err != nil {
+				t.Fatalf("failed to access xfs fs: %v", err)
+			}
+			stats, err = xfs.ProcStat()
 		}
 
 		if tt.invalid && err == nil {

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/prometheus/procfs/internal/util"
+	"github.com/prometheus/procfs/internal/fs"
 )
 
 // Stats contains XFS filesystem runtime statistics, parsed from
@@ -173,8 +173,8 @@ type ExtendedPrecisionStats struct {
 // FS represents the pseudo-filesystems proc and sys, which provides an interface to
 // kernel data structures.
 type FS struct {
-	proc *util.FS
-	sys  *util.FS
+	proc *fs.FS
+	sys  *fs.FS
 }
 
 // DefaultProcMountPoint is the common mount point of the proc filesystem.
@@ -189,14 +189,14 @@ func NewFS(procMountPoint string, sysMountPoint string) (FS, error) {
 	if strings.TrimSpace(procMountPoint) == "" {
 		procMountPoint = DefaultProcMountPoint
 	}
-	procfs, err := util.NewFS(procMountPoint)
+	procfs, err := fs.NewFS(procMountPoint)
 	if err != nil {
 		return FS{}, err
 	}
 	if strings.TrimSpace(sysMountPoint) == "" {
 		sysMountPoint = DefaultSysMountPoint
 	}
-	sysfs, err := util.NewFS(sysMountPoint)
+	sysfs, err := fs.NewFS(sysMountPoint)
 	if err != nil {
 		return FS{}, err
 	}

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -171,9 +171,9 @@ type ExtendedPrecisionStats struct {
 	ReadBytes  uint64
 }
 
-// XFS represents the pseudo-filesystems proc and sys, which provides an interface to
+// Handle represents the pseudo-filesystems proc and sys, which provides an interface to
 // kernel data structures.
-type XFS struct {
+type Handle struct {
 	procfs *procfs.FS
 	sysfs  *sysfs.FS
 }
@@ -184,30 +184,30 @@ const DefaultProcMountPoint = "/proc"
 // DefaultSysMountPoint is the common mount point of the sys filesystem.
 const DefaultSysMountPoint = "/proc"
 
-// NewXFS returns a new XFS mounted under the given mountPoint. It will error
+// New returns a new XFS mounted under the given mountPoint. It will error
 // if the mount point can't be read.
-func NewXFS(procMountPoint string, sysMountPoint string) (XFS, error) {
+func New(procMountPoint string, sysMountPoint string) (Handle, error) {
 	if strings.TrimSpace(procMountPoint) == "" {
 		procMountPoint = DefaultProcMountPoint
 	}
 	procfs, err := procfs.NewFS(procMountPoint)
 	if err != nil {
-		return XFS{}, err
+		return Handle{}, err
 	}
 	if strings.TrimSpace(sysMountPoint) == "" {
 		sysMountPoint = DefaultSysMountPoint
 	}
 	sysfs, err := sysfs.NewFS(sysMountPoint)
 	if err != nil {
-		return XFS{}, err
+		return Handle{}, err
 	}
-	return XFS{&procfs, &sysfs}, nil
+	return Handle{&procfs, &sysfs}, nil
 }
 
 // ProcStat retrieves XFS filesystem runtime statistics
 // from proc/fs/xfs/stat given the profs mount point.
-func (xfs XFS) ProcStat() (*Stats, error) {
-	f, err := os.Open(xfs.procfs.Path("fs/xfs/stat"))
+func (h Handle) ProcStat() (*Stats, error) {
+	f, err := os.Open(h.procfs.Path("fs/xfs/stat"))
 	if err != nil {
 		return nil, err
 	}
@@ -219,8 +219,8 @@ func (xfs XFS) ProcStat() (*Stats, error) {
 // SysStats retrieves XFS filesystem runtime statistics for each mounted XFS
 // filesystem.  Only available on kernel 4.4+.  On older kernels, an empty
 // slice of *xfs.Stats will be returned.
-func (xfs XFS) SysStats() ([]*Stats, error) {
-	matches, err := filepath.Glob(xfs.sysfs.Path("fs/xfs/*/stats/stats"))
+func (h Handle) SysStats() ([]*Stats, error) {
+	matches, err := filepath.Glob(h.sysfs.Path("fs/xfs/*/stats/stats"))
 	if err != nil {
 		return nil, err
 	}

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -177,24 +177,18 @@ type FS struct {
 	sys  *fs.FS
 }
 
-// DefaultProcMountPoint is the common mount point of the proc filesystem.
-const DefaultProcMountPoint = "/proc"
-
-// DefaultSysMountPoint is the common mount point of the sys filesystem.
-const DefaultSysMountPoint = "/sys"
-
 // NewFS returns a new XFS handle using the given proc and sys mountPoints. It will error
 // if either of the mounts point can't be read.
 func NewFS(procMountPoint string, sysMountPoint string) (FS, error) {
 	if strings.TrimSpace(procMountPoint) == "" {
-		procMountPoint = DefaultProcMountPoint
+		procMountPoint = fs.DefaultProcMountPoint
 	}
 	procfs, err := fs.NewFS(procMountPoint)
 	if err != nil {
 		return FS{}, err
 	}
 	if strings.TrimSpace(sysMountPoint) == "" {
-		sysMountPoint = DefaultSysMountPoint
+		sysMountPoint = fs.DefaultSysMountPoint
 	}
 	sysfs, err := fs.NewFS(sysMountPoint)
 	if err != nil {

--- a/xfs/xfs_test.go
+++ b/xfs/xfs_test.go
@@ -21,7 +21,11 @@ import (
 )
 
 func TestReadProcStat(t *testing.T) {
-	stats, err := xfs.ReadProcStat("../fixtures/proc")
+	xfs, err := xfs.NewXFS("../fixtures/proc", "../fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access xfs fs: %v", err)
+	}
+	stats, err := xfs.ProcStat()
 	if err != nil {
 		t.Fatalf("failed to parse XFS stats: %v", err)
 	}
@@ -34,7 +38,11 @@ func TestReadProcStat(t *testing.T) {
 }
 
 func TestReadSysStats(t *testing.T) {
-	stats, err := xfs.ReadSysStats("../fixtures/sys")
+	xfs, err := xfs.NewXFS("../fixtures/proc", "../fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access xfs fs: %v", err)
+	}
+	stats, err := xfs.SysStats()
 	if err != nil {
 		t.Fatalf("failed to parse XFS stats: %v", err)
 	}

--- a/xfs/xfs_test.go
+++ b/xfs/xfs_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestReadProcStat(t *testing.T) {
-	xfs, err := xfs.NewXFS("../fixtures/proc", "../fixtures/sys")
+	xfs, err := xfs.New("../fixtures/proc", "../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access xfs fs: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestReadProcStat(t *testing.T) {
 }
 
 func TestReadSysStats(t *testing.T) {
-	xfs, err := xfs.NewXFS("../fixtures/proc", "../fixtures/sys")
+	xfs, err := xfs.New("../fixtures/proc", "../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access xfs fs: %v", err)
 	}

--- a/xfs/xfs_test.go
+++ b/xfs/xfs_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestReadProcStat(t *testing.T) {
-	xfs, err := xfs.New("../fixtures/proc", "../fixtures/sys")
+	xfs, err := xfs.NewFS("../fixtures/proc", "../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access xfs fs: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestReadProcStat(t *testing.T) {
 }
 
 func TestReadSysStats(t *testing.T) {
-	xfs, err := xfs.New("../fixtures/proc", "../fixtures/sys")
+	xfs, err := xfs.NewFS("../fixtures/proc", "../fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access xfs fs: %v", err)
 	}


### PR DESCRIPTION
Based on discussion in #148, instead of removing the FS type completely, this PR moves the FS type to a shared internal package and exposes a more consistent API for each of the subpackages.