### PR TITLE
Ignore infiniband files that report 'permission denied'

### DIFF
--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -251,7 +251,7 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
@@ -334,7 +334,7 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %v", name, err)

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -119,7 +119,7 @@ func (nc NetClass) parseNetClassIface(devicePath string) (*NetClassIface, error)
 		name := filepath.Join(devicePath, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %v", name, err)


### PR DESCRIPTION
Example files at `/sys/class/net/ib0/`:

```
--w-------  1 root root 4096 Mar 12 11:34 create_child
--w-------  1 root root 4096 Mar 12 11:34 delete_child
```

This would resolve #272 and https://github.com/prometheus/node_exporter/issues/1634