### PR TITLE
Parse /proc/<pid>/cgroup file

### DIFF
--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -70,7 +70,7 @@ func parseCgroupString(cgroupStr string) (*Cgroup, error) {
 
 // parseCgroups reads each line of the /proc/[pid]/cgroup file
 func parseCgroups(data []byte) ([]*Cgroup, error) {
-	cgroups := []*Cgroup{}
+	var cgroups []*Cgroup
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		mountString := scanner.Text()
@@ -85,9 +85,11 @@ func parseCgroups(data []byte) ([]*Cgroup, error) {
 	return cgroups, err
 }
 
-// GetCgroups returns a Cgroup struct for all process control hierarchies running on this system
-func GetCgroups(pid int) ([]*Cgroup, error) {
-	data, err := util.ReadFileNoStat(fmt.Sprintf("/proc/%d/cgroup", pid))
+// Cgroups reads from /proc/<pid>/cgroups and returns a []*Cgroup struct locating this PID in each process
+// control hierarchy running on this system. On every system (v1 and v2), all hierarchies contain all processes,
+// so the len of the returned struct is equal to the number of active hierarchies on this system
+func (p Proc) Cgroups() ([]*Cgroup, error) {
+	data, err := util.ReadFileNoStat(fmt.Sprintf("/proc/%d/cgroup", p.PID))
 	if err != nil {
 		return nil, err
 	}

--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -26,21 +26,25 @@ import (
 // specific control hierarchy. The kernel has two cgroup APIs, v1 and v2. v1 has one hierarchy per available resource
 // controller, while v2 has one unified hierarchy shared by all controllers. Regardless of v1 or v2, all hierarchies
 // contain all running processes, so the question answerable with a Cgroup struct is 'where is this process in
-// this hierarchy' (where==what path). By prefixing this path with the mount point of this hierarchy, you can locate
-// the relevant pseudo-files needed to read/set the data for this PID in this hierarchy
+// this hierarchy' (where==what path on the specific cgroupfs). By prefixing this path with the mount point of
+// *this specific* hierarchy, you can locate the relevant pseudo-files needed to read/set the data for this PID
+// in this hierarchy
 //
 // Also see http://man7.org/linux/man-pages/man7/cgroups.7.html
 type Cgroup struct {
-	// HierarchyId for cgroups V2 is always 0. For cgroups v1 this is a unique
-	// ID number that can be matched to a hierarchy ID found in /proc/cgroups
+	// HierarchyId that can be matched to a named hierarchy using /proc/cgroups. Cgroups V2 only has one
+	// hierarchy, so HierarchyId is always 0. For cgroups v1 this is a unique ID number
 	HierarchyId int
-	// Controllers using this hierarchy of processes. Controllers are also known as subsystems.
+	// Controllers using this hierarchy of processes. Controllers are also known as subsystems. For
+	// Cgroups V2 this may be empty, as all active controllers use the same hierarchy
 	Controllers []string
-	// Path of this control group, relative to the mount point of the various controllers
+	// Path of this control group, relative to the mount point of the cgroupfs representing this specific
+	// hierarchy
 	Path string
 }
 
 // parseCgroupString parses each line of the /proc/[pid]/cgroup file
+// Line format is hierarchyID:[controller1,controller2]:path
 func parseCgroupString(cgroupStr string) (*Cgroup, error) {
 	var err error
 

--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -17,9 +17,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/prometheus/procfs/internal/util"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 // Cgroup models one line from /proc/[pid]/cgroup. Each Cgroup struct describes the the placement of a PID inside a
@@ -32,9 +33,9 @@ import (
 //
 // Also see http://man7.org/linux/man-pages/man7/cgroups.7.html
 type Cgroup struct {
-	// HierarchyId that can be matched to a named hierarchy using /proc/cgroups. Cgroups V2 only has one
-	// hierarchy, so HierarchyId is always 0. For cgroups v1 this is a unique ID number
-	HierarchyId int
+	// HierarchyID that can be matched to a named hierarchy using /proc/cgroups. Cgroups V2 only has one
+	// hierarchy, so HierarchyID is always 0. For cgroups v1 this is a unique ID number
+	HierarchyID int
 	// Controllers using this hierarchy of processes. Controllers are also known as subsystems. For
 	// Cgroups V2 this may be empty, as all active controllers use the same hierarchy
 	Controllers []string
@@ -57,7 +58,7 @@ func parseCgroupString(cgroupStr string) (*Cgroup, error) {
 		Path:        fields[2],
 		Controllers: nil,
 	}
-	cgroup.HierarchyId, err = strconv.Atoi(fields[0])
+	cgroup.HierarchyID, err = strconv.Atoi(fields[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse hierarchy ID")
 	}

--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -1,0 +1,91 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/prometheus/procfs/internal/util"
+	"strconv"
+	"strings"
+)
+
+// Cgroup models one line from /proc/[pid]/cgroup. Each Cgroup struct describes the the placement of a PID inside a
+// specific control hierarchy. The kernel has two cgroup APIs, v1 and v2. v1 has one hierarchy per available resource
+// controller, while v2 has one unified hierarchy shared by all controllers. Regardless of v1 or v2, all hierarchies
+// contain all running processes, so the question answerable with a Cgroup struct is 'where is this process in
+// this hierarchy' (where==what path). By prefixing this path with the mount point of this hierarchy, you can locate
+// the relevant pseudo-files needed to read/set the data for this PID in this hierarchy
+//
+// Also see http://man7.org/linux/man-pages/man7/cgroups.7.html
+type Cgroup struct {
+	// HierarchyId for cgroups V2 is always 0. For cgroups v1 this is a unique
+	// ID number that can be matched to a hierarchy ID found in /proc/cgroups
+	HierarchyId int
+	// Controllers using this hierarchy of processes. Controllers are also known as subsystems.
+	// TODO is it a problem that len(Controllers)==1 even when there are no controllers?
+	Controllers []string
+	// Path of this control group, relative to the mount point of the various controllers
+	Path string
+}
+
+// parseCgroupString parses each line of the /proc/[pid]/cgroup file
+func parseCgroupString(cgroupStr string) (*Cgroup, error) {
+	var err error
+
+	fields := strings.Split(cgroupStr, ":")
+	if len(fields) != 3 {
+		return nil, fmt.Errorf("incorrect number of fields (%d) in cgroup string: %s", len(fields), cgroupStr)
+	}
+
+	cgroup := &Cgroup{
+		Path: fields[2],
+	}
+	cgroup.HierarchyId, err = strconv.Atoi(fields[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse hierarchy ID")
+	}
+	// fields[1] may be ""
+	ssNames := strings.Split(fields[1], ",")
+	cgroup.Controllers = append(cgroup.Controllers, ssNames...)
+
+	return cgroup, nil
+}
+
+// parseCgroups reads each line of the /proc/[pid]/cgroup file
+func parseCgroups(data []byte) ([]*Cgroup, error) {
+	cgroups := []*Cgroup{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		mountString := scanner.Text()
+		parsedMounts, err := parseCgroupString(mountString)
+		if err != nil {
+			return nil, err
+		}
+		cgroups = append(cgroups, parsedMounts)
+	}
+
+	err := scanner.Err()
+	return cgroups, err
+}
+
+// GetCgroups returns a Cgroup struct for all process control hierarchies running on this system
+func GetCgroups(pid int) ([]*Cgroup, error) {
+	data, err := util.ReadFileNoStat(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return nil, err
+	}
+	return parseCgroups(data)
+}

--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -35,7 +35,6 @@ type Cgroup struct {
 	// ID number that can be matched to a hierarchy ID found in /proc/cgroups
 	HierarchyId int
 	// Controllers using this hierarchy of processes. Controllers are also known as subsystems.
-	// TODO is it a problem that len(Controllers)==1 even when there are no controllers?
 	Controllers []string
 	// Path of this control group, relative to the mount point of the various controllers
 	Path string
@@ -51,16 +50,17 @@ func parseCgroupString(cgroupStr string) (*Cgroup, error) {
 	}
 
 	cgroup := &Cgroup{
-		Path: fields[2],
+		Path:        fields[2],
+		Controllers: nil,
 	}
 	cgroup.HierarchyId, err = strconv.Atoi(fields[0])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse hierarchy ID")
 	}
-	// fields[1] may be ""
-	ssNames := strings.Split(fields[1], ",")
-	cgroup.Controllers = append(cgroup.Controllers, ssNames...)
-
+	if fields[1] != "" {
+		ssNames := strings.Split(fields[1], ",")
+		cgroup.Controllers = append(cgroup.Controllers, ssNames...)
+	}
 	return cgroup, nil
 }
 

--- a/proc_cgroup_test.go
+++ b/proc_cgroup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/proc_cgroup_test.go
+++ b/proc_cgroup_test.go
@@ -51,7 +51,7 @@ func TestParseCgroupString(t *testing.T) {
 			shouldErr: false,
 			cgroup: &Cgroup{
 				HierarchyId: 0,
-				Controllers: []string{""},
+				Controllers: nil,
 				Path:        "/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service",
 			},
 		},

--- a/proc_cgroup_test.go
+++ b/proc_cgroup_test.go
@@ -30,7 +30,7 @@ func TestParseCgroupString(t *testing.T) {
 			s:         "10:rdma:/",
 			shouldErr: false,
 			cgroup: &Cgroup{
-				HierarchyId: 10,
+				HierarchyID: 10,
 				Controllers: []string{"rdma"},
 				Path:        "/",
 			},
@@ -40,7 +40,7 @@ func TestParseCgroupString(t *testing.T) {
 			s:         "3:cpu,cpuacct:/user.slice/user-1000.slice/session-10.scope",
 			shouldErr: false,
 			cgroup: &Cgroup{
-				HierarchyId: 3,
+				HierarchyID: 3,
 				Controllers: []string{"cpu", "cpuacct"},
 				Path:        "/user.slice/user-1000.slice/session-10.scope",
 			},
@@ -50,7 +50,7 @@ func TestParseCgroupString(t *testing.T) {
 			s:         "0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service",
 			shouldErr: false,
 			cgroup: &Cgroup{
-				HierarchyId: 0,
+				HierarchyID: 0,
 				Controllers: nil,
 				Path:        "/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service",
 			},

--- a/proc_cgroup_test.go
+++ b/proc_cgroup_test.go
@@ -1,0 +1,89 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCgroupString(t *testing.T) {
+	tests := []struct {
+		name      string
+		s         string
+		shouldErr bool
+		cgroup    *Cgroup
+	}{
+		{
+			name:      "cgroups-v1 simple line",
+			s:         "10:rdma:/",
+			shouldErr: false,
+			cgroup: &Cgroup{
+				HierarchyId: 10,
+				Controllers: []string{"rdma"},
+				Path:        "/",
+			},
+		},
+		{
+			name:      "cgroups-v1 multi-hier line",
+			s:         "3:cpu,cpuacct:/user.slice/user-1000.slice/session-10.scope",
+			shouldErr: false,
+			cgroup: &Cgroup{
+				HierarchyId: 3,
+				Controllers: []string{"cpu", "cpuacct"},
+				Path:        "/user.slice/user-1000.slice/session-10.scope",
+			},
+		},
+		{
+			name:      "cgroup-v2 line",
+			s:         "0::/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service",
+			shouldErr: false,
+			cgroup: &Cgroup{
+				HierarchyId: 0,
+				Controllers: []string{""},
+				Path:        "/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service",
+			},
+		},
+		{
+			name:      "extra fields",
+			s:         "0::/:foobar",
+			shouldErr: true,
+			cgroup:    nil,
+		},
+		{
+			name:      "bad hierarchy ID field",
+			s:         "a:cpu:/",
+			shouldErr: true,
+			cgroup:    nil,
+		},
+	}
+
+	for i, test := range tests {
+		t.Logf("[%02d] test %q", i, test.name)
+
+		cgroup, err := parseCgroupString(test.s)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("%s: expected an error, but none occurred", test.name)
+		}
+		if !test.shouldErr && err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+		}
+
+		if want, have := test.cgroup, cgroup; !reflect.DeepEqual(want, have) {
+			t.Errorf("cgroup:\nwant:\n%+v\nhave:\n%+v", want, have)
+		}
+	}
+
+}

--- a/proc_cgroup_test.go
+++ b/proc_cgroup_test.go
@@ -56,10 +56,14 @@ func TestParseCgroupString(t *testing.T) {
 			},
 		},
 		{
-			name:      "extra fields",
+			name:      "extra fields (such as those added by later kernel versions)",
 			s:         "0::/:foobar",
-			shouldErr: true,
-			cgroup:    nil,
+			shouldErr: false,
+			cgroup: &Cgroup{
+				HierarchyID: 0,
+				Controllers: nil,
+				Path:        "/",
+			},
 		},
 		{
 			name:      "bad hierarchy ID field",


### PR DESCRIPTION
This is a quick patch to support parsing the per-process cgroup file. Should work OK on both cgroups-v1 and cgroups-v2. 

There is one TODO in the code I could use some feedback on :-) 

I've intentionally not gone too crazy in adding this since it's my first contrib. Future work would be to locate the full path to the cgroup folder per each `Cgroup` struct (this could be accomplished by reading the mount point for that controller hierarchy and then prefixing this to the parsed Path), and also reading the actual subsystem-specific files. I do have some code to handle these later issues but I wanted to get one small change through review before biting off more 

fixes #201 
