### PR TITLE
Add UIDs to ProcStatus struct

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -189,7 +189,7 @@ Ngid:	0
 Pid:	26231
 PPid:	1
 TracerPid:	0
-Uid:	0	0	0	0
+Uid:	1000	1000	1000	0
 Gid:	0	0	0	0
 FDSize:	128
 Groups:

--- a/proc_status.go
+++ b/proc_status.go
@@ -71,6 +71,9 @@ type ProcStatus struct {
 	VoluntaryCtxtSwitches uint64
 	// Number of involuntary context switches.
 	NonVoluntaryCtxtSwitches uint64
+
+	// UIDs of the process (Real, effective, saved set, and filesystem UIDs (GIDs))
+	UIDs [4]string
 }
 
 // NewStatus returns the current status information of the process.
@@ -114,6 +117,8 @@ func (s *ProcStatus) fillStatus(k string, vString string, vUint uint64, vUintByt
 		s.TGID = int(vUint)
 	case "Name":
 		s.Name = vString
+	case "Uid":
+		copy(s.UIDs[:], strings.Split(vString, "\t"))
 	case "VmPeak":
 		s.VmPeak = vUintBytes
 	case "VmSize":

--- a/proc_status_test.go
+++ b/proc_status_test.go
@@ -75,3 +75,19 @@ func TestProcStatusName(t *testing.T) {
 		t.Errorf("want name %s, have %s", want, have)
 	}
 }
+
+func TestProcStatusUIDs(t *testing.T) {
+	p, err := getProcFixtures(t).Proc(26231)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := p.NewStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, have := [4]string{"1000", "1000", "1000", "0"}, s.UIDs; want != have {
+		t.Errorf("want uids %s, have %s", want, have)
+	}
+}


### PR DESCRIPTION
These are left as a string since the built-in function os.LookupId
accepts UID as a string.