### PR TITLE
Fix MDStat() error return

### DIFF
--- a/mdstat.go
+++ b/mdstat.go
@@ -52,7 +52,7 @@ type MDStat struct {
 func (fs FS) MDStat() ([]MDStat, error) {
 	data, err := ioutil.ReadFile(fs.proc.Path("mdstat"))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing mdstat %s: %s", fs.proc.Path("mdstat"), err)
+		return nil, err
 	}
 	mdstat, err := parseMDStat(data)
 	if err != nil {


### PR DESCRIPTION
Don't touch the ioutil error message so that the return can be tested
with `os.IsNotExist()`.

Related to https://github.com/prometheus/node_exporter/issues/1719

Signed-off-by: Ben Kochie <superq@gmail.com>