### PR TITLE
Fix build on RISCV

### DIFF
--- a/cpuinfo_riscvx.go
+++ b/cpuinfo_riscvx.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+// +build riscv riscv64
+
+package procfs
+
+var parseCPUInfo = parseCPUInfoRISCV


### PR DESCRIPTION
PR #318 forgot to wire `parseCPUInfo` to `parseCPUInfoRISCV` on
`GOARCH=riscv{,64}`, leading to a build/test failure:

```
./cpuinfo.go:71:9: undefined: parseCPUInfo
./cpuinfo_test.go:222:2: undefined: parseCPUInfo
```

/cc @discordianfish @SuperQ 