### PR TITLE
internal/util: Read(U)intFromFile: Return file name in errors

### DIFF
--- a/internal/util/parse.go
+++ b/internal/util/parse.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -68,18 +69,26 @@ func ParsePInt64s(ss []string) ([]*int64, error) {
 func ReadUintFromFile(path string) (uint64, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to read file %s: %w", path, err)
 	}
-	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	u, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse uint from file %s: %w", path, err)
+	}
+	return u, nil
 }
 
 // ReadIntFromFile reads a file and attempts to parse a int64 from it.
 func ReadIntFromFile(path string) (int64, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to read file %s: %w", path, err)
 	}
-	return strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	i, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse int from file %s: %w", path, err)
+	}
+	return i, nil
 }
 
 // ParseBool parses a string into a boolean pointer.

--- a/kernel_random.go
+++ b/kernel_random.go
@@ -16,6 +16,7 @@
 package procfs
 
 import (
+	"errors"
 	"os"
 
 	"github.com/prometheus/procfs/internal/util"
@@ -49,7 +50,7 @@ func (fs FS) KernelRandom() (KernelRandom, error) {
 		"read_wakeup_threshold":   &random.ReadWakeupThreshold,
 	} {
 		val, err := util.ReadUintFromFile(fs.proc.Path("sys", "kernel", "random", file))
-		if os.IsNotExist(err) {
+		if os.IsNotExist(errors.Unwrap(err)) {
 			continue
 		}
 		if err != nil {

--- a/sysfs/class_thermal.go
+++ b/sysfs/class_thermal.go
@@ -83,7 +83,7 @@ func parseClassThermalZone(zone string) (ClassThermalZoneStats, error) {
 
 	var zonePassive *uint64
 	passive, err := util.ReadUintFromFile(filepath.Join(zone, "passive"))
-	if os.IsNotExist(err) || os.IsPermission(err) {
+	if os.IsNotExist(errors.Unwrap(err)) || os.IsPermission(errors.Unwrap(err)) {
 		zonePassive = nil
 	} else if err != nil {
 		return ClassThermalZoneStats{}, err

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -16,6 +16,7 @@
 package sysfs
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -196,7 +197,7 @@ func parseCpufreqCpuinfo(cpuPath string) (*SystemCPUCpufreqStats, error) {
 	for i, f := range uintFiles {
 		v, err := util.ReadUintFromFile(filepath.Join(cpuPath, f))
 		if err != nil {
-			if os.IsNotExist(err) || os.IsPermission(err) {
+			if os.IsNotExist(errors.Unwrap(err)) || os.IsPermission(errors.Unwrap(err)) {
 				continue
 			}
 			return &SystemCPUCpufreqStats{}, err


### PR DESCRIPTION
This PR improves error messages by adding the affected file name. This helps downstream users  to locate the source of errors which is useful for e.g. prometheus/node_exporter#1710.

The original error is wrapped as some consumers perform checks on it. The consumers within procfs have been updated to Unwrap the error if necessary.

@pgier @discordianfish What do you think?
cc @SuperQ who was involved with the referenced node_exporter/cpufreq issue.