### PR TITLE
introduce new function ReadFileNoStat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,23 +86,25 @@ should contain the path to the file(s) being read and a URL of the linux kernel 
 Most functionality in this library consists of reading files and then parsing the text into structured data.  In most
 cases reading and parsing should be separated into different functions/methods with a public `fs.Thing()` method and 
 a private `parseThing(r Reader)` function.  This provides a logical separation and allows parsing to be tested
-directly without the need to read from the filesystem.  Using a `Reader` argument is preferred for parsing the contents 
-of a single file.  When a set of files in a directory needs to be parsed, then a `path` string parameter to the parse
-function can be used.
+directly without the need to read from the filesystem.  Using a `Reader` argument is preferred over other data types
+such as `string` or `*File` because it provides the most flexibility regarding the data source.  When a set of files 
+in a directory needs to be parsed, then a `path` string parameter to the parse function can be used instead.
 
 ### /proc and /sys filesystem I/O 
 
-The `proc` and `sys` filesystems are pseudo file systems and work a bit differently from standard disk I/O.  Many of the files
-are changing continuously and the data being read can in some cases change between subsequent reads in the same file.
-Also, most of the files are relatively small (less than a few KBs). Therefore, for most files it's recommended to read the full
-file in a single operation using something like `ioutil.ReadFile`.  Reading files one line at a time while
-the file is kept open should be avoided.
+The `proc` and `sys` filesystems are pseudo file systems and work a bit differently from standard disk I/O.  
+Many of the files are changing continuously and the data being read can in some cases change between subsequent 
+reads in the same file.  Also, most of the files are relatively small (less than a few KBs), and system calls
+to the `stat` function will often return the wrong size.  Therefore, for most files it's recommended to read the 
+full file in a single operation using an internal utility function called `util.ReadFileNoStat`.
+This function is similar to `ioutil.ReadFile`, but it avoids the system call to `stat` to get the current size of
+the file.
 
 Note that parsing the file's contents can still be performed one line at a time.  This is done by first reading 
 the full file, and then using a scanner on the `[]byte` or `string` containing the data.
 
 ```
-    data, err := ioutil.ReadFile("/proc/cpuinfo")
+    data, err := util.ReadFileNoStat("/proc/cpuinfo")
     if err != nil {
         return err
     }

--- a/cpuinfo.go
+++ b/cpuinfo.go
@@ -16,9 +16,10 @@ package procfs
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // CPUInfo contains general information about a system CPU found in /proc/cpuinfo
@@ -54,7 +55,7 @@ type CPUInfo struct {
 // CPUInfo returns information about current system CPUs.
 // See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func (fs FS) CPUInfo() ([]CPUInfo, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("cpuinfo"))
+	data, err := util.ReadFileNoStat(fs.proc.Path("cpuinfo"))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/sysreadfile.go
+++ b/internal/util/sysreadfile.go
@@ -17,6 +17,7 @@ package util
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"syscall"
@@ -51,12 +52,17 @@ func SysReadFile(file string) (string, error) {
 // ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.
 // This is similar to ioutil.ReadFile but without the call to os.Stat, because
 // many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
+// Reads a max file size of 512kB.  For files larger than this, a scanner
+// should be used.
 func ReadFileNoStat(filename string) ([]byte, error) {
+	const maxBufferSize = 1024 * 500
+
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
-	return ioutil.ReadAll(f)
+	reader := io.LimitReader(f, maxBufferSize)
+	return ioutil.ReadAll(reader)
 }

--- a/ipvs.go
+++ b/ipvs.go
@@ -15,6 +15,7 @@ package procfs
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -24,6 +25,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // IPVSStats holds IPVS statistics, as exposed by the kernel in `/proc/net/ip_vs_stats`.
@@ -64,17 +67,16 @@ type IPVSBackendStatus struct {
 
 // IPVSStats reads the IPVS statistics from the specified `proc` filesystem.
 func (fs FS) IPVSStats() (IPVSStats, error) {
-	file, err := os.Open(fs.proc.Path("net/ip_vs_stats"))
+	data, err := util.ReadFileNoStat(fs.proc.Path("net/ip_vs_stats"))
 	if err != nil {
 		return IPVSStats{}, err
 	}
-	defer file.Close()
 
-	return parseIPVSStats(file)
+	return parseIPVSStats(bytes.NewReader(data))
 }
 
 // parseIPVSStats performs the actual parsing of `ip_vs_stats`.
-func parseIPVSStats(file io.Reader) (IPVSStats, error) {
+func parseIPVSStats(r io.Reader) (IPVSStats, error) {
 	var (
 		statContent []byte
 		statLines   []string
@@ -82,7 +84,7 @@ func parseIPVSStats(file io.Reader) (IPVSStats, error) {
 		stats       IPVSStats
 	)
 
-	statContent, err := ioutil.ReadAll(file)
+	statContent, err := ioutil.ReadAll(r)
 	if err != nil {
 		return IPVSStats{}, err
 	}

--- a/proc.go
+++ b/proc.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/procfs/internal/fs"
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // Proc provides information about a running process.
@@ -121,13 +122,7 @@ func (fs FS) AllProcs() (Procs, error) {
 
 // CmdLine returns the command line of a process.
 func (p Proc) CmdLine() ([]string, error) {
-	f, err := os.Open(p.path("cmdline"))
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	data, err := ioutil.ReadAll(f)
+	data, err := util.ReadFileNoStat(p.path("cmdline"))
 	if err != nil {
 		return nil, err
 	}
@@ -141,13 +136,7 @@ func (p Proc) CmdLine() ([]string, error) {
 
 // Comm returns the command name of a process.
 func (p Proc) Comm() (string, error) {
-	f, err := os.Open(p.path("comm"))
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	data, err := ioutil.ReadAll(f)
+	data, err := util.ReadFileNoStat(p.path("comm"))
 	if err != nil {
 		return "", err
 	}

--- a/proc_environ.go
+++ b/proc_environ.go
@@ -14,22 +14,16 @@
 package procfs
 
 import (
-	"io/ioutil"
-	"os"
 	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // Environ reads process environments from /proc/<pid>/environ
 func (p Proc) Environ() ([]string, error) {
 	environments := make([]string, 0)
 
-	f, err := os.Open(p.path("environ"))
-	if err != nil {
-		return environments, err
-	}
-	defer f.Close()
-
-	data, err := ioutil.ReadAll(f)
+	data, err := util.ReadFileNoStat(p.path("environ"))
 	if err != nil {
 		return environments, err
 	}

--- a/proc_io.go
+++ b/proc_io.go
@@ -15,8 +15,8 @@ package procfs
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // ProcIO models the content of /proc/<pid>/io.
@@ -43,13 +43,7 @@ type ProcIO struct {
 func (p Proc) IO() (ProcIO, error) {
 	pio := ProcIO{}
 
-	f, err := os.Open(p.path("io"))
-	if err != nil {
-		return pio, err
-	}
-	defer f.Close()
-
-	data, err := ioutil.ReadAll(f)
+	data, err := util.ReadFileNoStat(p.path("io"))
 	if err != nil {
 		return pio, err
 	}

--- a/proc_stat.go
+++ b/proc_stat.go
@@ -16,10 +16,10 @@ package procfs
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/prometheus/procfs/internal/fs"
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // Originally, this USER_HZ value was dynamically retrieved via a sysconf call
@@ -113,13 +113,7 @@ func (p Proc) NewStat() (ProcStat, error) {
 
 // Stat returns the current status information of the process.
 func (p Proc) Stat() (ProcStat, error) {
-	f, err := os.Open(p.path("stat"))
-	if err != nil {
-		return ProcStat{}, err
-	}
-	defer f.Close()
-
-	data, err := ioutil.ReadAll(f)
+	data, err := util.ReadFileNoStat(p.path("stat"))
 	if err != nil {
 		return ProcStat{}, err
 	}

--- a/proc_status.go
+++ b/proc_status.go
@@ -15,10 +15,10 @@ package procfs
 
 import (
 	"bytes"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // ProcStatus provides status information about the process,
@@ -75,13 +75,7 @@ type ProcStatus struct {
 
 // NewStatus returns the current status information of the process.
 func (p Proc) NewStatus() (ProcStatus, error) {
-	f, err := os.Open(p.path("status"))
-	if err != nil {
-		return ProcStatus{}, err
-	}
-	defer f.Close()
-
-	data, err := ioutil.ReadAll(f)
+	data, err := util.ReadFileNoStat(p.path("status"))
 	if err != nil {
 		return ProcStatus{}, err
 	}


### PR DESCRIPTION
This function should be a slight improvement over
ioutil.ReadFile because it skips the call to os.Stat which commonly
returns the wrong file size for files in /proc and /sys.

Usage of this function also makes the code a bit more concise for
parsing of several of the files in /proc.
