### PR TITLE
procfs: clean up /proc/crypto parser and tests

### DIFF
--- a/crypto_test.go
+++ b/crypto_test.go
@@ -19,12 +19,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func newint64(i int64) *int64 {
-	return &i
-}
-func newuint64(i uint64) *uint64 {
-	return &i
-}
 func TestFS_Crypto(t *testing.T) {
 	fs := getProcFixtures(t)
 	crypto, err := fs.Crypto()
@@ -34,12 +28,86 @@ func TestFS_Crypto(t *testing.T) {
 	}
 
 	refs := []Crypto{
-		{Name: "ccm(aes)", Driver: "ccm_base(ctr(aes-aesni),cbcmac(aes-aesni))", Module: "ccm", Priority: newint64(300), Refcnt: newint64(4), Selftest: "passed", Internal: "no", Type: "aead", Async: false, Blocksize: newuint64(1), Ivsize: newuint64(16), Maxauthsize: newuint64(16), Geniv: "<none>"},
-		{Name: "cbcmac(aes)", Driver: "cbcmac(aes-aesni)", Module: "ccm", Priority: newint64(300), Refcnt: newint64(7), Selftest: "passed", Internal: "no", Type: "shash", Blocksize: newuint64(1), Digestsize: newuint64(16)},
-		{Name: "ecdh", Driver: "ecdh-generic", Module: "ecdh_generic", Priority: newint64(100), Refcnt: newint64(1), Selftest: "passed", Internal: "no", Type: "kpp"},
-		{Name: "ecb(arc4)", Driver: "ecb(arc4)-generic", Module: "arc4", Priority: newint64(100), Refcnt: newint64(1), Selftest: "passed", Internal: "no", Type: "skcipher", Async: false, Blocksize: newuint64(1), MinKeysize: newuint64(1), MaxKeysize: newuint64(256), Ivsize: newuint64(0), Chunksize: newuint64(1), Walksize: newuint64(1)},
-		{Name: "arc4", Driver: "arc4-generic", Module: "arc4", Priority: newint64(0), Refcnt: newint64(3), Selftest: "passed", Internal: "no", Type: "cipher", Blocksize: newuint64(1), MinKeysize: newuint64(1), MaxKeysize: newuint64(256)},
-		{Name: "crct10dif", Driver: "crct10dif-pclmul", Module: "crct10dif_pclmul", Priority: newint64(200), Refcnt: newint64(2), Selftest: "passed", Internal: "no", Type: "shash", Blocksize: newuint64(1), Digestsize: newuint64(2)},
+		{
+			Name:        "ccm(aes)",
+			Driver:      "ccm_base(ctr(aes-aesni),cbcmac(aes-aesni))",
+			Module:      "ccm",
+			Priority:    newint64(300),
+			Refcnt:      newint64(4),
+			Selftest:    "passed",
+			Internal:    "no",
+			Type:        "aead",
+			Async:       false,
+			Blocksize:   newuint64(1),
+			Ivsize:      newuint64(16),
+			Maxauthsize: newuint64(16),
+			Geniv:       "<none>",
+		},
+		{
+			Name:       "cbcmac(aes)",
+			Driver:     "cbcmac(aes-aesni)",
+			Module:     "ccm",
+			Priority:   newint64(300),
+			Refcnt:     newint64(7),
+			Selftest:   "passed",
+			Internal:   "no",
+			Type:       "shash",
+			Blocksize:  newuint64(1),
+			Digestsize: newuint64(16),
+		},
+		{
+			Name:     "ecdh",
+			Driver:   "ecdh-generic",
+			Module:   "ecdh_generic",
+			Priority: newint64(100),
+			Refcnt:   newint64(1),
+			Selftest: "passed",
+			Internal: "no",
+			Type:     "kpp",
+			Async:    true,
+		},
+		{
+			Name:       "ecb(arc4)",
+			Driver:     "ecb(arc4)-generic",
+			Module:     "arc4",
+			Priority:   newint64(100),
+			Refcnt:     newint64(1),
+			Selftest:   "passed",
+			Internal:   "no",
+			Type:       "skcipher",
+			Async:      false,
+			Blocksize:  newuint64(1),
+			MinKeysize: newuint64(1),
+			MaxKeysize: newuint64(256),
+			Ivsize:     newuint64(0),
+			Chunksize:  newuint64(1),
+			Walksize:   newuint64(1),
+		},
+		{
+			Name:       "arc4",
+			Driver:     "arc4-generic",
+			Module:     "arc4",
+			Priority:   newint64(0),
+			Refcnt:     newint64(3),
+			Selftest:   "passed",
+			Internal:   "no",
+			Type:       "cipher",
+			Blocksize:  newuint64(1),
+			MinKeysize: newuint64(1),
+			MaxKeysize: newuint64(256),
+		},
+		{
+			Name:       "crct10dif",
+			Driver:     "crct10dif-pclmul",
+			Module:     "crct10dif_pclmul",
+			Priority:   newint64(200),
+			Refcnt:     newint64(2),
+			Selftest:   "passed",
+			Internal:   "no",
+			Type:       "shash",
+			Blocksize:  newuint64(1),
+			Digestsize: newuint64(2),
+		},
 	}
 
 	if want, have := len(refs), len(crypto); want > have {
@@ -51,4 +119,12 @@ func TestFS_Crypto(t *testing.T) {
 			t.Fatalf("unexpected crypto entry (-want +got):\n%s", diff)
 		}
 	}
+}
+
+func newint64(i int64) *int64 {
+	return &i
+}
+
+func newuint64(i uint64) *uint64 {
+	return &i
 }

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -554,7 +554,7 @@ power management:
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/crypto
-Lines: 971
+Lines: 972
 name         : ccm(aes)
 driver       : ccm_base(ctr(aes-aesni),cbcmac(aes-aesni))
 module       : ccm
@@ -588,6 +588,7 @@ refcnt       : 1
 selftest     : passed
 internal     : no
 type         : kpp
+async        : yes
 
 name         : ecb(arc4)
 driver       : ecb(arc4)-generic


### PR DESCRIPTION
I think this code could use more unit tests, but I've tidied it up a bit to make it easier to follow.