### PR TITLE
Fix for mountstats error due to multiline "impl_id" on FreeNAS

### DIFF
--- a/mountstats.go
+++ b/mountstats.go
@@ -338,12 +338,12 @@ func parseMountStatsNFS(s *bufio.Scanner, statVersion string) (*MountStatsNFS, e
 		if len(ss) == 0 {
 			break
 		}
-		if len(ss) < 2 {
-			return nil, fmt.Errorf("not enough information for NFS stats: %v", ss)
-		}
 
 		switch ss[0] {
 		case fieldOpts:
+			if len(ss) < 2 {
+				return nil, fmt.Errorf("not enough information for NFS stats: %v", ss)
+			}
 			if stats.Opts == nil {
 				stats.Opts = map[string]string{}
 			}
@@ -356,6 +356,9 @@ func parseMountStatsNFS(s *bufio.Scanner, statVersion string) (*MountStatsNFS, e
 				}
 			}
 		case fieldAge:
+			if len(ss) < 2 {
+				return nil, fmt.Errorf("not enough information for NFS stats: %v", ss)
+			}
 			// Age integer is in seconds
 			d, err := time.ParseDuration(ss[1] + "s")
 			if err != nil {
@@ -364,6 +367,9 @@ func parseMountStatsNFS(s *bufio.Scanner, statVersion string) (*MountStatsNFS, e
 
 			stats.Age = d
 		case fieldBytes:
+			if len(ss) < 2 {
+				return nil, fmt.Errorf("not enough information for NFS stats: %v", ss)
+			}
 			bstats, err := parseNFSBytesStats(ss[1:])
 			if err != nil {
 				return nil, err
@@ -371,6 +377,9 @@ func parseMountStatsNFS(s *bufio.Scanner, statVersion string) (*MountStatsNFS, e
 
 			stats.Bytes = *bstats
 		case fieldEvents:
+			if len(ss) < 2 {
+				return nil, fmt.Errorf("not enough information for NFS stats: %v", ss)
+			}
 			estats, err := parseNFSEventsStats(ss[1:])
 			if err != nil {
 				return nil, err

--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -254,6 +254,26 @@ func TestMountStats(t *testing.T) {
 			}},
 		},
 		{
+			name: "NFS4.1 device with multiline impl_id OK",
+			s:    "device 192.168.0.1:/srv mounted on /mnt/nfs with fstype nfs4 statvers=1.1\nopts: rw,vers=4.1,rsize=131072,wsize=131072,namlen=255,acregmin=3,acregmax=60,acdirmin=30,acdirmax=60,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.0.2,fsc,local_lock=none\nage: 1234567\nimpl_id: name='FreeBSD 11.2-STABLE #0 r325575+c9231c7d6bd(HEAD): Mon Nov 18 22:46:47 UTC 2019\nuser@host:/path/to/something'\n,domain='something.org',date='1293840000,0'",
+			mounts: []*Mount{{
+				Device: "192.168.0.1:/srv",
+				Mount:  "/mnt/nfs",
+				Type:   "nfs4",
+				Stats: &MountStatsNFS{
+					StatVersion: "1.1",
+					Opts: map[string]string{"rw": "", "vers": "4.1",
+						"rsize": "131072", "wsize": "131072", "namlen": "255", "acregmin": "3",
+						"acregmax": "60", "acdirmin": "30", "acdirmax": "60", "fsc": "", "hard": "",
+						"proto": "tcp", "timeo": "600", "retrans": "2",
+						"sec": "sys", "clientaddr": "192.168.0.2",
+						"local_lock": "none",
+					},
+					Age: 1234567 * time.Second,
+				},
+			}},
+		},
+		{
 			name: "fixtures/proc OK",
 			mounts: []*Mount{
 				{

--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -64,7 +64,7 @@ func TestMountStats(t *testing.T) {
 		},
 		{
 			name:    "NFSv4 device with too little info",
-			s:       "device 192.168.1.1:/srv mounted on /mnt/nfs with fstype nfs4 statvers=1.1\nhello",
+			s:       "device 192.168.1.1:/srv mounted on /mnt/nfs with fstype nfs4 statvers=1.1\nopts:",
 			invalid: true,
 		},
 		{


### PR DESCRIPTION
This PR fixes the issue described in [prometheus/node_exporter#1583](https://github.com/prometheus/node_exporter/issues/1583)

When reading from /proc/self/mountstats for FreeNAS NFS mount, the data in "impl_id" tends to be printed in 3 lines. As seen in the above issue, the second and third line are one field long. This results in parser exiting with "not enough information for NFS stats" error.
The PR moves the length check so that node-exporter won't crash when trying to export NFS client metrics connected to the FreeNAS server.

@discordianfish @pgier