### PR TITLE
additional error handling when reading files in /sys/class

### DIFF
--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -251,6 +251,9 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
 			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
 		}
 
@@ -331,6 +334,9 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
 			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
 		}
 

--- a/sysfs/class_power_supply.go
+++ b/sysfs/class_power_supply.go
@@ -18,6 +18,7 @@ package sysfs
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/prometheus/procfs/internal/util"
@@ -141,6 +142,9 @@ func parsePowerSupply(path string) (*PowerSupply, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
 			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
 		}
 

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -18,6 +18,7 @@ package sysfs
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/prometheus/procfs/internal/util"
@@ -118,6 +119,9 @@ func (nc NetClass) parseNetClassIface(devicePath string) (*NetClassIface, error)
 		name := filepath.Join(devicePath, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+				continue
+			}
 			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
 		}
 		vp := util.NewValueParser(value)


### PR DESCRIPTION
Some regular files in /sys/class are not readable on certain
systems, so just ignore them.

Related to #213 which checks that directory entries are regular files and not symlinks.  However, there is the additional problem that some files in /sys/class/ (e.g. `/sys/class/net/enp0s31f6/phys_port_id`) are not readable even though they are regular files.  Before the recent refactoring, these read errors were ignored.  This change makes these errors ignored again.
