### PR TITLE
sysfs : Functionality to read /sys/class/net/<device>/statistics 

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -2885,6 +2885,129 @@ Lines: 1
 1000
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/net/eth0/statistics
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/collisions
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/multicast
+Lines: 1
+685
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_bytes
+Lines: 1
+67684
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_compressed
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_crc_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_dropped
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_fifo_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_frame_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_length_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_missed_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_nohandler
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_over_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/rx_packets
+Lines: 1
+869
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_aborted_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_bytes
+Lines: 1
+2113
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_carrier_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_compressed
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_dropped
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_fifo_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_heartbeat_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_packets
+Lines: 1
+11
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/net/eth0/statistics/tx_window_errors
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/class/net/eth0/tx_queue_len
 Lines: 1
 1000

--- a/sysfs/net_class_test.go
+++ b/sysfs/net_class_test.go
@@ -69,6 +69,30 @@ func TestNetClass(t *testing.T) {
 		speed            int64 = 1000
 		txQueueLen       int64 = 1000
 		netType          int64 = 1
+		collisions       int64
+		multicast        int64 = 685
+		rxBytes          int64 = 67684
+		rxCompressed     int64
+		rxCrcErrors      int64
+		rxDropped        int64
+		rxErrrors        int64
+		rxFifoErrors     int64
+		rxFrameErrors    int64
+		rxLengthErrors   int64
+		rxMissedErrors   int64
+		rxNoHandler      int64
+		rxOverErrors     int64
+		rxPackets        int64 = 869
+		txAbortedErrors  int64
+		txBytes          int64 = 2113
+		txCarrierErrors  int64
+		txCompressed     int64
+		txDropped        int64
+		txErrors         int64
+		txFifoErrors     int64
+		txHeartbtErrors  int64
+		txPackets        int64 = 11
+		txWindowErrors   int64
 	)
 
 	netClass := NetClass{
@@ -100,6 +124,30 @@ func TestNetClass(t *testing.T) {
 			Speed:            &speed,
 			TxQueueLen:       &txQueueLen,
 			Type:             &netType,
+			Collisions:       &collisions,
+			Multicast:        &multicast,
+			RxBytes:          &rxBytes,
+			RxCompressed:     &rxCompressed,
+			RxCrcErrors:      &rxCrcErrors,
+			RxDropped:        &rxDropped,
+			RxErrors:         &rxErrrors,
+			RxFifoErrors:     &rxFifoErrors,
+			RxFrameErrors:    &rxFrameErrors,
+			RxLengthErrors:   &rxLengthErrors,
+			RxMissedErrors:   &rxMissedErrors,
+			RxNoHandler:      &rxNoHandler,
+			RxOverErrors:     &rxOverErrors,
+			RxPackets:        &rxPackets,
+			TxAbortedErrors:  &txAbortedErrors,
+			TxBytes:          &txBytes,
+			TxCarrierErrors:  &txCarrierErrors,
+			TxCompressed:     &txCompressed,
+			TxDropped:        &txDropped,
+			TxErrors:         &txErrors,
+			TxFifoErrors:     &txFifoErrors,
+			TxHeartbtErrors:  &txHeartbtErrors,
+			TxPackets:        &txPackets,
+			TxWindowErrors:   &txWindowErrors,
 		},
 	}
 


### PR DESCRIPTION
/proc/net/dev does not always show all adapters that one is interested in, however, the statistics folder has pertinent information such as tx_bytes and rx_bytes that shows similar network traffic.

On my managed K8S environment, I needed these values to show the underlying worker node's network traffic accurately. Since net/dev didn't show me all the adapters I was interested in (calico, enp0s* etc.) I needed a reliable way to find these values. The statistics sub-directory has these metrics and so this feature addon extends the current sysfs functionality to add these metrics.

Assuming this is approved, the next PR will be in nodeexporter to expose these metrics

[For more information](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net-statistics)