### PR TITLE
re-add functions required by client_golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ point is initialized, and then the stat information is read.
 
 ```go
 fs, err := procfs.NewFS("/proc")
-stats, err := fs.NewStat()
+stats, err := fs.Stat()
 ```
 
 Some sub-packages such as `blockdevice`, require access to both the proc and sys filesystems.

--- a/proc_limits.go
+++ b/proc_limits.go
@@ -77,6 +77,13 @@ var (
 	limitsDelimiter = regexp.MustCompile("  +")
 )
 
+// NewLimits returns the current soft limits of the process.
+//
+// Deprecated: use p.Limits() instead
+func (p Proc) NewLimits() (ProcLimits, error) {
+	return p.Limits()
+}
+
 // Limits returns the current soft limits of the process.
 func (p Proc) Limits() (ProcLimits, error) {
 	f, err := os.Open(p.path("limits"))

--- a/proc_stat.go
+++ b/proc_stat.go
@@ -104,6 +104,13 @@ type ProcStat struct {
 	proc fs.FS
 }
 
+// NewStat returns the current status information of the process.
+//
+// Deprecated: use NewStat() instead
+func (p Proc) NewStat() (ProcStat, error) {
+	return p.Stat()
+}
+
 // Stat returns the current status information of the process.
 func (p Proc) Stat() (ProcStat, error) {
 	f, err := os.Open(p.path("stat"))

--- a/stat.go
+++ b/stat.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs/internal/fs"
 )
 
 // CPUStat shows how much time the cpu spend in various stages.
@@ -139,9 +141,21 @@ func parseSoftIRQStat(line string) (SoftIRQStat, uint64, error) {
 	return softIRQStat, total, nil
 }
 
-// Stat returns an information about current kernel/system statistics.
+// NewStat returns information about current cpu/process statistics.
+// See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+//
+// Deprecated: use fs.Stat() instead
+func NewStat() (Stat, error) {
+	fs, err := NewFS(fs.DefaultProcMountPoint)
+	if err != nil {
+		return Stat{}, err
+	}
+	return fs.Stat()
+}
+
+// Stat returns information about current cpu/process statistics.
+// See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func (fs FS) Stat() (Stat, error) {
-	// See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 
 	f, err := os.Open(fs.proc.Path("stat"))
 	if err != nil {


### PR DESCRIPTION
Adding back some functions that were removed during refactoring.
These are needed by client_golang for backwards compatibility.
They are now marked deprecated and can be removed once there
are no more dependencies on them.

Related to PR #162 