### PR TITLE
Expose xs_qm_dquot_unused XFS counter

### DIFF
--- a/xfs/parse.go
+++ b/xfs/parse.go
@@ -381,11 +381,15 @@ func extendedPrecisionStats(us []uint64) (ExtendedPrecisionStats, error) {
 }
 
 func quotaManagerStats(us []uint32) (QuotaManagerStats, error) {
-	if l := len(us); l < 8 {
-		return QuotaManagerStats{}, fmt.Errorf("insufficient number of values for XFS quota stats expecting at least 8, got: %d", l)
+	// The "Unused" attribute first appears in Linux 4.20
+	// As a result either 8 or 9 elements may appear in this slice depending on
+	// the kernel version.
+	l := len(us)
+	if l != 8 && l != 9 {
+		return QuotaManagerStats{}, fmt.Errorf("incorrect number of values for XFS quota stats: %d", l)
 	}
 
-	return QuotaManagerStats{
+	s := QuotaManagerStats{
 		Reclaims:      us[0],
 		ReclaimMisses: us[1],
 		DquoteDups:    us[2],
@@ -394,7 +398,13 @@ func quotaManagerStats(us []uint32) (QuotaManagerStats, error) {
 		Wants:         us[5],
 		ShakeReclaims: us[6],
 		InactReclaims: us[7],
-	}, nil
+	}
+
+	if l > 8 {
+		s.Unused = us[8]
+	}
+
+	return s, nil
 }
 
 func debugStats(us []uint32) (DebugStats, error) {

--- a/xfs/parse_test.go
+++ b/xfs/parse_test.go
@@ -369,6 +369,11 @@ func TestParseStats(t *testing.T) {
 			invalid: true,
 		},
 		{
+			name:    "qm bad",
+			s:       "qm 1 2 3 4 5 6 7 8 9 10",
+			invalid: true,
+		},
+		{
 			name: "qm OK",
 			s:    "qm 1 2 3 4 5 6 7 8",
 			stats: &xfs.Stats{
@@ -381,6 +386,23 @@ func TestParseStats(t *testing.T) {
 					Wants:         6,
 					ShakeReclaims: 7,
 					InactReclaims: 8,
+				},
+			},
+		},
+		{
+			name: "qm OK",
+			s:    "qm 1 2 3 4 5 6 7 8 9",
+			stats: &xfs.Stats{
+				QuotaManager: xfs.QuotaManagerStats{
+					Reclaims:      1,
+					ReclaimMisses: 2,
+					DquoteDups:    3,
+					CacheMisses:   4,
+					CacheHits:     5,
+					Wants:         6,
+					ShakeReclaims: 7,
+					InactReclaims: 8,
+					Unused:        9,
 				},
 			},
 		},

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -202,6 +202,7 @@ type QuotaManagerStats struct {
 	Wants         uint32
 	ShakeReclaims uint32
 	InactReclaims uint32
+	Unused        uint32
 }
 
 // XstratStats contains statistics regarding bytes processed by the XFS daemon.


### PR DESCRIPTION
Add support for exposing the xs_qm_dquot_unused XFS statistic which appears in
Linux 4.20 and later.

Signed-off-by: Steven Kreuzer <skreuzer@FreeBSD.org>