### PR TITLE
procfs: ensure NetSockstat6 compatibility with os.IsNotExist

### DIFF
--- a/net_sockstat.go
+++ b/net_sockstat.go
@@ -51,6 +51,9 @@ func (fs FS) NetSockstat() (*NetSockstat, error) {
 }
 
 // NetSockstat6 retrieves IPv6 socket statistics.
+//
+// If IPv6 is disabled on this kernel, the returned error can be checked with
+// os.IsNotExist.
 func (fs FS) NetSockstat6() (*NetSockstat, error) {
 	return readSockstat(fs.proc.Path("net", "sockstat6"))
 }
@@ -60,6 +63,8 @@ func readSockstat(name string) (*NetSockstat, error) {
 	// This file is small and can be read with one syscall.
 	b, err := util.ReadFileNoStat(name)
 	if err != nil {
+		// Do not wrap this error so the caller can detect os.IsNotExist and
+		// similar conditions.
 		return nil, err
 	}
 

--- a/net_sockstat_test.go
+++ b/net_sockstat_test.go
@@ -14,6 +14,7 @@
 package procfs
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -73,6 +74,17 @@ func TestNetSockstat6(t *testing.T) {
 	}
 	if diff := cmp.Diff(17, stat.Protocols[0].InUse); diff != "" {
 		t.Fatalf("unexpected number of TCP sockets (-want +got):\n%s", diff)
+	}
+}
+
+func Test_readSockstatIsNotExist(t *testing.T) {
+	// On a machine with IPv6 disabled for example, we want to ensure that
+	// readSockstat returns an error that is compatible with os.IsNotExist.
+	//
+	// We can use a synthetic file path here to verify this behavior.
+	_, err := readSockstat("/does/not/exist")
+	if err == nil || !os.IsNotExist(err) {
+		t.Fatalf("error is not compatible with os.IsNotExist: %#v", err)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

This will ensure we can gracefully degrade in node_exporter if need be.