### PR TITLE
Add sysfs handle and remove path from Get backstore function 

### DIFF
--- a/iscsi/get.go
+++ b/iscsi/get.go
@@ -137,14 +137,13 @@ func ReadWriteOPS(iqnPath string, tpgt string, lun string) (readmb uint64,
 
 // GetFileioUdev is getting the actual info to build up
 // the FILEIO data and match with the enable target
-func (fileio FILEIO) GetFileioUdev(targetCorePath string, fileioNumber string,
-	objectName string) (fio *FILEIO, err error) {
-
-	fileio.Name = "fileio_" + fileioNumber
-	fileio.Fnumber = fileioNumber
-	fileio.ObjectName = objectName
-
-	udevPath := filepath.Join(targetCorePath, fileio.Name, fileio.ObjectName, "udev_path")
+func (fs FS) GetFileioUdev(fileioNumber string, objectName string) (*FILEIO, error) {
+	fileio := FILEIO{
+		Name:       "fileio_" + fileioNumber,
+		Fnumber:    fileioNumber,
+		ObjectName: objectName,
+	}
+	udevPath := fs.configfs.Path(targetCore, fileio.Name, fileio.ObjectName, "udev_path")
 
 	if _, err := os.Stat(udevPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("iscsi: GetFileioUdev: fileio_%s is missing file name", fileio.Fnumber)
@@ -160,14 +159,13 @@ func (fileio FILEIO) GetFileioUdev(targetCorePath string, fileioNumber string,
 
 // GetIblockUdev is getting the actual info to build up
 // the IBLOCK data and match with the enable target
-func (iblock IBLOCK) GetIblockUdev(targetCorePath string, iblockNumber string,
-	objectName string) (ib *IBLOCK, err error) {
-
-	iblock.Name = "iblock_" + iblockNumber
-	iblock.Bnumber = iblockNumber
-	iblock.ObjectName = objectName
-
-	udevPath := filepath.Join(targetCorePath, iblock.Name, iblock.ObjectName, "udev_path")
+func (fs FS) GetIblockUdev(iblockNumber string, objectName string) (*IBLOCK, error) {
+	iblock := IBLOCK{
+		Name:       "iblock_" + iblockNumber,
+		Bnumber:    iblockNumber,
+		ObjectName: objectName,
+	}
+	udevPath := fs.configfs.Path(targetCore, iblock.Name, iblock.ObjectName, "udev_path")
 
 	if _, err := os.Stat(udevPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("iscsi: GetIBlockUdev: iblock_%s is missing file name", iblock.Bnumber)
@@ -183,12 +181,12 @@ func (iblock IBLOCK) GetIblockUdev(targetCorePath string, iblockNumber string,
 
 // GetRBDMatch is getting the actual info to build up
 // the RBD data and match with the enable target
-func (rbd RBD) GetRBDMatch(sysDevicePath string, rbdNumber string, poolImage string) (r *RBD, err error) {
-
-	rbd.Name = "rbd_" + rbdNumber
-	rbd.Rnumber = rbdNumber
-
-	systemRbds, err := filepath.Glob(filepath.Join(sysDevicePath, "/devices/rbd/[0-9]*"))
+func (fs FS) GetRBDMatch(rbdNumber string, poolImage string) (*RBD, error) {
+	rbd := RBD{
+		Name:    "rbd_" + rbdNumber,
+		Rnumber: rbdNumber,
+	}
+	systemRbds, err := filepath.Glob(fs.sysfs.Path(devicePath, "[0-9]*"))
 	if err != nil {
 		return nil, fmt.Errorf("iscsi: GetRBDMatch: Cannot find any rbd block")
 	}
@@ -228,11 +226,12 @@ func (rbd RBD) GetRBDMatch(sysDevicePath string, rbdNumber string, poolImage str
 }
 
 // GetRDMCPPath is getting the actual info to build up RDMCP data
-func (rdmcp RDMCP) GetRDMCPPath(targetCorePath string, rdmcpNumber string, objectName string) (r *RDMCP, err error) {
-	rdmcp.Name = "rd_mcp_" + rdmcpNumber
-	rdmcp.ObjectName = objectName
-
-	rdmcpPath := filepath.Join(targetCorePath, rdmcp.Name, rdmcp.ObjectName)
+func (fs FS) GetRDMCPPath(rdmcpNumber string, objectName string) (*RDMCP, error) {
+	rdmcp := RDMCP{
+		Name:       "rd_mcp_" + rdmcpNumber,
+		ObjectName: objectName,
+	}
+	rdmcpPath := fs.configfs.Path(targetCore, rdmcp.Name, rdmcp.ObjectName)
 
 	if _, err := os.Stat(rdmcpPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("iscsi: GetRDMCPPath: %s does not exist", rdmcpPath)

--- a/iscsi/get_test.go
+++ b/iscsi/get_test.go
@@ -14,7 +14,6 @@
 package iscsi_test
 
 import (
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -127,11 +126,11 @@ func TestGetStats(t *testing.T) {
 		{1504, 4733, 1234},
 	}
 
-	sysfs, err := iscsi.NewFS("../fixtures/sys/kernel/config")
+	sysconfigfs, err := iscsi.NewFS("../fixtures/sys", "../fixtures/sys/kernel/config")
 	if err != nil {
 		t.Fatalf("failed to access xfs fs: %v", err)
 	}
-	sysfsStat, err := sysfs.ISCSIStats()
+	sysfsStat, err := sysconfigfs.ISCSIStats()
 	statSize := len(sysfsStat)
 	if statSize != 4 {
 		t.Errorf("fixtures size does not match %d", statSize)
@@ -162,8 +161,7 @@ func TestGetStats(t *testing.T) {
 				t.Errorf("unexpected iSCSI iops data :\nwant:\n%v\nhave:\n%v", readTests[i].iops, iops)
 			}
 			if stat.Tpgt[0].Luns[0].Backstore == "rd_mcp" {
-				have_rdmcp := new(iscsi.RDMCP)
-				have_rdmcp, err := have_rdmcp.GetRDMCPPath(filepath.Join("../fixtures/sys/kernel/config", iscsi.TargetCore), "119", "ramdisk_lio_1G")
+				have_rdmcp, err := sysconfigfs.GetRDMCPPath("119", "ramdisk_lio_1G")
 				if err != nil {
 					t.Errorf("fail rdmcp error %v", err)
 				}
@@ -174,8 +172,7 @@ func TestGetStats(t *testing.T) {
 					t.Errorf("unexpected rdmcp data :\nwant:\n%v\nhave:\n%v", want_rdmcp, have_rdmcp)
 				}
 			} else if stat.Tpgt[0].Luns[0].Backstore == "iblock" {
-				have_iblock := new(iscsi.IBLOCK)
-				have_iblock, err = have_iblock.GetIblockUdev(filepath.Join("../fixtures/sys/kernel/config", iscsi.TargetCore), "0", "block_lio_rbd1")
+				have_iblock, err := sysconfigfs.GetIblockUdev("0", "block_lio_rbd1")
 				if err != nil {
 					t.Errorf("fail iblock error %v", err)
 				}
@@ -185,8 +182,7 @@ func TestGetStats(t *testing.T) {
 					t.Errorf("unexpected iblock data :\nwant:\n%v\nhave:\n%v", want_iblock, have_iblock)
 				}
 			} else if stat.Tpgt[0].Luns[0].Backstore == "fileio" {
-				have_fileio := new(iscsi.FILEIO)
-				have_fileio, err = have_fileio.GetFileioUdev(filepath.Join("../fixtures/sys/kernel/config", iscsi.TargetCore), "1", "file_lio_1G")
+				have_fileio, err := sysconfigfs.GetFileioUdev("1", "file_lio_1G")
 				if err != nil {
 					t.Errorf("fail fileio error %v", err)
 				}
@@ -196,8 +192,7 @@ func TestGetStats(t *testing.T) {
 					t.Errorf("unexpected fileio data :\nwant:\n%v\nhave:\n%v", want_fileio, have_fileio)
 				}
 			} else if stat.Tpgt[0].Luns[0].Backstore == "rbd" {
-				have_rbd := new(iscsi.RBD)
-				have_rbd, err = have_rbd.GetRBDMatch("../fixtures/sys", "0", "iscsi-images-demo")
+				have_rbd, err := sysconfigfs.GetRBDMatch("0", "iscsi-images-demo")
 				if err != nil {
 					t.Errorf("fail rbd error %v", err)
 				}


### PR DESCRIPTION
I do need to export configfs path in lio collector module, so instead of exporting the configfs all together I export the Path functions to help building configfs path. 

Signed-off-by: Alex Lau (AvengerMoJo) <alau@suse.com>