### PR TITLE
Unwrap infiband error

### DIFF
--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -97,7 +97,7 @@ func (fs FS) InfiniBandClass() (InfiniBandClass, error) {
 
 	dirs, err := ioutil.ReadDir(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list InfiniBand devices at %q: %v", path, err)
+		return nil, err
 	}
 
 	ibc := make(InfiniBandClass, len(dirs))


### PR DESCRIPTION
Don't wrap the error returned by the infiniband parser so that external
systems can parse the error with `os.IsNotExist(err)`.

Signed-off-by: Ben Kochie <superq@gmail.com>