### PR TITLE
mountstats: parse nfs mount options

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -81,7 +81,7 @@ device sysfs mounted on /sys with fstype sysfs
 device proc mounted on /proc with fstype proc
 device /dev/sda1 mounted on / with fstype ext4
 device 192.168.1.1:/srv/test mounted on /mnt/nfs/test with fstype nfs4 statvers=1.1
-	opts:	rw,vers=4.0,rsize=1048576,wsize=1048576,namlen=255,acregmin=3,acregmax=60,acdirmin=30,acdirmax=60,hard,proto=tcp,port=0,timeo=600,retrans=2,sec=sys,clientaddr=192.168.1.5,local_lock=none
+	opts:	rw,vers=4.0,rsize=1048576,wsize=1048576,namlen=255,acregmin=3,acregmax=60,acdirmin=30,acdirmax=60,hard,proto=tcp,port=0,timeo=600,retrans=2,sec=sys,mountaddr=192.168.1.1,clientaddr=192.168.1.5,local_lock=none
 	age:	13968
 	caps:	caps=0xfff7,wtmult=512,dtsize=32768,bsize=0,namlen=255
 	nfsv4:	bm0=0xfdffafff,bm1=0xf9be3e,bm2=0x0,acl=0x0,pnfs=not configured

--- a/mountstats.go
+++ b/mountstats.go
@@ -69,8 +69,8 @@ type MountStats interface {
 type MountStatsNFS struct {
 	// The version of statistics provided.
 	StatVersion string
-	// The optional mountaddr of the NFS mount.
-	MountAddress string
+	// The mount options of the NFS mount.
+	Opts map[string]string
 	// The age of the NFS mount.
 	Age time.Duration
 	// Statistics related to byte counters for various operations.
@@ -342,10 +342,15 @@ func parseMountStatsNFS(s *bufio.Scanner, statVersion string) (*MountStatsNFS, e
 
 		switch ss[0] {
 		case fieldOpts:
+			if stats.Opts == nil {
+				stats.Opts = map[string]string{}
+			}
 			for _, opt := range strings.Split(ss[1], ",") {
 				split := strings.Split(opt, "=")
-				if len(split) == 2 && split[0] == "mountaddr" {
-					stats.MountAddress = split[1]
+				if len(split) == 2 {
+					stats.Opts[split[0]] = split[1]
+				} else {
+					stats.Opts[opt] = ""
 				}
 			}
 		case fieldAge:

--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -227,8 +227,8 @@ func TestMountStats(t *testing.T) {
 				Mount:  "/mnt/nfs",
 				Type:   "nfs",
 				Stats: &MountStatsNFS{
-					StatVersion:  "1.1",
-					MountAddress: "192.168.1.1",
+					StatVersion: "1.1",
+					Opts:        map[string]string{"rw": "", "vers": "3", "mountaddr": "192.168.1.1", "proto": "udp"},
 				},
 			}},
 		},
@@ -282,7 +282,14 @@ func TestMountStats(t *testing.T) {
 					Type:   "nfs4",
 					Stats: &MountStatsNFS{
 						StatVersion: "1.1",
-						Age:         13968 * time.Second,
+						Opts: map[string]string{"rw": "", "vers": "4.0",
+							"rsize": "1048576", "wsize": "1048576", "namlen": "255", "acregmin": "3",
+							"acregmax": "60", "acdirmin": "30", "acdirmax": "60", "hard": "",
+							"proto": "tcp", "port": "0", "timeo": "600", "retrans": "2",
+							"sec": "sys", "mountaddr": "192.168.1.1", "clientaddr": "192.168.1.5",
+							"local_lock": "none",
+						},
+						Age: 13968 * time.Second,
 						Bytes: NFSBytesStats{
 							Read:      1207640230,
 							ReadTotal: 1210214218,
@@ -376,7 +383,7 @@ func mountsStr(mounts []*Mount) string {
 			continue
 		}
 
-		out += fmt.Sprintf("\n\t- mountaddr: %s", stats.MountAddress)
+		out += fmt.Sprintf("\n\t- opts: %s", stats.Opts)
 		out += fmt.Sprintf("\n\t- v%s, age: %s", stats.StatVersion, stats.Age)
 		out += fmt.Sprintf("\n\t- bytes: %v", stats.Bytes)
 		out += fmt.Sprintf("\n\t- events: %v", stats.Events)


### PR DESCRIPTION
Adds a map called 'Opts' to the stats which contains
the key value pairs from the 'opts' line
in /proc/<pid>/mountstats.

Fixes #102

This also changes functionality introduced in PR #130.  Instead of using a specific struct field, `MountAddress`, the mountaddr option is available via `Opts["mountaddr"]`.