### PR TITLE
Remove error wrapper from /sys/class/power_supply

### DIFF
--- a/sysfs/class_power_supply.go
+++ b/sysfs/class_power_supply.go
@@ -110,7 +110,7 @@ func (fs FS) PowerSupplyClass() (PowerSupplyClass, error) {
 
 	dirs, err := ioutil.ReadDir(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list power supplies at %q: %v", path, err)
+		return nil, err
 	}
 
 	psc := make(PowerSupplyClass, len(dirs))


### PR DESCRIPTION
Don't wrap the error of `ioutil.ReadDir()` so that the error return can
be tested with `os.IsNotExist()`. Fixes node_exporter log noise.

```
caller=collector.go:161 msg="collector failed" name=powersupplyclass duration_seconds=0.00079848 err="could not get power_supply class info: error obtaining power_supply class info: failed to list power supplies at \"/sys/class/power_supply\": open /sys/class/power_supply: no such file or directory"
```

Signed-off-by: Ben Kochie <superq@gmail.com>