### PR TITLE
Add ProcSMaps from smaps file

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -173,6 +173,283 @@ Lines: 1
 411605849 93680043 79
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/26231/smaps
+Lines: 273
+561c3902b000-561c39757000 r-xp 00000000 fd:01 664619                     /usr/lib/postgresql/11/bin/postgres
+Size:               7344 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                5264 kB
+Pss:                 756 kB
+Shared_Clean:       5264 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:         5264 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd ex mr mw me dw sd 
+561c39957000-561c3997a000 r--p 0072c000 fd:01 664619                     /usr/lib/postgresql/11/bin/postgres
+Size:                140 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                 136 kB
+Pss:                   9 kB
+Shared_Clean:          0 kB
+Shared_Dirty:        136 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:           80 kB
+Anonymous:           136 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  4 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd mr mw me dw ac sd 
+561c39988000-561c399f9000 rw-p 00000000 00:00 0 
+Size:                452 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                  56 kB
+Pss:                  52 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          4 kB
+Private_Clean:         0 kB
+Private_Dirty:        52 kB
+Referenced:           48 kB
+Anonymous:            56 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me ac sd 
+561c3a0e9000-561c3a160000 rw-p 00000000 00:00 0                          [heap]
+Size:                476 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                 372 kB
+Pss:                 202 kB
+Shared_Clean:          0 kB
+Shared_Dirty:        184 kB
+Private_Clean:         0 kB
+Private_Dirty:       188 kB
+Referenced:          124 kB
+Anonymous:           372 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me ac sd 
+561c3a160000-561c3a2a4000 rw-p 00000000 00:00 0                          [heap]
+Size:               1296 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                1012 kB
+Pss:                1012 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:      1012 kB
+Referenced:          484 kB
+Anonymous:          1012 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me ac sd 
+7f9d3ad33000-7f9d3ad3d000 r-xp 00000000 fd:01 657391                     /lib/x86_64-linux-gnu/libnss_files-2.24.so
+Size:                 40 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd ex mr mw me sd 
+7f9d3af45000-7f9d43cf1000 rw-s 00000000 00:05 348923                     /dev/zero (deleted)
+Size:             145072 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                4392 kB
+Pss:                 789 kB
+Shared_Clean:          0 kB
+Shared_Dirty:       4392 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:         4280 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr sh mr mw me ms sd 
+7f9d4bff8000-7f9d4bffa000 rw-s 00000000 00:109 3                         /dev/shm/PostgreSQL.1973848873
+Size:                  8 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  4 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr sh mr mw ms sd 
+7f9d4bffa000-7f9d4bffb000 rw-s 00000000 00:05 0                          /SYSV0052e2c1 (deleted)
+Size:                  4 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr sh mr mw me ms sd 
+7ffda435e000-7ffda437f000 rw-p 00000000 00:00 0                          [stack]
+Size:                132 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                  32 kB
+Pss:                  32 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:        32 kB
+Referenced:           16 kB
+Anonymous:            32 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me gd ac 
+7ffda43f7000-7ffda43fa000 r--p 00000000 00:00 0                          [vvar]
+Size:                 12 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd mr pf io de dd sd 
+7ffda43fa000-7ffda43fc000 r-xp 00000000 00:00 0                          [vdso]
+Size:                  8 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   4 kB
+Pss:                   0 kB
+Shared_Clean:          4 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            4 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd ex mr mw me de sd 
+ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
+Size:                  4 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd ex 
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/26231/stat
 Lines: 1
 26231 (vim) R 5392 7446 5392 34835 7446 4218880 32533 309516 26 82 1677 44 158 99 20 0 1 0 82375 56274944 1981 18446744073709551615 4194304 6294284 140736914091744 140736914087944 139965136429984 0 0 12288 1870679807 0 0 0 17 0 0 0 31 0 0 8391624 8481048 16420864 140736914093252 140736914093279 140736914093279 140736914096107 0

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -1,0 +1,246 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package procfs
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type ProcSMaps []*ProcSMap
+
+type ProcSMap struct {
+	*ProcMap
+	// Size of the mapping
+	Size uint64
+	// Amount of the mapping that is currently resident in RAM
+	Rss uint64
+	// Process's proportional share of this mapping
+	Pss uint64
+	// Size in bytes of clean shared pages
+	SharedClean uint64
+	// Size in bytes of dirty shared pages
+	SharedDirty uint64
+	// Size in bytes of clean private pages
+	PrivateClean uint64
+	// Size in bytes of dirty private pages
+	PrivateDirty uint64
+	// Amount of memory currently marked as referenced or accessed
+	Referenced uint64
+	// Amount of memory that does not belong to any file
+	Anonymous uint64
+	// Amount would-be-anonymous memory currently on swap
+	Swap uint64
+	// Process's proportional memory on swap
+	SwapPss uint64
+	// Page size used by the kernel to back the virtual memory area
+	KernelPageSize uint64
+	// Page size used by the processor MMU to back the virtual memory area
+	MMUPageSize uint64
+	// Kernel flags associated with the virtual memory area
+	VMFlags string
+}
+
+// SizeSum returns the sum of Pss from all mappings
+func (s ProcSMaps) SizeSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.Size
+	}
+
+	return
+}
+
+// RssSum returns the sum of Pss from all mappings
+func (s ProcSMaps) RssSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.Rss
+	}
+
+	return
+}
+
+// PssSum returns the sum of Pss from all mappings
+func (s ProcSMaps) PssSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.Pss
+	}
+
+	return
+}
+
+// SharedCleanSum returns the sum of Pss from all mappings
+func (s ProcSMaps) SharedCleanSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.SharedClean
+	}
+
+	return
+}
+
+// SharedDirtySum returns the sum of Pss from all mappings
+func (s ProcSMaps) SharedDirtySum() (sum uint64) {
+	for _, x := range s {
+		sum += x.SharedDirty
+	}
+
+	return
+}
+
+// PrivateCleanSum returns the sum of Pss from all mappings
+func (s ProcSMaps) PrivateCleanSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.PrivateClean
+	}
+
+	return
+}
+
+// PrivateDirtySum returns the sum of Pss from all mappings
+func (s ProcSMaps) PrivateDirtySum() (sum uint64) {
+	for _, x := range s {
+		sum += x.PrivateDirty
+	}
+
+	return
+}
+
+// ReferencedSum returns the sum of Pss from all mappings
+func (s ProcSMaps) ReferencedSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.Referenced
+	}
+
+	return
+}
+
+// AnonymousSum returns the sum of Pss from all mappings
+func (s ProcSMaps) AnonymousSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.Anonymous
+	}
+
+	return
+}
+
+// SwapSum returns the sum of Pss from all mappings
+func (s ProcSMaps) SwapSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.Swap
+	}
+
+	return
+}
+
+// SwapPssSum returns the sum of Pss from all mappings
+func (s ProcSMaps) SwapPssSum() (sum uint64) {
+	for _, x := range s {
+		sum += x.SwapPss
+	}
+
+	return
+}
+
+// ProcSMaps reads from /proc/[pid]/maps to get the memory-mappings of the
+// process.
+func (p Proc) ProcSMaps() (ProcSMaps, error) {
+	file, err := os.Open(p.path("smaps"))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var currentMap *ProcSMap
+
+	smaps := []*ProcSMap{}
+	scan := bufio.NewScanner(file)
+
+	for scan.Scan() {
+		line := scan.Text()
+		// first line of a mapping start with an hexadecimal address in lower-case
+		// All other line start with a capitalized words.
+		if (line[0] >= '0' && line[0] <= '9') || (line[0] >= 'a' && line[0] <= 'f') {
+			if currentMap != nil {
+				smaps = append(smaps, currentMap)
+			}
+
+			m, err := parseProcMap(line)
+			if err != nil {
+				return nil, err
+			}
+
+			currentMap = &ProcSMap{
+				ProcMap: m,
+			}
+
+			continue
+		}
+
+		kv := strings.SplitN(line, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+
+		k := kv[0]
+		v := strings.TrimSpace(kv[1])
+		v = strings.TrimRight(v, " kB")
+
+		vKBytes, _ := strconv.ParseUint(v, 10, 64)
+		vBytes := vKBytes * 1024
+
+		currentMap.fillValue(k, v, vKBytes, vBytes)
+	}
+
+	if currentMap != nil {
+		smaps = append(smaps, currentMap)
+	}
+
+	return smaps, nil
+}
+
+func (s *ProcSMap) fillValue(k string, vString string, vUint uint64, vUintBytes uint64) {
+	switch k {
+	case "Size":
+		s.Size = vUintBytes
+	case "Rss":
+		s.Rss = vUintBytes
+	case "Pss":
+		s.Pss = vUintBytes
+	case "Shared_Clean":
+		s.SharedClean = vUintBytes
+	case "Shared_Dirty":
+		s.SharedDirty = vUintBytes
+	case "Private_Clean":
+		s.PrivateClean = vUintBytes
+	case "Private_Dirty":
+		s.PrivateDirty = vUintBytes
+	case "Referenced":
+		s.Referenced = vUintBytes
+	case "Anonymous":
+		s.Anonymous = vUintBytes
+	case "Swap":
+		s.Swap = vUintBytes
+	case "SwapPss":
+		s.SwapPss = vUintBytes
+	case "KernelPageSize":
+		s.KernelPageSize = vUintBytes
+	case "MMUPageSize":
+		s.MMUPageSize = vUintBytes
+	case "VmFlags":
+		s.VMFlags = vString
+	}
+}

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -199,7 +199,12 @@ func (p Proc) ProcSMaps() (ProcSMaps, error) {
 		v := strings.TrimSpace(kv[1])
 		v = strings.TrimRight(v, " kB")
 
-		vKBytes, _ := strconv.ParseUint(v, 10, 64)
+		vKBytes, err := strconv.ParseUint(v, 10, 64)
+
+		// VmFlags is the only field which is not a number, ignore parse error for it.
+		if err != nil && k != "VmFlags" {
+			return nil, err
+		}
 		vBytes := vKBytes * 1024
 
 		currentMap.fillValue(k, v, vKBytes, vBytes)

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -56,7 +56,7 @@ type ProcSMap struct {
 	VMFlags string
 }
 
-// SizeSum returns the sum of Pss from all mappings
+// SizeSum returns the sum of all mappings
 func (s ProcSMaps) SizeSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.Size
@@ -65,7 +65,7 @@ func (s ProcSMaps) SizeSum() (sum uint64) {
 	return
 }
 
-// RssSum returns the sum of Pss from all mappings
+// RssSum returns the sum of all mappings
 func (s ProcSMaps) RssSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.Rss
@@ -74,7 +74,7 @@ func (s ProcSMaps) RssSum() (sum uint64) {
 	return
 }
 
-// PssSum returns the sum of Pss from all mappings
+// PssSum returns the sum of all mappings
 func (s ProcSMaps) PssSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.Pss
@@ -83,7 +83,7 @@ func (s ProcSMaps) PssSum() (sum uint64) {
 	return
 }
 
-// SharedCleanSum returns the sum of Pss from all mappings
+// SharedCleanSum returns the sum of all mappings
 func (s ProcSMaps) SharedCleanSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.SharedClean
@@ -92,7 +92,7 @@ func (s ProcSMaps) SharedCleanSum() (sum uint64) {
 	return
 }
 
-// SharedDirtySum returns the sum of Pss from all mappings
+// SharedDirtySum returns the sum of all mappings
 func (s ProcSMaps) SharedDirtySum() (sum uint64) {
 	for _, x := range s {
 		sum += x.SharedDirty
@@ -101,7 +101,7 @@ func (s ProcSMaps) SharedDirtySum() (sum uint64) {
 	return
 }
 
-// PrivateCleanSum returns the sum of Pss from all mappings
+// PrivateCleanSum returns the sum of all mappings
 func (s ProcSMaps) PrivateCleanSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.PrivateClean
@@ -110,7 +110,7 @@ func (s ProcSMaps) PrivateCleanSum() (sum uint64) {
 	return
 }
 
-// PrivateDirtySum returns the sum of Pss from all mappings
+// PrivateDirtySum returns the sum of all mappings
 func (s ProcSMaps) PrivateDirtySum() (sum uint64) {
 	for _, x := range s {
 		sum += x.PrivateDirty
@@ -119,7 +119,7 @@ func (s ProcSMaps) PrivateDirtySum() (sum uint64) {
 	return
 }
 
-// ReferencedSum returns the sum of Pss from all mappings
+// ReferencedSum returns the sum of all mappings
 func (s ProcSMaps) ReferencedSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.Referenced
@@ -128,7 +128,7 @@ func (s ProcSMaps) ReferencedSum() (sum uint64) {
 	return
 }
 
-// AnonymousSum returns the sum of Pss from all mappings
+// AnonymousSum returns the sum of all mappings
 func (s ProcSMaps) AnonymousSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.Anonymous
@@ -137,7 +137,7 @@ func (s ProcSMaps) AnonymousSum() (sum uint64) {
 	return
 }
 
-// SwapSum returns the sum of Pss from all mappings
+// SwapSum returns the sum of all mappings
 func (s ProcSMaps) SwapSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.Swap
@@ -146,7 +146,7 @@ func (s ProcSMaps) SwapSum() (sum uint64) {
 	return
 }
 
-// SwapPssSum returns the sum of Pss from all mappings
+// SwapPssSum returns the sum of all mappings
 func (s ProcSMaps) SwapPssSum() (sum uint64) {
 	for _, x := range s {
 		sum += x.SwapPss

--- a/proc_smaps_test.go
+++ b/proc_smaps_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package procfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sys/unix"
+)
+
+func TestProcSmaps(t *testing.T) {
+	p, err := getProcFixtures(t).Proc(26231)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := p.ProcSMaps()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		want int
+		have int
+	}{
+		{name: "length", want: 13, have: len(s)},
+		{name: "SizeSum", want: 154988 * 1024, have: int(s.SizeSum())},
+		{name: "SizeSum", want: 11268 * 1024, have: int(s.RssSum())},
+		{name: "SizeSum", want: 2852 * 1024, have: int(s.PssSum())},
+		{name: "SizeSum", want: 5268 * 1024, have: int(s.SharedCleanSum())},
+		{name: "SizeSum", want: 4716 * 1024, have: int(s.SharedDirtySum())},
+		{name: "SizeSum", want: 0 * 1024, have: int(s.PrivateCleanSum())},
+		{name: "SizeSum", want: 1284 * 1024, have: int(s.PrivateDirtySum())},
+		{name: "SizeSum", want: 10300 * 1024, have: int(s.ReferencedSum())},
+		{name: "SizeSum", want: 1608 * 1024, have: int(s.AnonymousSum())},
+		{name: "SizeSum", want: 8 * 1024, have: int(s.SwapSum())},
+		{name: "SizeSum", want: 0 * 1024, have: int(s.SwapPssSum())},
+	} {
+		if test.want != test.have {
+			t.Errorf("want %s %d, have %d", test.name, test.want, test.have)
+		}
+	}
+
+	wantMap := &ProcMap{
+		StartAddr: 0x561c3902b000,
+		EndAddr:   0x561c39757000,
+		Perms:     &ProcMapPermissions{true, false, true, false, true},
+		Offset:    0,
+		Dev:       unix.Mkdev(0xfd, 0x01),
+		Inode:     664619,
+		Pathname:  "/usr/lib/postgresql/11/bin/postgres",
+	}
+
+	if len(s) > 0 {
+		if diff := cmp.Diff(wantMap, s[0].ProcMap); diff != "" {
+			t.Fatalf("unexpected proc/map entry (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/proc_smaps_test.go
+++ b/proc_smaps_test.go
@@ -22,6 +22,23 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func BenchmarkProcSmaps(b *testing.B) {
+	fs, err := NewFS(procTestFixtures)
+	if err != nil {
+		b.Fatalf("Creating pseudo fs from getProcFixtures failed at fixtures/proc with error: %s", err)
+	}
+
+	p, err := fs.Proc(26231)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = p.ProcSMaps()
+	}
+}
+
 func TestProcSmaps(t *testing.T) {
 	p, err := getProcFixtures(t).Proc(26231)
 	if err != nil {

--- a/proc_smaps_test.go
+++ b/proc_smaps_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
The smaps file contains information not available though existing source.

The one that interest me here is the "Pss" and "SwapPss" which is the process proportional usage of resident memory and swap respectively (which is I think the pages size divided by the number of process that share those pages).

I need this to expose a more significant memory usage for a group of process for prometheus process-exporter (https://github.com/ncabatoff/process-exporter/issues/140)