### PR TITLE
cpuinfo: Enable for all 32-bit ARM CPUs

### DIFF
--- a/cpuinfo_arm.go
+++ b/cpuinfo_arm.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 // +build linux
-// +build armv6l
 
 package procfs
 


### PR DESCRIPTION
Repurpose the ARMv6 cpuinfo for all ARM CPUs. CPU info format likely is
not dependent on instruction set version.

Signed-off-by: Christian Svensson <bluecmd@google.com>

Fixes #291