### PR TITLE
procfs: simplify meminfo parser

### DIFF
--- a/meminfo.go
+++ b/meminfo.go
@@ -16,6 +16,8 @@ package procfs
 import (
 	"bufio"
 	"bytes"
+	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
@@ -143,311 +145,133 @@ type Meminfo struct {
 // Meminfo returns an information about current kernel/system memory statistics.
 // See https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func (fs FS) Meminfo() (Meminfo, error) {
-	data, err := util.ReadFileNoStat(fs.proc.Path("meminfo"))
+	b, err := util.ReadFileNoStat(fs.proc.Path("meminfo"))
 	if err != nil {
 		return Meminfo{}, err
 	}
-	return parseMemInfo(data)
+
+	m, err := parseMemInfo(bytes.NewReader(b))
+	if err != nil {
+		return Meminfo{}, fmt.Errorf("failed to parse meminfo: %v", err)
+	}
+
+	return *m, nil
 }
 
-func parseMemInfo(info []byte) (m Meminfo, err error) {
-	scanner := bufio.NewScanner(bytes.NewReader(info))
+func parseMemInfo(r io.Reader) (*Meminfo, error) {
+	var m Meminfo
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		// Each line has at least a name and value; we ignore the unit.
+		fields := strings.Fields(s.Text())
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("malformed meminfo line: %q", s.Text())
+		}
 
-	var line string
-	for scanner.Scan() {
-		line = scanner.Text()
+		v, err := strconv.ParseUint(fields[1], 0, 64)
+		if err != nil {
+			return nil, err
+		}
 
-		field := strings.Fields(line)
-		switch field[0] {
+		switch fields[0] {
 		case "MemTotal:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.MemTotal = v
 		case "MemFree:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.MemFree = v
 		case "MemAvailable:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.MemAvailable = v
 		case "Buffers:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Buffers = v
 		case "Cached:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Cached = v
 		case "SwapCached:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.SwapCached = v
 		case "Active:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Active = v
 		case "Inactive:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Inactive = v
 		case "Active(anon):":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.ActiveAnon = v
 		case "Inactive(anon):":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.InactiveAnon = v
 		case "Active(file):":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.ActiveFile = v
 		case "Inactive(file):":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.InactiveFile = v
 		case "Unevictable:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Unevictable = v
 		case "Mlocked:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Mlocked = v
 		case "SwapTotal:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.SwapTotal = v
 		case "SwapFree:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.SwapFree = v
 		case "Dirty:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Dirty = v
 		case "Writeback:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Writeback = v
 		case "AnonPages:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.AnonPages = v
 		case "Mapped:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Mapped = v
 		case "Shmem:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Shmem = v
 		case "Slab:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Slab = v
 		case "SReclaimable:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.SReclaimable = v
 		case "SUnreclaim:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.SUnreclaim = v
 		case "KernelStack:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.KernelStack = v
 		case "PageTables:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.PageTables = v
 		case "NFS_Unstable:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.NFSUnstable = v
 		case "Bounce:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Bounce = v
 		case "WritebackTmp:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.WritebackTmp = v
 		case "CommitLimit:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.CommitLimit = v
 		case "Committed_AS:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.CommittedAS = v
 		case "VmallocTotal:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.VmallocTotal = v
 		case "VmallocUsed:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.VmallocUsed = v
 		case "VmallocChunk:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.VmallocChunk = v
 		case "HardwareCorrupted:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.HardwareCorrupted = v
 		case "AnonHugePages:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.AnonHugePages = v
 		case "ShmemHugePages:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.ShmemHugePages = v
 		case "ShmemPmdMapped:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.ShmemPmdMapped = v
 		case "CmaTotal:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.CmaTotal = v
 		case "CmaFree:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.CmaFree = v
 		case "HugePages_Total:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.HugePagesTotal = v
 		case "HugePages_Free:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.HugePagesFree = v
 		case "HugePages_Rsvd:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.HugePagesRsvd = v
 		case "HugePages_Surp:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.HugePagesSurp = v
 		case "Hugepagesize:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.Hugepagesize = v
 		case "DirectMap4k:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.DirectMap4k = v
 		case "DirectMap2M:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.DirectMap2M = v
 		case "DirectMap1G:":
-			v, err := strconv.ParseUint(field[1], 0, 64)
-			if err != nil {
-				return Meminfo{}, err
-			}
 			m.DirectMap1G = v
 		}
 	}
-	return m, nil
+
+	return &m, nil
 }


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

This function should probably return `*Meminfo` per the usual Go conventions. Are we okay to make that change too?