### PR TITLE
Fix build tags

### DIFF
--- a/proc_maps.go
+++ b/proc_maps.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package procfs
 

--- a/proc_maps_test.go
+++ b/proc_maps_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package procfs
 


### PR DESCRIPTION
proc_maps.go and proc_maps_test.go import "golang.org/x/sys/unix", but
only guard against MS Windows in the build tag. However, that package
only works with the build tags also used in
golang.org/x/sys/unix/syscall.go.

This commits brings the build tags in line with that. The procfs
package then compiles again on all GOOS/GOARCH (but returns an error
for unsupported platforms, as expected by users like the
prometheus/client_golang process collector).

Cf. https://github.com/prometheus/client_golang/pull/758

Signed-off-by: beorn7 <beorn@grafana.com>