### PR TITLE
move ReadFileNoStat to its own file

### DIFF
--- a/internal/util/readfile.go
+++ b/internal/util/readfile.go
@@ -1,0 +1,38 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.
+// This is similar to ioutil.ReadFile but without the call to os.Stat, because
+// many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
+// Reads a max file size of 512kB.  For files larger than this, a scanner
+// should be used.
+func ReadFileNoStat(filename string) ([]byte, error) {
+	const maxBufferSize = 1024 * 512
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := io.LimitReader(f, maxBufferSize)
+	return ioutil.ReadAll(reader)
+}

--- a/internal/util/sysreadfile.go
+++ b/internal/util/sysreadfile.go
@@ -17,8 +17,6 @@ package util
 
 import (
 	"bytes"
-	"io"
-	"io/ioutil"
 	"os"
 	"syscall"
 )
@@ -47,22 +45,4 @@ func SysReadFile(file string) (string, error) {
 	}
 
 	return string(bytes.TrimSpace(b[:n])), nil
-}
-
-// ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.
-// This is similar to ioutil.ReadFile but without the call to os.Stat, because
-// many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
-// Reads a max file size of 512kB.  For files larger than this, a scanner
-// should be used.
-func ReadFileNoStat(filename string) ([]byte, error) {
-	const maxBufferSize = 1024 * 500
-
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	reader := io.LimitReader(f, maxBufferSize)
-	return ioutil.ReadAll(reader)
 }


### PR DESCRIPTION
This allows it to be built on all platforms
Fixes #221
