### PR TITLE
cpuinfo: add parsing of physical id, core id, siblings, and cpus cores to s390x arch

### DIFF
--- a/cpuinfo.go
+++ b/cpuinfo.go
@@ -313,6 +313,22 @@ func parseCPUInfoS390X(info []byte) ([]CPUInfo, error) {
 				return nil, err
 			}
 			cpuinfo[i].CPUMHz = v
+		case "physical id":
+			cpuinfo[i].PhysicalID = field[1]
+		case "core id":
+			cpuinfo[i].CoreID = field[1]
+		case "cpu cores":
+			v, err := strconv.ParseUint(field[1], 0, 32)
+			if err != nil {
+				return nil, err
+			}
+			cpuinfo[i].CPUCores = uint(v)
+		case "siblings":
+			v, err := strconv.ParseUint(field[1], 0, 32)
+			if err != nil {
+				return nil, err
+			}
+			cpuinfo[i].Siblings = uint(v)
 		}
 	}
 

--- a/cpuinfo_test.go
+++ b/cpuinfo_test.go
@@ -115,18 +115,34 @@ processor 2: version = FF,  identification = 2733E8,  machine = 2964
 processor 3: version = FF,  identification = 2733E8,  machine = 2964
 
 cpu number      : 0
+physical id     : 2
+core id         : 0
+siblings        : 8
+cpu cores       : 4
 cpu MHz dynamic : 5000
 cpu MHz static  : 5000
 
 cpu number      : 1
+physical id     : 2
+core id         : 0
+siblings        : 8
+cpu cores       : 4
 cpu MHz dynamic : 5000
 cpu MHz static  : 5000
 
 cpu number      : 2
+physical id     : 2
+core id         : 1
+siblings        : 8
+cpu cores       : 4
 cpu MHz dynamic : 5000
 cpu MHz static  : 5000
 
 cpu number      : 3
+physical id     : 2
+core id         : 1
+siblings        : 8
+cpu cores       : 4
 cpu MHz dynamic : 5000
 cpu MHz static  : 5000
 `
@@ -326,6 +342,18 @@ func TestCPUInfoParseS390X(t *testing.T) {
 	}
 	if want, have := 5000.0, cpuinfo[2].CPUMHz; want != have {
 		t.Errorf("want cpu MHz %v, have %v", want, have)
+	}
+	if want, have := uint(8), cpuinfo[3].Siblings; want != have {
+		t.Errorf("want siblings %v, have %v", want, have)
+	}
+	if want, have := "1", cpuinfo[3].CoreID; want != have {
+		t.Errorf("want core id %v, have %v", want, have)
+	}
+	if want, have := uint(4), cpuinfo[2].CPUCores; want != have {
+		t.Errorf("want cpu cores %v, have %v", want, have)
+	}
+	if want, have := "2", cpuinfo[2].PhysicalID; want != have {
+		t.Errorf("want physical id %v, have %v", want, have)
 	}
 }
 


### PR DESCRIPTION
Fix #333

Signed-off-by: paulfantom <pawel@krupa.net.pl>

/cc @SuperQ @simonpasquier 