### PR TITLE
Fix running test on arm64

### DIFF
--- a/cpuinfo_test.go
+++ b/cpuinfo_test.go
@@ -207,6 +207,7 @@ machine		: CHRP IBM,8233-E8B
 )
 
 func TestCPUInfoX86(t *testing.T) {
+	parseCPUInfo = parseCPUInfoX86
 	cpuinfo, err := getProcFixtures(t).CPUInfo()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
On arm64, the CPUInfo in TestCPUInfoX86 calls parseCPUInfoARM,
so it panics.

Log: https://ci.debian.net/data/autopkgtest/testing/arm64/g/golang-procfs/5986092/log.gz
