### PR TITLE
Supported for /proc/<pid>/environ

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -21,6 +21,11 @@ Mode: 644
 Path: fixtures/proc/26231/cwd
 SymlinkTo: /usr/bin
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/26231/environ
+Lines: 1
+PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/binNULLBYTEHOSTNAME=cd24e11f73a5NULLBYTETERM=xtermNULLBYTEGOLANG_VERSION=1.12.5NULLBYTEGOPATH=/goNULLBYTEHOME=/rootNULLBYTEEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/26231/exe
 SymlinkTo: /usr/bin/vim
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/proc_environ.go
+++ b/proc_environ.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// IO creates a new ProcIO instance from a given Proc instance.
+func (p Proc) Environ() ([]string, error) {
+	environments := make([]string, 0)
+
+	f, err := os.Open(p.path("environ"))
+	if err != nil {
+		return environments, err
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return environments, err
+	}
+
+	environments = strings.Split(string(data), "\000")
+	if len(environments) > 0 {
+		environments = environments[:len(environments) - 1]
+	}
+
+	return environments, nil
+}

--- a/proc_environ.go
+++ b/proc_environ.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-// IO creates a new ProcIO instance from a given Proc instance.
+// Environ reads process environments from /proc/<pid>/environ
 func (p Proc) Environ() ([]string, error) {
 	environments := make([]string, 0)
 
@@ -36,7 +36,7 @@ func (p Proc) Environ() ([]string, error) {
 
 	environments = strings.Split(string(data), "\000")
 	if len(environments) > 0 {
-		environments = environments[:len(environments) - 1]
+		environments = environments[:len(environments)-1]
 	}
 
 	return environments, nil

--- a/proc_environ_test.go
+++ b/proc_environ_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2019 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/proc_environ_test.go
+++ b/proc_environ_test.go
@@ -1,0 +1,47 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import "testing"
+
+func TestProcEnviron(t *testing.T) {
+	p, err := getProcFixtures(t).Proc(26231)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	environments, err := p.Environ()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedEnvironments := []string{
+		"PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"HOSTNAME=cd24e11f73a5",
+		"TERM=xterm",
+		"GOLANG_VERSION=1.12.5",
+		"GOPATH=/go",
+		"HOME=/root",
+	}
+
+	if want, have := len(expectedEnvironments), len(environments); want != have {
+		t.Errorf("want %d parsed environments, have %d", want, have)
+	}
+
+	for i, environment := range environments {
+		if want, have := expectedEnvironments[i], environment; want != have {
+			t.Errorf("%d: want %v, have %v", i, want, have)
+		}
+	}
+}


### PR DESCRIPTION
Supported for `/proc/<pid>/environ`

```sh
# cat -e /proc/1/environ
PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin^@HOSTNAME=33cfa6747903^@TERM=xterm^@GOLANG_VERSION=1.12.5^@GOPATH=/go^@HOME=/root^@
```

- Split `\000` .
- Remove last empty array element.
- About the format of the return value is the slice `[]string` : It uses the same interface as [os.Environ](https://golang.org/pkg/os/#Environ).