### PR TITLE
bcache: add priorityStats flag

### DIFF
--- a/bcache/get.go
+++ b/bcache/get.go
@@ -51,21 +51,21 @@ func NewFS(mountPoint string) (FS, error) {
 	return FS{&fs}, nil
 }
 
-// Stats is a wrapper around _Stats
+// Stats is a wrapper around stats()
 // It returns full available statistics
 func (fs FS) Stats() ([]*Stats, error) {
-	return fs._Stats(true)
+	return fs.stats(true)
 }
 
-// StatsWithoutPriority is a wrapper around _Stats.
+// StatsWithoutPriority is a wrapper around stats().
 // It ignores priority_stats file, because it is expensive to read.
 func (fs FS) StatsWithoutPriority() ([]*Stats, error) {
-	return fs._Stats(false)
+	return fs.stats(false)
 }
 
-// _Stats retrieves bcache runtime statistics for each bcache.
+// stats() retrieves bcache runtime statistics for each bcache.
 // priorityStats flag controls if we need to read priority_stats.
-func (fs FS) _Stats(priorityStats bool) ([]*Stats, error) {
+func (fs FS) stats(priorityStats bool) ([]*Stats, error) {
 	matches, err := filepath.Glob(fs.sys.Path("fs/bcache/*-*"))
 	if err != nil {
 		return nil, err

--- a/bcache/get.go
+++ b/bcache/get.go
@@ -52,7 +52,7 @@ func NewFS(mountPoint string) (FS, error) {
 }
 
 // Stats retrieves bcache runtime statistics for each bcache.
-func (fs FS) Stats() ([]*Stats, error) {
+func (fs FS) Stats(priorityStats bool) ([]*Stats, error) {
 	matches, err := filepath.Glob(fs.sys.Path("fs/bcache/*-*"))
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (fs FS) Stats() ([]*Stats, error) {
 		name := filepath.Base(uuidPath)
 
 		// stats
-		s, err := GetStats(uuidPath)
+		s, err := GetStats(uuidPath, priorityStats)
 		if err != nil {
 			return nil, err
 		}
@@ -251,7 +251,7 @@ func (p *parser) getPriorityStats() PriorityStats {
 }
 
 // GetStats collects from sysfs files data tied to one bcache ID.
-func GetStats(uuidPath string) (*Stats, error) {
+func GetStats(uuidPath string, priorityStats bool) (*Stats, error) {
 	var bs Stats
 
 	par := parser{uuidPath: uuidPath}
@@ -370,8 +370,10 @@ func GetStats(uuidPath string) (*Stats, error) {
 		cs.MetadataWritten = par.readValue("metadata_written")
 		cs.Written = par.readValue("written")
 
-		ps := par.getPriorityStats()
-		cs.Priority = ps
+		if priorityStats {
+			ps := par.getPriorityStats()
+			cs.Priority = ps
+		}
 	}
 
 	if par.err != nil {

--- a/bcache/get.go
+++ b/bcache/get.go
@@ -51,34 +51,21 @@ func NewFS(mountPoint string) (FS, error) {
 	return FS{&fs}, nil
 }
 
-// Stats retrieves bcache runtime statistics for each bcache.
+// Stats is a wrapper around _Stats
+// It returns full available statistics
 func (fs FS) Stats() ([]*Stats, error) {
-	matches, err := filepath.Glob(fs.sys.Path("fs/bcache/*-*"))
-	if err != nil {
-		return nil, err
-	}
-
-	stats := make([]*Stats, 0, len(matches))
-	for _, uuidPath := range matches {
-		// "*-*" in glob above indicates the name of the bcache.
-		name := filepath.Base(uuidPath)
-
-		// stats
-		s, err := GetStats(uuidPath, true)
-		if err != nil {
-			return nil, err
-		}
-
-		s.Name = name
-		stats = append(stats, s)
-	}
-
-	return stats, nil
+	return fs._Stats(true)
 }
 
-// StatsWithoutPriority retrieves bcache runtime statistics for each bcache.
+// StatsWithoutPriority is a wrapper around _Stats.
 // It ignores priority_stats file, because it is expensive to read.
 func (fs FS) StatsWithoutPriority() ([]*Stats, error) {
+	return fs._Stats(false)
+}
+
+// _Stats retrieves bcache runtime statistics for each bcache.
+// priorityStats flag controls if we need to read priority_stats.
+func (fs FS) _Stats(priorityStats bool) ([]*Stats, error) {
 	matches, err := filepath.Glob(fs.sys.Path("fs/bcache/*-*"))
 	if err != nil {
 		return nil, err
@@ -90,7 +77,7 @@ func (fs FS) StatsWithoutPriority() ([]*Stats, error) {
 		name := filepath.Base(uuidPath)
 
 		// stats
-		s, err := GetStats(uuidPath, false)
+		s, err := GetStats(uuidPath, priorityStats)
 		if err != nil {
 			return nil, err
 		}

--- a/bcache/get_test.go
+++ b/bcache/get_test.go
@@ -23,7 +23,7 @@ func TestFSBcacheStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to access bcache fs: %v", err)
 	}
-	stats, err := bcache.Stats()
+	stats, err := bcache.Stats(true)
 	if err != nil {
 		t.Fatalf("failed to parse bcache stats: %v", err)
 	}

--- a/bcache/get_test.go
+++ b/bcache/get_test.go
@@ -23,7 +23,7 @@ func TestFSBcacheStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to access bcache fs: %v", err)
 	}
-	stats, err := bcache.Stats(true)
+	stats, err := bcache.Stats()
 	if err != nil {
 		t.Fatalf("failed to parse bcache stats: %v", err)
 	}


### PR DESCRIPTION
bcache: add priorityStats flag

This commit adds priorityStats flag,
which is used when we need priority stats info.

The reason for this flag to be false is that
collecting of priority stats might be expensive
as described here:
https://github.com/prometheus/node_exporter/issues/1593

Signed-off-by: Aleksei Zakharov <zaharov@selectel.ru>