### PR TITLE
Fix update_fixtures target in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The procfs library is organized by packages based on whether the gathered data i
 point is initialized, and then the stat information is read.
 
 ```go
-	fs, err := procfs.NewFS("/proc")
-    stats, err := fs.NewStat()
+fs, err := procfs.NewFS("/proc")
+stats, err := fs.NewStat()
 ```
 
 ## Building and Testing
@@ -36,8 +36,8 @@ ensure the `fixtures` directory is up to date by removing the existing directory
 extracting the ttar file using `make fixtures/.unpacked` or just `make test`.
 
 ```bash
-    rm -rf fixtures
-    make test
+rm -rf fixtures
+make test
 ```
 
 Next, make the required changes to the extracted files in the `fixtures` directory.  When

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ extracting the ttar file using `make fixtures/.unpacked` or just `make test`.
 ```
 
 Next, make the required changes to the extracted files in the `fixtures` directory.  When 
-the changes are complete, run `make update-fixtures` to create a new `fixtures.ttar` file
+the changes are complete, run `make update_fixtures` to create a new `fixtures.ttar` file
 based on the updated `fixtures` directory.  And finally, verify the changes using 
 `git diff fixtures.ttar`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ backwards-incompatible ways without warnings. Use it at your own risk.
 
 The procfs library is organized by packages based on whether the gathered data is coming from
 /proc, /sys, or both.  Each package contains an `FS` type which represents the path to either /proc, /sys, or both.  For example, current cpu statistics are gathered from
-`/proc/stat` and are available via the root procfs package.  First, the proc filesystem mount 
+`/proc/stat` and are available via the root procfs package.  First, the proc filesystem mount
 point is initialized, and then the stat information is read.
 
 ```go
@@ -40,7 +40,7 @@ extracting the ttar file using `make fixtures/.unpacked` or just `make test`.
     make test
 ```
 
-Next, make the required changes to the extracted files in the `fixtures` directory.  When 
+Next, make the required changes to the extracted files in the `fixtures` directory.  When
 the changes are complete, run `make update_fixtures` to create a new `fixtures.ttar` file
-based on the updated `fixtures` directory.  And finally, verify the changes using 
+based on the updated `fixtures` directory.  And finally, verify the changes using
 `git diff fixtures.ttar`.


### PR DESCRIPTION
The target to update the fixtures is called `update_fixtures` (with underscore) instead of `update-fixtures`. Also remove trailing spaces and indentation in example code.