### PR TITLE
Handle multi-digit powercap indexes

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -3754,6 +3754,73 @@ Path: fixtures/sys/class/powercap/intel-rapl:0:0/uevent
 Lines: 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/powercap/intel-rapl:a
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/constraint_0_max_power_uw
+Lines: 1
+95000000
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/constraint_0_name
+Lines: 1
+long_term
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/constraint_0_power_limit_uw
+Lines: 1
+4090000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/constraint_0_time_window_us
+Lines: 1
+999424
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/constraint_1_max_power_uw
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/constraint_1_name
+Lines: 1
+short_term
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/constraint_1_power_limit_uw
+Lines: 1
+4090000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/constraint_1_time_window_us
+Lines: 1
+2440
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/enabled
+Lines: 1
+1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/energy_uj
+Lines: 1
+240422366267
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/max_energy_range_uj
+Lines: 1
+262143328850
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/name
+Lines: 1
+package-10
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/powercap/intel-rapl:a/uevent
+Lines: 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/thermal
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/class_powercap.go
+++ b/sysfs/class_powercap.go
@@ -100,11 +100,11 @@ func (rz RaplZone) GetEnergyMicrojoules() (uint64, error) {
 // provided back as an integer, and stripped from the returned name. Usage
 // count is used when the index value is absent from the name.
 func getIndexAndName(countNameUsages map[string]int, name string) (int, string) {
-	length := len(name)
-	if length >= 2 {
-		index, err := strconv.Atoi(name[length-1:])
-		if name[length-2:length-1] == "-" && err == nil {
-			return index, name[:length-2]
+	s := strings.Split(name, "-")
+	if len(s) == 2 {
+		index, err := strconv.Atoi(s[1])
+		if err == nil {
+			return index, s[0]
 		}
 	}
 	// return count as the index, since name didn't have an index at the end

--- a/sysfs/class_powercap_test.go
+++ b/sysfs/class_powercap_test.go
@@ -56,7 +56,7 @@ func TestNewRaplValues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(zones) != 2 {
+	if len(zones) != 3 {
 		t.Fatal("wrong number of RAPL values")
 	}
 	microjoules, err := zones[0].GetEnergyMicrojoules()
@@ -65,5 +65,8 @@ func TestNewRaplValues(t *testing.T) {
 	}
 	if microjoules != 240422366267 {
 		t.Fatal("wrong microjoule number")
+	}
+	if zones[2].Index != 10 {
+		t.Fatal("wrong index number")
 	}
 }


### PR DESCRIPTION
Correctly handle powercap name strings by splitting on "-" rather than
assuming the index is a single digit number.

https://github.com/prometheus/node_exporter/issues/1808

Signed-off-by: Ben Kochie <superq@gmail.com>