### PR TITLE
Add smaps information from /proc/pid/smaps_rollup

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -173,6 +173,283 @@ Lines: 1
 411605849 93680043 79
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/26231/smaps
+Lines: 252
+00400000-00cb1000 r-xp 00000000 fd:01 952273                             /bin/alertmanager
+Size:               8900 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                2952 kB
+Pss:                2952 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:      2952 kB
+Private_Dirty:         0 kB
+Referenced:         2864 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd ex mr mw me dw sd 
+00cb1000-016b0000 r--p 008b1000 fd:01 952273                             /bin/alertmanager
+Size:              10236 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                6152 kB
+Pss:                6152 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:      6152 kB
+Private_Dirty:         0 kB
+Referenced:         5308 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd mr mw me dw sd 
+016b0000-0171a000 rw-p 012b0000 fd:01 952273                             /bin/alertmanager
+Size:                424 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                 176 kB
+Pss:                 176 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:        84 kB
+Private_Dirty:        92 kB
+Referenced:          176 kB
+Anonymous:            92 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                 12 kB
+SwapPss:              12 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me dw ac sd 
+0171a000-0173f000 rw-p 00000000 00:00 0 
+Size:                148 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                  76 kB
+Pss:                  76 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:        76 kB
+Referenced:           76 kB
+Anonymous:            76 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me ac sd 
+c000000000-c000400000 rw-p 00000000 00:00 0 
+Size:               4096 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                2564 kB
+Pss:                2564 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:        20 kB
+Private_Dirty:      2544 kB
+Referenced:         2544 kB
+Anonymous:          2564 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:               1100 kB
+SwapPss:            1100 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me ac sd 
+c000400000-c001600000 rw-p 00000000 00:00 0 
+Size:              18432 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:               16024 kB
+Pss:               16024 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:      5864 kB
+Private_Dirty:     10160 kB
+Referenced:        11944 kB
+Anonymous:         16024 kB
+LazyFree:           5848 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                440 kB
+SwapPss:             440 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me ac sd nh 
+c001600000-c004000000 rw-p 00000000 00:00 0 
+Size:              43008 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me ac sd 
+7f0ab95ca000-7f0abbb7b000 rw-p 00000000 00:00 0 
+Size:              38596 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                1992 kB
+Pss:                1992 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:       476 kB
+Private_Dirty:      1516 kB
+Referenced:         1828 kB
+Anonymous:          1992 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                384 kB
+SwapPss:             384 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me ac sd 
+7ffc07ecf000-7ffc07ef0000 rw-p 00000000 00:00 0                          [stack]
+Size:                132 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   8 kB
+Pss:                   8 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         8 kB
+Referenced:            8 kB
+Anonymous:             8 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  4 kB
+SwapPss:               4 kB
+Locked:                0 kB
+VmFlags: rd wr mr mw me gd ac 
+7ffc07f9e000-7ffc07fa1000 r--p 00000000 00:00 0                          [vvar]
+Size:                 12 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd mr pf io de dd sd 
+7ffc07fa1000-7ffc07fa3000 r-xp 00000000 00:00 0                          [vdso]
+Size:                  8 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   4 kB
+Pss:                   0 kB
+Shared_Clean:          4 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            4 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd ex mr mw me de sd 
+ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
+Size:                  4 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+VmFlags: rd ex 
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/26231/smaps_rollup
+Lines: 17
+00400000-ffffffffff601000 ---p 00000000 00:00 0                          [rollup]
+Rss:               29948 kB
+Pss:               29944 kB
+Shared_Clean:          4 kB
+Shared_Dirty:          0 kB
+Private_Clean:     15548 kB
+Private_Dirty:     14396 kB
+Referenced:        24752 kB
+Anonymous:         20756 kB
+LazyFree:           5848 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:               1940 kB
+SwapPss:            1940 kB
+Locked:                0 kB
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/26231/stat
 Lines: 1
 26231 (vim) R 5392 7446 5392 34835 7446 4218880 32533 309516 26 82 1677 44 158 99 20 0 1 0 82375 56274944 1981 18446744073709551615 4194304 6294284 140736914091744 140736914087944 139965136429984 0 0 12288 1870679807 0 0 0 17 0 0 0 31 0 0 8391624 8481048 16420864 140736914093252 140736914093279 140736914093279 140736914096107 0

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -28,7 +28,8 @@ import (
 )
 
 var (
-	rFirstLine = regexp.MustCompile(`^[a-f0-9].*$`)
+	// match the header line before each mapped zone in /proc/pid/smaps
+	procSMapsHeaderLine = regexp.MustCompile(`^[a-f0-9].*$`)
 )
 
 type ProcSMapsRollup struct {
@@ -100,7 +101,7 @@ func (p Proc) procSMapsRollupManual() (ProcSMapsRollup, error) {
 	for scan.Scan() {
 		line := scan.Text()
 
-		if rFirstLine.MatchString(line) {
+		if procSMapsHeaderLine.MatchString(line) {
 			continue
 		}
 

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -121,13 +121,15 @@ func (s *ProcSMapsRollup) parseLine(line string) error {
 	}
 
 	k := kv[0]
+	if k == "VmFlags" {
+		return nil
+	}
+
 	v := strings.TrimSpace(kv[1])
 	v = strings.TrimRight(v, " kB")
 
 	vKBytes, err := strconv.ParseUint(v, 10, 64)
-
-	// VmFlags is the only field which is not a number, ignore parse error for it.
-	if err != nil && k != "VmFlags" {
+	if err != nil {
 		return err
 	}
 	vBytes := vKBytes * 1024

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -1,0 +1,162 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package procfs
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+var (
+	rFirstLine = regexp.MustCompile(`^[a-f0-9].*$`)
+)
+
+type ProcSMaps struct {
+	// Amount of the mapping that is currently resident in RAM
+	Rss uint64
+	// Process's proportional share of this mapping
+	Pss uint64
+	// Size in bytes of clean shared pages
+	SharedClean uint64
+	// Size in bytes of dirty shared pages
+	SharedDirty uint64
+	// Size in bytes of clean private pages
+	PrivateClean uint64
+	// Size in bytes of dirty private pages
+	PrivateDirty uint64
+	// Amount of memory currently marked as referenced or accessed
+	Referenced uint64
+	// Amount of memory that does not belong to any file
+	Anonymous uint64
+	// Amount would-be-anonymous memory currently on swap
+	Swap uint64
+	// Process's proportional memory on swap
+	SwapPss uint64
+}
+
+// ProcSMaps reads from /proc/[pid]/smaps_rollup to get summed memory information of the
+// process.
+//
+// If smaps_rollup does not exists (require kernel >= 4.15), the content of /proc/pid/smaps will
+// we read and summed.
+func (p Proc) ProcSMaps() (ProcSMaps, error) {
+	data, err := util.ReadFileNoStat(p.path("smaps_rollup"))
+	if err != nil && os.IsNotExist(err) {
+		return p.procSMapsManualRollup()
+	}
+	if err != nil {
+		return ProcSMaps{}, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	smaps := ProcSMaps{}
+
+	// skip first line which don't contains information we need
+	lines = lines[1:]
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		if err := smaps.parseLine(line); err != nil {
+			return ProcSMaps{}, err
+		}
+	}
+
+	return smaps, nil
+}
+
+// Read /proc/pid/smaps and do the roll-up in Go code.
+func (p Proc) procSMapsManualRollup() (ProcSMaps, error) {
+	file, err := os.Open(p.path("smaps"))
+	if err != nil {
+		return ProcSMaps{}, err
+	}
+	defer file.Close()
+
+	smaps := ProcSMaps{}
+	scan := bufio.NewScanner(file)
+
+	for scan.Scan() {
+		line := scan.Text()
+
+		if rFirstLine.MatchString(line) {
+			continue
+		}
+
+		if err := smaps.parseLine(line); err != nil {
+			return ProcSMaps{}, err
+		}
+	}
+
+	return smaps, nil
+}
+
+func (s *ProcSMaps) parseLine(line string) error {
+	kv := strings.SplitN(line, ":", 2)
+	if len(kv) != 2 {
+		fmt.Println(line)
+		return errors.New("invalid net/dev line, missing colon")
+	}
+
+	k := kv[0]
+	v := strings.TrimSpace(kv[1])
+	v = strings.TrimRight(v, " kB")
+
+	vKBytes, err := strconv.ParseUint(v, 10, 64)
+
+	// VmFlags is the only field which is not a number, ignore parse error for it.
+	if err != nil && k != "VmFlags" {
+		return err
+	}
+	vBytes := vKBytes * 1024
+
+	s.addValue(k, v, vKBytes, vBytes)
+
+	return nil
+}
+
+func (s *ProcSMaps) addValue(k string, vString string, vUint uint64, vUintBytes uint64) {
+	switch k {
+	case "Rss":
+		s.Rss += vUintBytes
+	case "Pss":
+		s.Pss += vUintBytes
+	case "Shared_Clean":
+		s.SharedClean += vUintBytes
+	case "Shared_Dirty":
+		s.SharedDirty += vUintBytes
+	case "Private_Clean":
+		s.PrivateClean += vUintBytes
+	case "Private_Dirty":
+		s.PrivateDirty += vUintBytes
+	case "Referenced":
+		s.Referenced += vUintBytes
+	case "Anonymous":
+		s.Anonymous += vUintBytes
+	case "Swap":
+		s.Swap += vUintBytes
+	case "SwapPss":
+		s.SwapPss += vUintBytes
+	}
+}

--- a/proc_smaps_test.go
+++ b/proc_smaps_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-func BenchmarkProcSmaps(b *testing.B) {
+func BenchmarkProcSMapsRollup(b *testing.B) {
 	fs, err := NewFS(procTestFixtures)
 	if err != nil {
 		b.Fatalf("Creating pseudo fs from getProcFixtures failed at fixtures/proc with error: %s", err)
@@ -32,36 +32,36 @@ func BenchmarkProcSmaps(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, _ = p.ProcSMaps()
+		_, _ = p.ProcSMapsRollup()
 	}
 }
 
-func TestProcSmaps(t *testing.T) {
+func TestProcSmapsRollup(t *testing.T) {
 	p, err := getProcFixtures(t).Proc(26231)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s1, err := p.ProcSMaps()
+	s1, err := p.ProcSMapsRollup()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := p.procSMapsManualRollup()
+	s2, err := p.procSMapsRollupManual()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	cases := []struct {
 		name  string
-		smaps ProcSMaps
+		smaps ProcSMapsRollup
 	}{
 		{
-			name:  "ProcSMaps",
+			name:  "ProcSMapsRollup",
 			smaps: s1,
 		},
 		{
-			name:  "procSMapsManualRollup",
+			name:  "procSMapsRollupManual",
 			smaps: s2,
 		},
 	}

--- a/proc_smaps_test.go
+++ b/proc_smaps_test.go
@@ -1,0 +1,91 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package procfs
+
+import (
+	"testing"
+)
+
+func BenchmarkProcSmaps(b *testing.B) {
+	fs, err := NewFS(procTestFixtures)
+	if err != nil {
+		b.Fatalf("Creating pseudo fs from getProcFixtures failed at fixtures/proc with error: %s", err)
+	}
+
+	p, err := fs.Proc(26231)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = p.ProcSMaps()
+	}
+}
+
+func TestProcSmaps(t *testing.T) {
+	p, err := getProcFixtures(t).Proc(26231)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s1, err := p.ProcSMaps()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := p.procSMapsManualRollup()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		smaps ProcSMaps
+	}{
+		{
+			name:  "ProcSMaps",
+			smaps: s1,
+		},
+		{
+			name:  "procSMapsManualRollup",
+			smaps: s2,
+		},
+	}
+
+	for _, c := range cases {
+		for _, test := range []struct {
+			name string
+			want uint64
+			have uint64
+		}{
+			{name: "Rss", want: 29948 * 1024, have: c.smaps.Rss},
+			{name: "Pss", want: 29944 * 1024, have: c.smaps.Pss},
+			{name: "SharedClean", want: 4 * 1024, have: c.smaps.SharedClean},
+			{name: "SharedDirty", want: 0 * 1024, have: c.smaps.SharedDirty},
+			{name: "PrivateClean", want: 15548 * 1024, have: c.smaps.PrivateClean},
+			{name: "PrivateDirty", want: 14396 * 1024, have: c.smaps.PrivateDirty},
+			{name: "Referenced", want: 24752 * 1024, have: c.smaps.Referenced},
+			{name: "Anonymous", want: 20756 * 1024, have: c.smaps.Anonymous},
+			{name: "Swap", want: 1940 * 1024, have: c.smaps.Swap},
+			{name: "SwapPss", want: 1940 * 1024, have: c.smaps.SwapPss},
+		} {
+			if test.want != test.have {
+				t.Errorf("want %s %s %d, have %d", c.name, test.name, test.want, test.have)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Follow-up of #281 

Unlike #281, this one only return the sum of value, either from smaps_rollup or (if file does not exists) from smaps.

The information that interest me here is the "Pss" and "SwapPss" which is the process proportional usage of resident memory and swap respectively (which is I think the pages size divided by the number of process that share those pages).

I need this to expose a more significant memory usage for a group of process for prometheus process-exporter (ncabatoff/process-exporter#140)

Signed-off-by: Pierre Fersing <pierre.fersing@bleemeo.com>