### PR TITLE
Add CPUInfo parser for mipsle

### DIFF
--- a/cpuinfo_mipsle.go
+++ b/cpuinfo_mipsle.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package procfs
+
+var parseCPUInfo = parseCPUInfoMips


### PR DESCRIPTION
Use mips CPUInfo parser for mipsle. They appear to have identical
cpuinfo output.

https://github.com/prometheus/node_exporter/pull/1735

Signed-off-by: Ben Kochie <superq@gmail.com>