### PR TITLE
sysfs: add parsing of clocksource

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -1107,6 +1107,22 @@ Mode: 644
 Directory: fixtures/sys/devices/system
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/devices/system/clocksource
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/devices/system/clocksource/clocksource0
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/clocksource/clocksource0/available_clocksource
+Lines: 1
+tsc hpet acpi_pm 
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/clocksource/clocksource0/current_clocksource
+Lines: 1
+tsc
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/devices/system/cpu
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/clocksource.go
+++ b/sysfs/clocksource.go
@@ -22,32 +22,23 @@ import (
 	"github.com/prometheus/procfs/internal/util"
 )
 
-// Clocksource contains metrics related to the clock source
-type Clocksource struct {
+// ClockSource contains metrics related to the clock source
+type ClockSource struct {
 	Name      string
 	Available []string
 	Current   string
 }
 
-// NewClocksource returns clocksource information including current and available clocksources.
-func NewClocksource() ([]Clocksource, error) {
-	fs, err := NewFS(DefaultMountPoint)
-	if err != nil {
-		return []Clocksource{}, err
-	}
-
-	return fs.NewClocksource()
-}
-
-// NewClocksource returns clocksource information including current and available clocksources.
-func (fs FS) NewClocksource() ([]Clocksource, error) {
+// ClockSources returns clocksource information including current and available clocksources
+// read from '/sys/devices/system/clocksource'
+func (fs FS) ClockSources() ([]ClockSource, error) {
 
 	clocksourcePaths, err := filepath.Glob(fs.sys.Path("devices/system/clocksource/clocksource[0-9]*"))
 	if err != nil {
 		return nil, err
 	}
 
-	clocksources := make([]Clocksource, len(clocksourcePaths))
+	clocksources := make([]ClockSource, len(clocksourcePaths))
 	for i, clocksourcePath := range clocksourcePaths {
 		clocksourceName := strings.TrimPrefix(filepath.Base(clocksourcePath), "clocksource")
 
@@ -62,7 +53,7 @@ func (fs FS) NewClocksource() ([]Clocksource, error) {
 	return clocksources, nil
 }
 
-func parseClocksource(clocksourcePath string) (*Clocksource, error) {
+func parseClocksource(clocksourcePath string) (*ClockSource, error) {
 
 	stringFiles := []string{
 		"available_clocksource",
@@ -74,11 +65,11 @@ func parseClocksource(clocksourcePath string) (*Clocksource, error) {
 	for i, f := range stringFiles {
 		stringOut[i], err = util.SysReadFile(filepath.Join(clocksourcePath, f))
 		if err != nil {
-			return &Clocksource{}, err
+			return &ClockSource{}, err
 		}
 	}
 
-	return &Clocksource{
+	return &ClockSource{
 		Available: strings.Fields(stringOut[0]),
 		Current:   stringOut[1],
 	}, nil

--- a/sysfs/clocksource.go
+++ b/sysfs/clocksource.go
@@ -1,0 +1,85 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sysfs
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// Clocksource contains metrics related to the clock source
+type Clocksource struct {
+	Name      string
+	Available []string
+	Current   string
+}
+
+// NewClocksource returns clocksource information including current and available clocksources.
+func NewClocksource() ([]Clocksource, error) {
+	fs, err := NewFS(DefaultMountPoint)
+	if err != nil {
+		return []Clocksource{}, err
+	}
+
+	return fs.NewClocksource()
+}
+
+// NewClocksource returns clocksource information including current and available clocksources.
+func (fs FS) NewClocksource() ([]Clocksource, error) {
+
+	clocksourcePaths, err := filepath.Glob(fs.sys.Path("devices/system/clocksource/clocksource[0-9]*"))
+	if err != nil {
+		return nil, err
+	}
+
+	clocksources := make([]Clocksource, len(clocksourcePaths))
+	for i, clocksourcePath := range clocksourcePaths {
+		clocksourceName := strings.TrimPrefix(filepath.Base(clocksourcePath), "clocksource")
+
+		clocksource, err := parseClocksource(clocksourcePath)
+		if err != nil {
+			return nil, err
+		}
+		clocksource.Name = clocksourceName
+		clocksources[i] = *clocksource
+	}
+
+	return clocksources, nil
+}
+
+func parseClocksource(clocksourcePath string) (*Clocksource, error) {
+
+	stringFiles := []string{
+		"available_clocksource",
+		"current_clocksource",
+	}
+	stringOut := make([]string, len(stringFiles))
+	var err error
+
+	for i, f := range stringFiles {
+		stringOut[i], err = util.SysReadFile(filepath.Join(clocksourcePath, f))
+		if err != nil {
+			return &Clocksource{}, err
+		}
+	}
+
+	return &Clocksource{
+		Available: strings.Fields(stringOut[0]),
+		Current:   stringOut[1],
+	}, nil
+}

--- a/sysfs/clocksource_test.go
+++ b/sysfs/clocksource_test.go
@@ -26,12 +26,12 @@ func TestNewClocksource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err := fs.NewClocksource()
+	c, err := fs.ClockSources()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	clocksources := []Clocksource{
+	clocksources := []ClockSource{
 		{
 			Name:      "0",
 			Available: []string{"tsc", "hpet", "acpi_pm"},

--- a/sysfs/clocksource_test.go
+++ b/sysfs/clocksource_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sysfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewClocksource(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := fs.NewClocksource()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clocksources := []Clocksource{
+		{
+			Name:      "0",
+			Available: []string{"tsc", "hpet", "acpi_pm"},
+			Current:   "tsc",
+		},
+	}
+
+	if !reflect.DeepEqual(clocksources, c) {
+		t.Errorf("Result not correct: want %v, have %v", clocksources, c)
+	}
+}


### PR DESCRIPTION
Read current and available clocksource data from
/sys/devices/system/clocksource

Related to https://github.com/prometheus/node_exporter/issues/1336