### PR TITLE
Adds /sys/class/thermal/cooling_device* support

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -1435,6 +1435,42 @@ Mode: 444
 Directory: fixtures/sys/class/thermal
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/thermal/cooling_device0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/thermal/cooling_device0/cur_state
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/thermal/cooling_device0/max_state
+Lines: 1
+50
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/thermal/cooling_device0/type
+Lines: 1
+Processor
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/thermal/cooling_device1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/thermal/cooling_device1/cur_state
+Lines: 1
+-1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/thermal/cooling_device1/max_state
+Lines: 1
+27
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/thermal/cooling_device1/type
+Lines: 1
+intel_powerclamp
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/thermal/thermal_zone0
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/class_cooling_device.go
+++ b/sysfs/class_cooling_device.go
@@ -1,0 +1,91 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sysfs
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// ClassCoolingDeviceStats contains info from files in /sys/class/thermal/cooling_device[0-9]*
+// for a single device.
+// https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt
+type ClassCoolingDeviceStats struct {
+	Name     string // The name of the cooling device.
+	Type     string // Type of the cooling device(processor/fan/...)
+	MaxState int64  // Maximum cooling state of the cooling device
+	CurState int64  // Current cooling state of the cooling device
+}
+
+func (fs FS) ClassCoolingDeviceStats() ([]ClassCoolingDeviceStats, error) {
+	cds, err := filepath.Glob(fs.sys.Path("class/thermal/cooling_device[0-9]*"))
+	if err != nil {
+		return []ClassCoolingDeviceStats{}, err
+	}
+
+	var coolingDeviceStats = ClassCoolingDeviceStats{}
+	stats := make([]ClassCoolingDeviceStats, len(cds))
+	for i, cd := range cds {
+		cdName := strings.TrimPrefix(filepath.Base(cd), "cooling_device")
+
+		coolingDeviceStats, err = parseCoolingDeviceStats(cd)
+		if err != nil {
+			return []ClassCoolingDeviceStats{}, err
+		}
+
+		coolingDeviceStats.Name = cdName
+		stats[i] = coolingDeviceStats
+	}
+	return stats, nil
+}
+
+func parseCoolingDeviceStats(cd string) (ClassCoolingDeviceStats, error) {
+	// get cd type
+	cdType, err := util.SysReadFile(filepath.Join(cd, "type"))
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+
+	cdMaxStateString, err := util.SysReadFile(filepath.Join(cd, "max_state"))
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+	cdMaxStateInt, err := strconv.ParseInt(cdMaxStateString, 10, 64)
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+
+	// cur_state can be -1, eg intel powerclamp
+	// https://www.kernel.org/doc/Documentation/thermal/intel_powerclamp.txt
+	cdCurStateString, err := util.SysReadFile(filepath.Join(cd, "cur_state"))
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+
+	cdCurStateInt, err := strconv.ParseInt(cdCurStateString, 10, 64)
+	if err != nil {
+		return ClassCoolingDeviceStats{}, err
+	}
+
+	return ClassCoolingDeviceStats{
+		Type:     cdType,
+		MaxState: cdMaxStateInt,
+		CurState: cdCurStateInt,
+	}, nil
+}

--- a/sysfs/class_cooling_device.go
+++ b/sysfs/class_cooling_device.go
@@ -56,7 +56,6 @@ func (fs FS) ClassCoolingDeviceStats() ([]ClassCoolingDeviceStats, error) {
 }
 
 func parseCoolingDeviceStats(cd string) (ClassCoolingDeviceStats, error) {
-	// get cd type
 	cdType, err := util.SysReadFile(filepath.Join(cd, "type"))
 	if err != nil {
 		return ClassCoolingDeviceStats{}, err

--- a/sysfs/class_cooling_device_test.go
+++ b/sysfs/class_cooling_device_test.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sysfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestClassCoolingDeviceStats(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	coolingDeviceTest, err := fs.ClassCoolingDeviceStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	classCoolingDeviceStats := []ClassCoolingDeviceStats{
+		{
+			Name:     "0",
+			Type:     "Processor",
+			MaxState: 50,
+			CurState: 0,
+		},
+		{
+			Name:     "1",
+			Type:     "intel_powerclamp",
+			MaxState: 27,
+			CurState: -1,
+		},
+	}
+
+	if !reflect.DeepEqual(classCoolingDeviceStats, coolingDeviceTest) {
+		t.Errorf("Result not correct: want %v, have %v", classCoolingDeviceStats, coolingDeviceTest)
+	}
+}


### PR DESCRIPTION
Adds support for `/sys/class/thermal/cooling_device[0-9]+` devices, returning name, type, cur_state and max_state. 

The latter 2 are int64, which differs from most values in this library which appear to be uint64 - this is due to the type `intel_powerclamp` returning a -1 as it's `cur_value` when idle injection is disabled.