### PR TITLE
Add missing cpuinfo support for armv6l

### DIFF
--- a/cpuinfo_armv6l.go
+++ b/cpuinfo_armv6l.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+// +build armv6l
+
+package procfs
+
+var parseCPUInfo = parseCPUInfoARM


### PR DESCRIPTION
Dear maintainer,

PR #257 added basic multiplatform support for cpuinfo.

Due to this change, this project does not compile on 32-bit ARM CPUs, e.g. the armv7l in a Raspberry Pi 3b. I think this PR should solve this problem.