### PR TITLE
procfs: tidy up NetUnix APIs and internals

### DIFF
--- a/net_unix.go
+++ b/net_unix.go
@@ -42,41 +42,39 @@ const (
 	netUnixStateDisconnected = 4
 )
 
-// NetUnixType is the type of the type field.
-type NetUnixType uint64
+// NetUNIXType is the type of the type field.
+type NetUNIXType uint64
 
-// NetUnixFlags is the type of the flags field.
-type NetUnixFlags uint64
+// NetUNIXFlags is the type of the flags field.
+type NetUNIXFlags uint64
 
-// NetUnixState is the type of the state field.
-type NetUnixState uint64
+// NetUNIXState is the type of the state field.
+type NetUNIXState uint64
 
-// NetUnixLine represents a line of /proc/net/unix.
-type NetUnixLine struct {
+// NetUNIXLine represents a line of /proc/net/unix.
+type NetUNIXLine struct {
 	KernelPtr string
 	RefCount  uint64
 	Protocol  uint64
-	Flags     NetUnixFlags
-	Type      NetUnixType
-	State     NetUnixState
+	Flags     NetUNIXFlags
+	Type      NetUNIXType
+	State     NetUNIXState
 	Inode     uint64
 	Path      string
 }
 
-// NetUnix holds the data read from /proc/net/unix.
-type NetUnix struct {
-	Rows []*NetUnixLine
+// NetUNIX holds the data read from /proc/net/unix.
+type NetUNIX struct {
+	Rows []*NetUNIXLine
 }
 
-// NetUnix returns data read from /proc/net/unix.
-func (fs FS) NetUnix() (*NetUnix, error) {
-	// TODO: this function name and type should be "NetUNIX" per Go convention.
-	// Consider changing at a later time.
+// NetUNIX returns data read from /proc/net/unix.
+func (fs FS) NetUNIX() (*NetUNIX, error) {
 	return readNetUNIX(fs.proc.Path("net/unix"))
 }
 
 // readNetUNIX reads data in /proc/net/unix format from the specified file.
-func readNetUNIX(file string) (*NetUnix, error) {
+func readNetUNIX(file string) (*NetUNIX, error) {
 	// This file could be quite large and a streaming read is desirable versus
 	// reading the entire contents at once.
 	f, err := os.Open(file)
@@ -89,7 +87,7 @@ func readNetUNIX(file string) (*NetUnix, error) {
 }
 
 // parseNetUNIX creates a NetUnix structure from the incoming stream.
-func parseNetUNIX(r io.Reader) (*NetUnix, error) {
+func parseNetUNIX(r io.Reader) (*NetUNIX, error) {
 	// Begin scanning by checking for the existence of Inode.
 	s := bufio.NewScanner(r)
 	s.Scan()
@@ -105,7 +103,7 @@ func parseNetUNIX(r io.Reader) (*NetUnix, error) {
 		minFields++
 	}
 
-	var nu NetUnix
+	var nu NetUNIX
 	for s.Scan() {
 		line := s.Text()
 		item, err := nu.parseLine(line, hasInode, minFields)
@@ -123,7 +121,7 @@ func parseNetUNIX(r io.Reader) (*NetUnix, error) {
 	return &nu, nil
 }
 
-func (u *NetUnix) parseLine(line string, hasInode bool, min int) (*NetUnixLine, error) {
+func (u *NetUNIX) parseLine(line string, hasInode bool, min int) (*NetUNIXLine, error) {
 	fields := strings.Fields(line)
 
 	l := len(fields)
@@ -164,7 +162,7 @@ func (u *NetUnix) parseLine(line string, hasInode bool, min int) (*NetUnixLine, 
 		}
 	}
 
-	n := &NetUnixLine{
+	n := &NetUNIXLine{
 		KernelPtr: kernelPtr,
 		RefCount:  users,
 		Type:      typ,
@@ -188,42 +186,42 @@ func (u *NetUnix) parseLine(line string, hasInode bool, min int) (*NetUnixLine, 
 	return n, nil
 }
 
-func (u NetUnix) parseUsers(s string) (uint64, error) {
+func (u NetUNIX) parseUsers(s string) (uint64, error) {
 	return strconv.ParseUint(s, 16, 32)
 }
 
-func (u NetUnix) parseType(s string) (NetUnixType, error) {
+func (u NetUNIX) parseType(s string) (NetUNIXType, error) {
 	typ, err := strconv.ParseUint(s, 16, 16)
 	if err != nil {
 		return 0, err
 	}
 
-	return NetUnixType(typ), nil
+	return NetUNIXType(typ), nil
 }
 
-func (u NetUnix) parseFlags(s string) (NetUnixFlags, error) {
+func (u NetUNIX) parseFlags(s string) (NetUNIXFlags, error) {
 	flags, err := strconv.ParseUint(s, 16, 32)
 	if err != nil {
 		return 0, err
 	}
 
-	return NetUnixFlags(flags), nil
+	return NetUNIXFlags(flags), nil
 }
 
-func (u NetUnix) parseState(s string) (NetUnixState, error) {
+func (u NetUNIX) parseState(s string) (NetUNIXState, error) {
 	st, err := strconv.ParseInt(s, 16, 8)
 	if err != nil {
 		return 0, err
 	}
 
-	return NetUnixState(st), nil
+	return NetUNIXState(st), nil
 }
 
-func (u NetUnix) parseInode(s string) (uint64, error) {
+func (u NetUNIX) parseInode(s string) (uint64, error) {
 	return strconv.ParseUint(s, 10, 64)
 }
 
-func (t NetUnixType) String() string {
+func (t NetUNIXType) String() string {
 	switch t {
 	case netUnixTypeStream:
 		return "stream"
@@ -235,7 +233,7 @@ func (t NetUnixType) String() string {
 	return "unknown"
 }
 
-func (f NetUnixFlags) String() string {
+func (f NetUNIXFlags) String() string {
 	switch f {
 	case netUnixFlagListen:
 		return "listen"
@@ -244,7 +242,7 @@ func (f NetUnixFlags) String() string {
 	}
 }
 
-func (s NetUnixState) String() string {
+func (s NetUNIXState) String() string {
 	switch s {
 	case netUnixStateUnconnected:
 		return "unconnected"

--- a/net_unix_test.go
+++ b/net_unix_test.go
@@ -31,7 +31,7 @@ func TestNetUnix(t *testing.T) {
 		t.Fatalf("failed to open procfs: %v", err)
 	}
 
-	got, err := fs.NetUnix()
+	got, err := fs.NetUNIX()
 	if err != nil {
 		t.Fatalf("failed to get UNIX socket data: %v", err)
 	}
@@ -53,12 +53,12 @@ func TestNetUnixNoInode(t *testing.T) {
 	testNetUNIX(t, noCheckInode, got)
 }
 
-func testNetUNIX(t *testing.T, testInode bool, got *NetUnix) {
+func testNetUNIX(t *testing.T, testInode bool, got *NetUNIX) {
 	t.Helper()
 
 	// First verify that the input data matches a prepopulated structure.
 
-	want := []*NetUnixLine{
+	want := []*NetUNIXLine{
 		{
 			KernelPtr: "0000000000000000",
 			RefCount:  2,
@@ -120,7 +120,7 @@ func testNetUNIX(t *testing.T, testInode bool, got *NetUnix) {
 	// Now test the field enumerations and ensure they match up correctly
 	// with the constants used to generate readable strings.
 
-	wantFlags := []NetUnixFlags{
+	wantFlags := []NetUNIXFlags{
 		netUnixFlagListen,
 		netUnixFlagListen,
 		netUnixFlagDefault,
@@ -128,7 +128,7 @@ func testNetUNIX(t *testing.T, testInode bool, got *NetUnix) {
 		netUnixFlagDefault,
 	}
 
-	wantType := []NetUnixType{
+	wantType := []NetUNIXType{
 		netUnixTypeStream,
 		netUnixTypeSeqpacket,
 		netUnixTypeDgram,
@@ -136,7 +136,7 @@ func testNetUNIX(t *testing.T, testInode bool, got *NetUnix) {
 		netUnixTypeStream,
 	}
 
-	wantState := []NetUnixState{
+	wantState := []NetUNIXState{
 		netUnixStateUnconnected,
 		netUnixStateUnconnected,
 		netUnixStateUnconnected,
@@ -145,9 +145,9 @@ func testNetUNIX(t *testing.T, testInode bool, got *NetUnix) {
 	}
 
 	var (
-		gotFlags []NetUnixFlags
-		gotType  []NetUnixType
-		gotState []NetUnixState
+		gotFlags []NetUNIXFlags
+		gotType  []NetUNIXType
+		gotState []NetUNIXState
 	)
 
 	for _, r := range got.Rows {

--- a/net_unix_test.go
+++ b/net_unix_test.go
@@ -15,21 +15,51 @@ package procfs
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestNewNetUnix(t *testing.T) {
+// Whether or not to run tests with inode fixtures.
+const (
+	checkInode   = true
+	noCheckInode = false
+)
+
+func TestNetUnix(t *testing.T) {
 	fs, err := NewFS(procTestFixtures)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to open procfs: %v", err)
 	}
 
-	nu, err := fs.NewNetUnix()
+	got, err := fs.NetUnix()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to get UNIX socket data: %v", err)
 	}
 
-	lines := []*NetUnixLine{
-		&NetUnixLine{
+	testNetUNIX(t, checkInode, got)
+}
+
+func TestNetUnixNoInode(t *testing.T) {
+	fs, err := NewFS(procTestFixtures)
+	if err != nil {
+		t.Fatalf("failed to open procfs: %v", err)
+	}
+
+	got, err := readNetUNIX(fs.proc.Path("net/unix_without_inode"))
+	if err != nil {
+		t.Fatalf("failed to read UNIX socket data: %v", err)
+	}
+
+	testNetUNIX(t, noCheckInode, got)
+}
+
+func testNetUNIX(t *testing.T, testInode bool, got *NetUnix) {
+	t.Helper()
+
+	// First verify that the input data matches a prepopulated structure.
+
+	want := []*NetUnixLine{
+		{
 			KernelPtr: "0000000000000000",
 			RefCount:  2,
 			Flags:     1 << 16,
@@ -38,7 +68,7 @@ func TestNewNetUnix(t *testing.T) {
 			Inode:     3442596,
 			Path:      "/var/run/postgresql/.s.PGSQL.5432",
 		},
-		&NetUnixLine{
+		{
 			KernelPtr: "0000000000000000",
 			RefCount:  10,
 			Flags:     1 << 16,
@@ -47,7 +77,7 @@ func TestNewNetUnix(t *testing.T) {
 			Inode:     10061,
 			Path:      "/run/udev/control",
 		},
-		&NetUnixLine{
+		{
 			KernelPtr: "0000000000000000",
 			RefCount:  7,
 			Flags:     0,
@@ -56,7 +86,7 @@ func TestNewNetUnix(t *testing.T) {
 			Inode:     12392,
 			Path:      "/dev/log",
 		},
-		&NetUnixLine{
+		{
 			KernelPtr: "0000000000000000",
 			RefCount:  3,
 			Flags:     0,
@@ -65,7 +95,7 @@ func TestNewNetUnix(t *testing.T) {
 			Inode:     4787297,
 			Path:      "/var/run/postgresql/.s.PGSQL.5432",
 		},
-		&NetUnixLine{
+		{
 			KernelPtr: "0000000000000000",
 			RefCount:  3,
 			Flags:     0,
@@ -75,105 +105,66 @@ func TestNewNetUnix(t *testing.T) {
 		},
 	}
 
-	if want, have := len(lines), len(nu.Rows); want != have {
-		t.Errorf("want %d parsed net/unix lines, have %d", want, have)
-	}
-	for i, gotLine := range nu.Rows {
-		if i >= len(lines) {
-			continue
-		}
-		line := lines[i]
-		if *line != *gotLine {
-			t.Errorf("%d item: got %v, want %v", i, *gotLine, *line)
+	// Enable the fixtures to be used for multiple tests by clearing the inode
+	// field when appropriate.
+	if !testInode {
+		for i := 0; i < len(want); i++ {
+			want[i].Inode = 0
 		}
 	}
 
-	wantedFlags := "listen"
-	flags := lines[0].Flags.String()
-	if wantedFlags != flags {
-		t.Errorf("unexpected flag str: want %s, got %s", wantedFlags, flags)
-	}
-	wantedFlags = "default"
-	flags = lines[3].Flags.String()
-	if wantedFlags != flags {
-		t.Errorf("unexpected flag str: wanted %s, got %s", wantedFlags, flags)
+	if diff := cmp.Diff(want, got.Rows); diff != "" {
+		t.Fatalf("unexpected /proc/net/unix data (-want +got):\n%s", diff)
 	}
 
-	wantedType := "stream"
-	typ := lines[0].Type.String()
-	if wantedType != typ {
-		t.Errorf("unexpected type str: wanted %s, got %s", wantedType, typ)
+	// Now test the field enumerations and ensure they match up correctly
+	// with the constants used to generate readable strings.
+
+	wantFlags := []NetUnixFlags{
+		netUnixFlagListen,
+		netUnixFlagListen,
+		netUnixFlagDefault,
+		netUnixFlagDefault,
+		netUnixFlagDefault,
 	}
 
-	wantedType = "seqpacket"
-	typ = lines[1].Type.String()
-	if wantedType != typ {
-		t.Errorf("unexpected type str: want %s, got %s", wantedType, typ)
-	}
-}
-
-func TestNewNetUnixWithoutInode(t *testing.T) {
-	fs, err := NewFS(procTestFixtures)
-	if err != nil {
-		t.Fatal(err)
-	}
-	nu, err := NewNetUnixByPath(fs.proc.Path("net/unix_without_inode"))
-	if err != nil {
-		t.Fatal(err)
+	wantType := []NetUnixType{
+		netUnixTypeStream,
+		netUnixTypeSeqpacket,
+		netUnixTypeDgram,
+		netUnixTypeStream,
+		netUnixTypeStream,
 	}
 
-	lines := []*NetUnixLine{
-		&NetUnixLine{
-			KernelPtr: "0000000000000000",
-			RefCount:  2,
-			Flags:     1 << 16,
-			Type:      1,
-			State:     1,
-			Path:      "/var/run/postgresql/.s.PGSQL.5432",
-		},
-		&NetUnixLine{
-			KernelPtr: "0000000000000000",
-			RefCount:  10,
-			Flags:     1 << 16,
-			Type:      5,
-			State:     1,
-			Path:      "/run/udev/control",
-		},
-		&NetUnixLine{
-			KernelPtr: "0000000000000000",
-			RefCount:  7,
-			Flags:     0,
-			Type:      2,
-			State:     1,
-			Path:      "/dev/log",
-		},
-		&NetUnixLine{
-			KernelPtr: "0000000000000000",
-			RefCount:  3,
-			Flags:     0,
-			Type:      1,
-			State:     3,
-			Path:      "/var/run/postgresql/.s.PGSQL.5432",
-		},
-		&NetUnixLine{
-			KernelPtr: "0000000000000000",
-			RefCount:  3,
-			Flags:     0,
-			Type:      1,
-			State:     3,
-		},
+	wantState := []NetUnixState{
+		netUnixStateUnconnected,
+		netUnixStateUnconnected,
+		netUnixStateUnconnected,
+		netUnixStateConnected,
+		netUnixStateConnected,
 	}
 
-	if want, have := len(lines), len(nu.Rows); want != have {
-		t.Errorf("want %d parsed net/unix lines, have %d", want, have)
+	var (
+		gotFlags []NetUnixFlags
+		gotType  []NetUnixType
+		gotState []NetUnixState
+	)
+
+	for _, r := range got.Rows {
+		gotFlags = append(gotFlags, r.Flags)
+		gotType = append(gotType, r.Type)
+		gotState = append(gotState, r.State)
 	}
-	for i, gotLine := range nu.Rows {
-		if i >= len(lines) {
-			continue
-		}
-		line := lines[i]
-		if *line != *gotLine {
-			t.Errorf("%d item: got %v, want %v", i, *gotLine, *line)
-		}
+
+	if diff := cmp.Diff(wantFlags, gotFlags); diff != "" {
+		t.Fatalf("unexpected /proc/net/unix flags (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(wantType, gotType); diff != "" {
+		t.Fatalf("unexpected /proc/net/unix types (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(wantState, gotState); diff != "" {
+		t.Fatalf("unexpected /proc/net/unix states (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@gmail.com>

- remove unnecessary exported APIs; `FS.NetUnix` is sufficient and anything else is added API surface for little gain
- remove unecessary constants which are only used once (twice for error messages)
- remove duplication in tests and switch to go-cmp
- more idiomatic error messages