### PR TITLE
Added parsing of "checking" state to mdstat

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -1966,7 +1966,7 @@ Lines: 1
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/mdstat
-Lines: 56
+Lines: 60
 Personalities : [linear] [multipath] [raid0] [raid1] [raid6] [raid5] [raid4] [raid10]
 
 md3 : active raid6 sda1[8] sdh1[7] sdg1[6] sdf1[5] sde1[11] sdd1[3] sdc1[10] sdb1[9] sdd1[10](S) sdd2[11](S)
@@ -1988,6 +1988,10 @@ md6 : active raid1 sdb2[2](F) sdc[1](S) sda2[0]
 md8 : active raid1 sdb1[1] sda1[0] sdc[2](S) sde[3](S)
       195310144 blocks [2/2] [UU]
       [=>...................]  resync =  8.5% (16775552/195310144) finish=17.0min speed=259783K/sec
+
+md201 : active raid1 sda3[0] sdb3[1]
+      1993728 blocks super 1.2 [2/2] [UU]
+      [=>...................]  check =  5.7% (114176/1993728) finish=0.2min speed=114176K/sec
 
 md7 : active raid6 sdb1[0] sde1[3] sdd1[2] sdc1[1](F)
       7813735424 blocks super 1.2 level 6, 512k chunk, algorithm 2 [4/3] [U_UU]

--- a/mdstat.go
+++ b/mdstat.go
@@ -107,11 +107,14 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 		syncedBlocks := size
 		recovering := strings.Contains(lines[syncLineIdx], "recovery")
 		resyncing := strings.Contains(lines[syncLineIdx], "resync")
+		checking := strings.Contains(lines[syncLineIdx], "check")
 
 		// Append recovery and resyncing state info.
-		if recovering || resyncing {
+		if recovering || resyncing || checking {
 			if recovering {
 				state = "recovering"
+			} else if checking {
+				state = "checking"
 			} else {
 				state = "resyncing"
 			}

--- a/mdstat_test.go
+++ b/mdstat_test.go
@@ -40,6 +40,7 @@ func TestFS_MDStat(t *testing.T) {
 		"md219": {Name: "md219", ActivityState: "inactive", DisksTotal: 0, DisksFailed: 0, DisksActive: 0, DisksSpare: 3, BlocksTotal: 7932, BlocksSynced: 7932},
 		"md00":  {Name: "md00", ActivityState: "active", DisksActive: 1, DisksTotal: 1, DisksFailed: 0, DisksSpare: 0, BlocksTotal: 4186624, BlocksSynced: 4186624},
 		"md101": {Name: "md101", ActivityState: "active", DisksActive: 3, DisksTotal: 3, DisksFailed: 0, DisksSpare: 0, BlocksTotal: 322560, BlocksSynced: 322560},
+		"md201": {Name: "md201", ActivityState: "checking", DisksActive: 2, DisksTotal: 2, DisksFailed: 0, DisksSpare: 0, BlocksTotal: 1993728, BlocksSynced: 114176},
 	}
 
 	if want, have := len(refs), len(mdStats); want != have {


### PR DESCRIPTION
Currently the checking state caused by i.e. _checkarray_ (see https://www.thomas-krenn.com/en/wiki/Mdadm_checkarray_function#Perform_Automatic_Check) is not parsed as state an array can be in.

This is unfortunate as this condition certainly makes sense to monitor and take into considerations when writing alerts on i.e. disk read rates or total blocks vs. in sync blocks.

Signed-off-by: Christian Rohmann <github@frittentheke.de>


@discordianfish @pgier  PTAL