### PR TITLE
procfs: re-enable golangci-lint and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
-# Run only staticcheck for now. Additional linters will be enabled one-by-one.
 linters:
   enable:
   - staticcheck
   - govet
-  disable-all: true

--- a/iscsi/get.go
+++ b/iscsi/get.go
@@ -192,7 +192,7 @@ func (fs FS) GetRBDMatch(rbdNumber string, poolImage string) (*RBD, error) {
 	}
 
 	for systemRbdNumber, systemRbdPath := range systemRbds {
-		var systemPool, systemImage string = "", ""
+		var systemPool, systemImage string
 		systemPoolPath := filepath.Join(systemRbdPath, "pool")
 		if _, err := os.Stat(systemPoolPath); os.IsNotExist(err) {
 			continue

--- a/iscsi/get_test.go
+++ b/iscsi/get_test.go
@@ -22,8 +22,7 @@ import (
 
 func TestGetStats(t *testing.T) {
 	tests := []struct {
-		invalid bool
-		stat    *iscsi.Stats
+		stat *iscsi.Stats
 	}{
 		{
 			stat: &iscsi.Stats{

--- a/net_unix.go
+++ b/net_unix.go
@@ -207,10 +207,6 @@ func (u NetUnix) parseUsers(hexStr string) (uint64, error) {
 	return strconv.ParseUint(hexStr, 16, 32)
 }
 
-func (u NetUnix) parseProtocol(hexStr string) (uint64, error) {
-	return strconv.ParseUint(hexStr, 16, 32)
-}
-
 func (u NetUnix) parseType(hexStr string) (NetUnixType, error) {
 	typ, err := strconv.ParseUint(hexStr, 16, 16)
 	if err != nil {

--- a/vm_test.go
+++ b/vm_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package procfs
 
 import (


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

Not sure why this was disabled but it resulted in a few lingering defects in the code. I would prefer to see upstream staticcheck used if possible as well, but that's an issue for another day.