### PR TITLE
Add parsing of `Tgid:` from `/proc/<pid>/status`

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -179,7 +179,7 @@ Lines: 1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/26231/status
-Lines: 53
+Lines: 54
 
 Name:	prometheus
 Umask:	0022

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -179,7 +179,7 @@ Lines: 1
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/26231/status
-Lines: 54
+Lines: 53
 
 Name:	prometheus
 Umask:	0022

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -184,10 +184,10 @@ Lines: 53
 Name:	prometheus
 Umask:	0022
 State:	S (sleeping)
-Tgid:	1
+Tgid:	26231
 Ngid:	0
-Pid:	1
-PPid:	0
+Pid:	26231
+PPid:	1
 TracerPid:	0
 Uid:	0	0	0	0
 Gid:	0	0	0	0

--- a/proc_status.go
+++ b/proc_status.go
@@ -29,6 +29,9 @@ type ProcStatus struct {
 	// The process name.
 	Name string
 
+	// Thread group ID.
+	TGID int
+
 	// Peak virtual memory size.
 	VmPeak uint64
 	// Virtual memory size.
@@ -113,6 +116,8 @@ func (p Proc) NewStatus() (ProcStatus, error) {
 
 func (s *ProcStatus) fillStatus(k string, vString string, vUint uint64, vUintBytes uint64) {
 	switch k {
+	case "Tgid":
+		s.TGID = int(vUint)
 	case "Name":
 		s.Name = vString
 	case "VmPeak":

--- a/proc_status_test.go
+++ b/proc_status_test.go
@@ -34,6 +34,7 @@ func TestProcStatus(t *testing.T) {
 		have int
 	}{
 		{name: "Pid", want: 26231, have: s.PID},
+		{name: "Tgid", want: 26231, have: s.TGID},
 		{name: "VmPeak", want: 58472 * 1024, have: int(s.VmPeak)},
 		{name: "VmSize", want: 58440 * 1024, have: int(s.VmSize)},
 		{name: "VmLck", want: 0 * 1024, have: int(s.VmLck)},

--- a/proc_status_test.go
+++ b/proc_status_test.go
@@ -33,7 +33,7 @@ func TestProcStatus(t *testing.T) {
 		want int
 		have int
 	}{
-		{name: "pid", want: 26231, have: s.PID},
+		{name: "Pid", want: 26231, have: s.PID},
 		{name: "VmPeak", want: 58472 * 1024, have: int(s.VmPeak)},
 		{name: "VmSize", want: 58440 * 1024, have: int(s.VmSize)},
 		{name: "VmLck", want: 0 * 1024, have: int(s.VmLck)},


### PR DESCRIPTION
Hi @discordianfish @pgier ! Thank you for GREAT library !

I added parsing of `Tgid:` from `/proc/<pid>/status`

This pull request contains 2 fixes.

- Fix fixtures.ttar ( /proc/26231/status `Pid:` should be 26231 )
- Add parsing of `Tgid:` from `/proc/<pid>/status`

## Use case

- I want to detect if thread reader process ( using `p.PID == p.TGID` )

Thank you !
