### PR TITLE
Add support for /proc/swaps

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -1952,6 +1952,12 @@ procs_blocked 1
 softirq 5057579 250191 1481983 1647 211099 186066 0 1783454 622196 12499 508444
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/swaps
+Lines: 2
+Filename				Type		Size	Used	Priority
+/dev/dm-2                               partition	131068	176	-2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/proc/symlinktargets
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/swaps.go
+++ b/swaps.go
@@ -1,0 +1,89 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// Swap represents an entry in /proc/swaps.
+type Swap struct {
+	Filename string
+	Type     string
+	Size     int
+	Used     int
+	Priority int
+}
+
+// Swaps returns a slice of all configured swap devices on the system.
+func (fs FS) Swaps() ([]*Swap, error) {
+	data, err := util.ReadFileNoStat(fs.proc.Path("swaps"))
+	if err != nil {
+		return nil, err
+	}
+	return parseSwaps(data)
+}
+
+func parseSwaps(info []byte) ([]*Swap, error) {
+	swaps := []*Swap{}
+	scanner := bufio.NewScanner(bytes.NewReader(info))
+	scanner.Scan() // ignore header line
+	for scanner.Scan() {
+		swapString := scanner.Text()
+		parsedSwap, err := parseSwapString(swapString)
+		if err != nil {
+			return nil, err
+		}
+		swaps = append(swaps, parsedSwap)
+	}
+
+	err := scanner.Err()
+	return swaps, err
+}
+
+func parseSwapString(swapString string) (*Swap, error) {
+	var err error
+
+	swapFields := strings.Fields(swapString)
+	swapLength := len(swapFields)
+	if swapLength < 5 {
+		return nil, fmt.Errorf("too few fields in swap string: %s", swapString)
+	}
+
+	swap := &Swap{
+		Filename: swapFields[0],
+		Type:     swapFields[1],
+	}
+
+	swap.Size, err = strconv.Atoi(swapFields[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid swap size: %s", swapFields[2])
+	}
+	swap.Used, err = strconv.Atoi(swapFields[3])
+	if err != nil {
+		return nil, fmt.Errorf("invalid swap used: %s", swapFields[3])
+	}
+	swap.Priority, err = strconv.Atoi(swapFields[4])
+	if err != nil {
+		return nil, fmt.Errorf("invalid swap priority: %s", swapFields[4])
+	}
+
+	return swap, nil
+}

--- a/swaps_test.go
+++ b/swaps_test.go
@@ -1,0 +1,80 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSwaps(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       string
+		swap    *Swap
+		invalid bool
+	}{
+		{
+			name:    "device-mapper volume",
+			s:       "/dev/dm-2                               partition       131068  1024    -2",
+			invalid: false,
+			swap: &Swap{
+				Filename: "/dev/dm-2",
+				Type:     "partition",
+				Size:     131068,
+				Used:     1024,
+				Priority: -2,
+			},
+		},
+		{
+			name:    "Swap file",
+			s:       "/foo                                    file            1048572 0       -3",
+			invalid: false,
+			swap: &Swap{
+				Filename: "/foo",
+				Type:     "file",
+				Size:     1048572,
+				Used:     0,
+				Priority: -3,
+			},
+		},
+		{
+			name:    "Invalid number",
+			s:       "/dev/sda2                               partition       hello   world   -2",
+			invalid: true,
+		},
+		{
+			name:    "Not enough fields",
+			s:       "/dev/dm-2                               partition       131068  1024",
+			invalid: true,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("[%02d] test %q", i, test.name)
+
+		swap, err := parseSwapString(test.s)
+
+		if test.invalid && err == nil {
+			t.Error("unexpected success")
+		}
+		if !test.invalid && err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(test.swap, swap) {
+			t.Errorf("swap:\nwant:\n%+v\nhave:\n%+v", test.swap, swap)
+		}
+	}
+}


### PR DESCRIPTION
This code (both implementation and tests) is largely based on the existing mountinfo implementation.

Implementation of #244.