### PR TITLE
Add CPUInfo parsing for RISCV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - checkout
     - run: sudo pip install codespell
-    - run: codespell --skip=".git,./vendor,ttar,fixtures.ttar,./fixtures,go.mod,go.sum" -L uint,packages\',ded,alo,als,te,sie
+    - run: codespell --skip=".git,./vendor,ttar,fixtures.ttar,./fixtures,go.mod,go.sum" -L uint,packages\',ded,alo,als,te,sie,hart
 
 workflows:
   version: 2

--- a/cpuinfo.go
+++ b/cpuinfo.go
@@ -407,6 +407,46 @@ func parseCPUInfoPPC(info []byte) ([]CPUInfo, error) {
 	return cpuinfo, nil
 }
 
+func parseCPUInfoRISCV(info []byte) ([]CPUInfo, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(info))
+
+	firstLine := firstNonEmptyLine(scanner)
+	if !strings.HasPrefix(firstLine, "processor") || !strings.Contains(firstLine, ":") {
+		return nil, errors.New("invalid cpuinfo file: " + firstLine)
+	}
+	field := strings.SplitN(firstLine, ": ", 2)
+	v, err := strconv.ParseUint(field[1], 0, 32)
+	if err != nil {
+		return nil, err
+	}
+	firstcpu := CPUInfo{Processor: uint(v)}
+	cpuinfo := []CPUInfo{firstcpu}
+	i := 0
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.Contains(line, ":") {
+			continue
+		}
+		field := strings.SplitN(line, ": ", 2)
+		switch strings.TrimSpace(field[0]) {
+		case "processor":
+			v, err := strconv.ParseUint(field[1], 0, 32)
+			if err != nil {
+				return nil, err
+			}
+			i = int(v)
+			cpuinfo = append(cpuinfo, CPUInfo{}) // start of the next processor
+			cpuinfo[i].Processor = uint(v)
+		case "hart":
+			cpuinfo[i].CoreID = field[1]
+		case "isa":
+			cpuinfo[i].ModelName = field[1]
+		}
+	}
+	return cpuinfo, nil
+}
+
 func parseCPUInfoDummy(_ []byte) ([]CPUInfo, error) { // nolint:unused,deadcode
 	return nil, errors.New("not implemented")
 }

--- a/cpuinfo_others.go
+++ b/cpuinfo_others.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // +build linux
-// +build !386,!amd64,!arm,!arm64,!mips,!mips64,!mips64le,!mipsle,!ppc64,!ppc64le,!s390x
+// +build !386,!amd64,!arm,!arm64,!mips,!mips64,!mips64le,!mipsle,!ppc64,!ppc64le,!riscv64,!s390x
 
 package procfs
 

--- a/cpuinfo_test.go
+++ b/cpuinfo_test.go
@@ -204,6 +204,18 @@ platform	: pSeries
 model		: IBM,8233-E8B
 machine		: CHRP IBM,8233-E8B
 `
+
+	cpuinfoRiscv64 = `
+processor	: 0
+hart		: 0
+isa		: rv64imafdcsu
+mmu		: sv48
+
+processor	: 1
+hart		: 1
+isa		: rv64imafdcsu
+mmu		: sv48
+`
 )
 
 func TestCPUInfoX86(t *testing.T) {
@@ -343,5 +355,21 @@ func TestCPUInfoParsePPC(t *testing.T) {
 	}
 	if want, have := 3000.00, cpuinfo[2].CPUMHz; want != have {
 		t.Errorf("want cpu mhz %v, have %v", want, have)
+	}
+}
+
+func TestCPUInfoParseRISCV64(t *testing.T) {
+	cpuinfo, err := parseCPUInfoRISCV([]byte(cpuinfoRiscv64))
+	if err != nil || cpuinfo == nil {
+		t.Fatalf("unable to parse ppc cpu info: %v", err)
+	}
+	if want, have := 2, len(cpuinfo); want != have {
+		t.Errorf("want number of processors %v, have %v", want, have)
+	}
+	if want, have := "1", cpuinfo[1].CoreID; want != have {
+		t.Errorf("want CoreId %v, have %v", want, have)
+	}
+	if want, have := "rv64imafdcsu", cpuinfo[1].ModelName; want != have {
+		t.Errorf("want ModelName %v, have %v", want, have)
 	}
 }


### PR DESCRIPTION
Currently only 64-bit RISCV is supported (GOARCH=riscv64) by the Go
compiler, but the cpuinfo format would be the same for 32-bit RISCV.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>