### PR TITLE
Add several Infiniband counters

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -2595,6 +2595,11 @@ Mode: 755
 Directory: fixtures/sys/class/infiniband/mlx4_0/ports/1/counters
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/mlx4_0/ports/1/counters/VL15_dropped
+Lines: 1
+0
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/class/infiniband/mlx4_0/ports/1/counters/excessive_buffer_overrun_errors
 Lines: 1
 0
@@ -2695,6 +2700,11 @@ Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/infiniband/mlx4_0/ports/2/counters
 Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/mlx4_0/ports/2/counters/VL15_dropped
+Lines: 1
+0
+Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/class/infiniband/mlx4_0/ports/2/counters/excessive_buffer_overrun_errors
 Lines: 1

--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -42,22 +42,26 @@ type InfiniBandCounters struct {
 	LegacyPortXmitData64           *uint64 // counters_ext/port_xmit_data_64
 	LegacyPortXmitPackets64        *uint64 // counters_ext/port_xmit_packets_64
 
-	LinkDowned               *uint64 // counters/link_downed
-	LinkErrorRecovery        *uint64 // counters/link_error_recovery
-	MulticastRcvPackets      *uint64 // counters/multicast_rcv_packets
-	MulticastXmitPackets     *uint64 // counters/multicast_xmit_packets
-	PortRcvConstraintErrors  *uint64 // counters/port_rcv_constraint_errors
-	PortRcvData              *uint64 // counters/port_rcv_data
-	PortRcvDiscards          *uint64 // counters/port_rcv_discards
-	PortRcvErrors            *uint64 // counters/port_rcv_errors
-	PortRcvPackets           *uint64 // counters/port_rcv_packets
-	PortXmitConstraintErrors *uint64 // counters/port_xmit_constraint_errors
-	PortXmitData             *uint64 // counters/port_xmit_data
-	PortXmitDiscards         *uint64 // counters/port_xmit_discards
-	PortXmitPackets          *uint64 // counters/port_xmit_packets
-	PortXmitWait             *uint64 // counters/port_xmit_wait
-	UnicastRcvPackets        *uint64 // counters/unicast_rcv_packets
-	UnicastXmitPackets       *uint64 // counters/unicast_xmit_packets
+	LinkDowned                  *uint64 // counters/link_downed
+	LinkErrorRecovery           *uint64 // counters/link_error_recovery
+	MulticastRcvPackets         *uint64 // counters/multicast_rcv_packets
+	MulticastXmitPackets        *uint64 // counters/multicast_xmit_packets
+	PortRcvConstraintErrors     *uint64 // counters/port_rcv_constraint_errors
+	PortRcvData                 *uint64 // counters/port_rcv_data
+	PortRcvDiscards             *uint64 // counters/port_rcv_discards
+	PortRcvErrors               *uint64 // counters/port_rcv_errors
+	PortRcvPackets              *uint64 // counters/port_rcv_packets
+	PortRcvRemotePhysicalErrors *uint64 // counters/port_rcv_remote_physical_errors
+	PortRcvSwitchRelayErrors    *uint64 // counters/port_rcv_switch_relay_errors
+	PortXmitConstraintErrors    *uint64 // counters/port_xmit_constraint_errors
+	PortXmitData                *uint64 // counters/port_xmit_data
+	PortXmitDiscards            *uint64 // counters/port_xmit_discards
+	PortXmitPackets             *uint64 // counters/port_xmit_packets
+	PortXmitWait                *uint64 // counters/port_xmit_wait
+	SymbolError                 *uint64 // counters/symbol_error
+	UnicastRcvPackets           *uint64 // counters/unicast_rcv_packets
+	UnicastXmitPackets          *uint64 // counters/unicast_xmit_packets
+	VL15Dropped                 *uint64 // counters/VL15_dropped
 }
 
 // InfiniBandPort contains info from files in
@@ -287,6 +291,10 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 			counters.PortRcvErrors = vp.PUInt64()
 		case "port_rcv_packets":
 			counters.PortRcvPackets = vp.PUInt64()
+		case "port_rcv_remote_physical_errors":
+			counters.PortRcvRemotePhysicalErrors = vp.PUInt64()
+		case "port_rcv_switch_relay_errors":
+			counters.PortRcvSwitchRelayErrors = vp.PUInt64()
 		case "port_xmit_constraint_errors":
 			counters.PortXmitConstraintErrors = vp.PUInt64()
 		case "port_xmit_data":
@@ -300,10 +308,14 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 			counters.PortXmitPackets = vp.PUInt64()
 		case "port_xmit_wait":
 			counters.PortXmitWait = vp.PUInt64()
+		case "symbol_error":
+			counters.SymbolError = vp.PUInt64()
 		case "unicast_rcv_packets":
 			counters.UnicastRcvPackets = vp.PUInt64()
 		case "unicast_xmit_packets":
 			counters.UnicastXmitPackets = vp.PUInt64()
+		case "VL15_dropped":
+			counters.VL15Dropped = vp.PUInt64()
 		}
 
 		if err := vp.Err(); err != nil {

--- a/sysfs/class_infiniband_test.go
+++ b/sysfs/class_infiniband_test.go
@@ -59,29 +59,37 @@ func TestInfiniBandClass(t *testing.T) {
 	}
 
 	var (
-		port1LinkDowned               uint64
-		port1LinkErrorRecovery        uint64
-		port1PortRcvConstraintErrors  uint64
-		port1PortRcvData              uint64 = 8884894436
-		port1PortRcvErrors            uint64
-		port1PortRcvPackets           uint64 = 87169372
-		port1PortXmitConstraintErrors uint64
-		port1PortXmitData             uint64 = 106036453180
-		port1PortXmitDiscards         uint64
-		port1PortXmitPackets          uint64 = 85734114
-		port1PortXmitWait             uint64 = 3599
+		port1LinkDowned                  uint64
+		port1LinkErrorRecovery           uint64
+		port1PortRcvConstraintErrors     uint64
+		port1PortRcvData                 uint64 = 8884894436
+		port1PortRcvErrors               uint64
+		port1PortRcvPackets              uint64 = 87169372
+		port1PortRcvRemotePhysicalErrors uint64
+		port1PortRcvSwitchRelayErrors    uint64
+		port1PortXmitConstraintErrors    uint64
+		port1PortXmitData                uint64 = 106036453180
+		port1PortXmitDiscards            uint64
+		port1PortXmitPackets             uint64 = 85734114
+		port1PortXmitWait                uint64 = 3599
+		port1SymbolError                 uint64
+		port1VL15Dropped                 uint64
 
-		port2LinkDowned               uint64
-		port2LinkErrorRecovery        uint64
-		port2PortRcvConstraintErrors  uint64
-		port2PortRcvData              uint64 = 9841747136
-		port2PortRcvErrors            uint64
-		port2PortRcvPackets           uint64 = 89332064
-		port2PortXmitConstraintErrors uint64
-		port2PortXmitData             uint64 = 106161427560
-		port2PortXmitDiscards         uint64
-		port2PortXmitPackets          uint64 = 88622850
-		port2PortXmitWait             uint64 = 3846
+		port2LinkDowned                  uint64
+		port2LinkErrorRecovery           uint64
+		port2PortRcvConstraintErrors     uint64
+		port2PortRcvData                 uint64 = 9841747136
+		port2PortRcvErrors               uint64
+		port2PortRcvPackets              uint64 = 89332064
+		port2PortRcvRemotePhysicalErrors uint64
+		port2PortRcvSwitchRelayErrors    uint64
+		port2PortXmitConstraintErrors    uint64
+		port2PortXmitData                uint64 = 106161427560
+		port2PortXmitDiscards            uint64
+		port2PortXmitPackets             uint64 = 88622850
+		port2PortXmitWait                uint64 = 3846
+		port2SymbolError                 uint64
+		port2VL15Dropped                 uint64
 	)
 
 	want := InfiniBandClass{
@@ -100,17 +108,21 @@ func TestInfiniBandClass(t *testing.T) {
 					PhysStateID: 5,
 					Rate:        5000000000,
 					Counters: InfiniBandCounters{
-						LinkDowned:               &port1LinkDowned,
-						LinkErrorRecovery:        &port1LinkErrorRecovery,
-						PortRcvConstraintErrors:  &port1PortRcvConstraintErrors,
-						PortRcvData:              &port1PortRcvData,
-						PortRcvErrors:            &port1PortRcvErrors,
-						PortRcvPackets:           &port1PortRcvPackets,
-						PortXmitConstraintErrors: &port1PortXmitConstraintErrors,
-						PortXmitData:             &port1PortXmitData,
-						PortXmitDiscards:         &port1PortXmitDiscards,
-						PortXmitPackets:          &port1PortXmitPackets,
-						PortXmitWait:             &port1PortXmitWait,
+						LinkDowned:                  &port1LinkDowned,
+						LinkErrorRecovery:           &port1LinkErrorRecovery,
+						PortRcvConstraintErrors:     &port1PortRcvConstraintErrors,
+						PortRcvData:                 &port1PortRcvData,
+						PortRcvErrors:               &port1PortRcvErrors,
+						PortRcvPackets:              &port1PortRcvPackets,
+						PortRcvRemotePhysicalErrors: &port1PortRcvRemotePhysicalErrors,
+						PortRcvSwitchRelayErrors:    &port1PortRcvSwitchRelayErrors,
+						PortXmitConstraintErrors:    &port1PortXmitConstraintErrors,
+						PortXmitData:                &port1PortXmitData,
+						PortXmitDiscards:            &port1PortXmitDiscards,
+						PortXmitPackets:             &port1PortXmitPackets,
+						PortXmitWait:                &port1PortXmitWait,
+						SymbolError:                 &port1SymbolError,
+						VL15Dropped:                 &port1VL15Dropped,
 					},
 				},
 				2: {
@@ -122,17 +134,21 @@ func TestInfiniBandClass(t *testing.T) {
 					PhysStateID: 5,
 					Rate:        5000000000,
 					Counters: InfiniBandCounters{
-						LinkDowned:               &port2LinkDowned,
-						LinkErrorRecovery:        &port2LinkErrorRecovery,
-						PortRcvConstraintErrors:  &port2PortRcvConstraintErrors,
-						PortRcvData:              &port2PortRcvData,
-						PortRcvErrors:            &port2PortRcvErrors,
-						PortRcvPackets:           &port2PortRcvPackets,
-						PortXmitConstraintErrors: &port2PortXmitConstraintErrors,
-						PortXmitData:             &port2PortXmitData,
-						PortXmitDiscards:         &port2PortXmitDiscards,
-						PortXmitPackets:          &port2PortXmitPackets,
-						PortXmitWait:             &port2PortXmitWait,
+						LinkDowned:                  &port2LinkDowned,
+						LinkErrorRecovery:           &port2LinkErrorRecovery,
+						PortRcvConstraintErrors:     &port2PortRcvConstraintErrors,
+						PortRcvData:                 &port2PortRcvData,
+						PortRcvErrors:               &port2PortRcvErrors,
+						PortRcvPackets:              &port2PortRcvPackets,
+						PortRcvRemotePhysicalErrors: &port2PortRcvRemotePhysicalErrors,
+						PortRcvSwitchRelayErrors:    &port2PortRcvSwitchRelayErrors,
+						PortXmitConstraintErrors:    &port2PortXmitConstraintErrors,
+						PortXmitData:                &port2PortXmitData,
+						PortXmitDiscards:            &port2PortXmitDiscards,
+						PortXmitPackets:             &port2PortXmitPackets,
+						PortXmitWait:                &port2PortXmitWait,
+						SymbolError:                 &port2SymbolError,
+						VL15Dropped:                 &port2VL15Dropped,
 					},
 				},
 			},


### PR DESCRIPTION
Counters added:
* port_rcv_remote_physical_errors
* port_rcv_switch_relay_errors
* symbol_error
* VL15_dropped

I don't know if these are specific to Mellanox Infiniband but I see these on systems running Mellanox Infiniband.  The fixtures already existed for all but `VL15_dropped`.

Docs from Mellanox: https://community.mellanox.com/s/article/infiniband-port-counters