### PR TITLE
Convert stat parser to ReadFileNoStat()

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -15,13 +15,14 @@ package procfs
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 
 	"github.com/prometheus/procfs/internal/fs"
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // CPUStat shows how much time the cpu spend in various stages.
@@ -164,16 +165,15 @@ func (fs FS) NewStat() (Stat, error) {
 // Stat returns information about current cpu/process statistics.
 // See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func (fs FS) Stat() (Stat, error) {
-
-	f, err := os.Open(fs.proc.Path("stat"))
+	fileName := fs.proc.Path("stat")
+	data, err := util.ReadFileNoStat(fileName)
 	if err != nil {
 		return Stat{}, err
 	}
-	defer f.Close()
 
 	stat := Stat{}
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		line := scanner.Text()
 		parts := strings.Fields(scanner.Text())
@@ -237,7 +237,7 @@ func (fs FS) Stat() (Stat, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return Stat{}, fmt.Errorf("couldn't parse %s: %s", f.Name(), err)
+		return Stat{}, fmt.Errorf("couldn't parse %s: %s", fileName, err)
 	}
 
 	return stat, nil


### PR DESCRIPTION
Update the /proc/stat parser to use the util.ReadFileNoStat() helper.

May help with https://github.com/prometheus/node_exporter/issues/1372

Signed-off-by: Ben Kochie <superq@gmail.com>