### PR TITLE
Fix up codespell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - checkout
     - run: sudo pip install codespell
-    - run: codespell --skip=".git,./vendor,ttar,go.mod,go.sum" -L uint,packages\',ded,alo,als,te
+    - run: codespell --skip=".git,./vendor,ttar,fixtures.ttar,./fixtures,go.mod,go.sum" -L uint,packages\',ded,alo,als,te,sie
 
 workflows:
   version: 2

--- a/proc_fdinfo.go
+++ b/proc_fdinfo.go
@@ -41,7 +41,7 @@ type ProcFDInfo struct {
 	Flags string
 	// Mount point ID
 	MntID string
-	// List of inotify lines (structed) in the fdinfo file (kernel 3.8+ only)
+	// List of inotify lines (structured) in the fdinfo file (kernel 3.8+ only)
 	InotifyInfos []InotifyInfo
 }
 


### PR DESCRIPTION
* Ignore fixutres
* Ignore fixture item in cpuinfo_test.go
* Fix typo in proc_fdinfo.go

Signed-off-by: Ben Kochie <superq@gmail.com>