### PR TITLE
Re-add deprecated methods used by elastic/go-sysinfo

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -79,6 +79,13 @@ func (fs FS) Self() (Proc, error) {
 	return fs.Proc(pid)
 }
 
+// NewProc returns a process for the given pid.
+//
+// Deprecated: use fs.Proc() instead
+func (fs FS) NewProc(pid int) (Proc, error) {
+	return fs.Proc(pid)
+}
+
 // Proc returns a process for the given pid.
 func (fs FS) Proc(pid int) (Proc, error) {
 	if _, err := os.Stat(fs.proc.Path(strconv.Itoa(pid))); err != nil {

--- a/stat.go
+++ b/stat.go
@@ -153,6 +153,14 @@ func NewStat() (Stat, error) {
 	return fs.Stat()
 }
 
+// NewStat returns information about current cpu/process statistics.
+// See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+//
+// Deprecated: use fs.Stat() instead
+func (fs FS) NewStat() (Stat, error) {
+	return fs.Stat()
+}
+
 // Stat returns information about current cpu/process statistics.
 // See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func (fs FS) Stat() (Stat, error) {


### PR DESCRIPTION
Fixes #169 