### PR TITLE
Fix proc limits

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -111,7 +111,7 @@ Max core file size        0                    unlimited            bytes
 Max resident set          unlimited            unlimited            bytes
 Max processes             62898                62898                processes
 Max open files            2048                 4096                 files
-Max locked memory         65536                65536                bytes
+Max locked memory         18446744073708503040 18446744073708503040 bytes
 Max address space         8589934592           unlimited            bytes
 Max file locks            unlimited            unlimited            locks
 Max pending signals       62898                62898                signals

--- a/proc_limits.go
+++ b/proc_limits.go
@@ -97,7 +97,7 @@ func (p Proc) Limits() (ProcLimits, error) {
 		s = bufio.NewScanner(f)
 	)
 
-        s.Scan() // Skip limits header
+	s.Scan() // Skip limits header
 
 	for s.Scan() {
 		//fields := limitsMatch.Split(s.Text(), limitsFields)
@@ -153,7 +153,7 @@ func parseUint(s string) (uint64, error) {
 	if s == limitsUnlimited {
 		return 18446744073709551615, nil
 	}
-	i, err := strconv.ParseUint(s, 10, 64) 
+	i, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("couldn't parse value %s: %s", s, err)
 	}

--- a/proc_limits.go
+++ b/proc_limits.go
@@ -26,55 +26,55 @@ import (
 // http://man7.org/linux/man-pages/man2/getrlimit.2.html.
 type ProcLimits struct {
 	// CPU time limit in seconds.
-	CPUTime int64
+	CPUTime uint64
 	// Maximum size of files that the process may create.
-	FileSize int64
+	FileSize uint64
 	// Maximum size of the process's data segment (initialized data,
 	// uninitialized data, and heap).
-	DataSize int64
+	DataSize uint64
 	// Maximum size of the process stack in bytes.
-	StackSize int64
+	StackSize uint64
 	// Maximum size of a core file.
-	CoreFileSize int64
+	CoreFileSize uint64
 	// Limit of the process's resident set in pages.
-	ResidentSet int64
+	ResidentSet uint64
 	// Maximum number of processes that can be created for the real user ID of
 	// the calling process.
-	Processes int64
+	Processes uint64
 	// Value one greater than the maximum file descriptor number that can be
 	// opened by this process.
-	OpenFiles int64
+	OpenFiles uint64
 	// Maximum number of bytes of memory that may be locked into RAM.
-	LockedMemory int64
+	LockedMemory uint64
 	// Maximum size of the process's virtual memory address space in bytes.
-	AddressSpace int64
+	AddressSpace uint64
 	// Limit on the combined number of flock(2) locks and fcntl(2) leases that
 	// this process may establish.
-	FileLocks int64
+	FileLocks uint64
 	// Limit of signals that may be queued for the real user ID of the calling
 	// process.
-	PendingSignals int64
+	PendingSignals uint64
 	// Limit on the number of bytes that can be allocated for POSIX message
 	// queues for the real user ID of the calling process.
-	MsqqueueSize int64
+	MsqqueueSize uint64
 	// Limit of the nice priority set using setpriority(2) or nice(2).
-	NicePriority int64
+	NicePriority uint64
 	// Limit of the real-time priority set using sched_setscheduler(2) or
 	// sched_setparam(2).
-	RealtimePriority int64
+	RealtimePriority uint64
 	// Limit (in microseconds) on the amount of CPU time that a process
 	// scheduled under a real-time scheduling policy may consume without making
 	// a blocking system call.
-	RealtimeTimeout int64
+	RealtimeTimeout uint64
 }
 
 const (
-	limitsFields    = 3
+	limitsFields    = 4
 	limitsUnlimited = "unlimited"
 )
 
 var (
-	limitsDelimiter = regexp.MustCompile("  +")
+	limitsMatch = regexp.MustCompile(`(Max \w+\s{0,1}?\w*\s{0,1}\w*)\s{2,}(\w+)\s+(\w+)`)
 )
 
 // NewLimits returns the current soft limits of the process.
@@ -96,46 +96,50 @@ func (p Proc) Limits() (ProcLimits, error) {
 		l = ProcLimits{}
 		s = bufio.NewScanner(f)
 	)
+
+        s.Scan() // Skip limits header
+
 	for s.Scan() {
-		fields := limitsDelimiter.Split(s.Text(), limitsFields)
+		//fields := limitsMatch.Split(s.Text(), limitsFields)
+		fields := limitsMatch.FindStringSubmatch(s.Text())
 		if len(fields) != limitsFields {
 			return ProcLimits{}, fmt.Errorf(
 				"couldn't parse %s line %s", f.Name(), s.Text())
 		}
 
-		switch fields[0] {
+		switch fields[1] {
 		case "Max cpu time":
-			l.CPUTime, err = parseInt(fields[1])
+			l.CPUTime, err = parseUint(fields[2])
 		case "Max file size":
-			l.FileSize, err = parseInt(fields[1])
+			l.FileSize, err = parseUint(fields[2])
 		case "Max data size":
-			l.DataSize, err = parseInt(fields[1])
+			l.DataSize, err = parseUint(fields[2])
 		case "Max stack size":
-			l.StackSize, err = parseInt(fields[1])
+			l.StackSize, err = parseUint(fields[2])
 		case "Max core file size":
-			l.CoreFileSize, err = parseInt(fields[1])
+			l.CoreFileSize, err = parseUint(fields[2])
 		case "Max resident set":
-			l.ResidentSet, err = parseInt(fields[1])
+			l.ResidentSet, err = parseUint(fields[2])
 		case "Max processes":
-			l.Processes, err = parseInt(fields[1])
+			l.Processes, err = parseUint(fields[2])
 		case "Max open files":
-			l.OpenFiles, err = parseInt(fields[1])
+			l.OpenFiles, err = parseUint(fields[2])
 		case "Max locked memory":
-			l.LockedMemory, err = parseInt(fields[1])
+			l.LockedMemory, err = parseUint(fields[2])
 		case "Max address space":
-			l.AddressSpace, err = parseInt(fields[1])
+			l.AddressSpace, err = parseUint(fields[2])
 		case "Max file locks":
-			l.FileLocks, err = parseInt(fields[1])
+			l.FileLocks, err = parseUint(fields[2])
 		case "Max pending signals":
-			l.PendingSignals, err = parseInt(fields[1])
+			l.PendingSignals, err = parseUint(fields[2])
 		case "Max msgqueue size":
-			l.MsqqueueSize, err = parseInt(fields[1])
+			l.MsqqueueSize, err = parseUint(fields[2])
 		case "Max nice priority":
-			l.NicePriority, err = parseInt(fields[1])
+			l.NicePriority, err = parseUint(fields[2])
 		case "Max realtime priority":
-			l.RealtimePriority, err = parseInt(fields[1])
+			l.RealtimePriority, err = parseUint(fields[2])
 		case "Max realtime timeout":
-			l.RealtimeTimeout, err = parseInt(fields[1])
+			l.RealtimeTimeout, err = parseUint(fields[2])
 		}
 		if err != nil {
 			return ProcLimits{}, err
@@ -145,11 +149,11 @@ func (p Proc) Limits() (ProcLimits, error) {
 	return l, s.Err()
 }
 
-func parseInt(s string) (int64, error) {
+func parseUint(s string) (uint64, error) {
 	if s == limitsUnlimited {
-		return -1, nil
+		return 18446744073709551615, nil
 	}
-	i, err := strconv.ParseInt(s, 10, 64)
+	i, err := strconv.ParseUint(s, 10, 64) 
 	if err != nil {
 		return 0, fmt.Errorf("couldn't parse value %s: %s", s, err)
 	}

--- a/proc_limits_test.go
+++ b/proc_limits_test.go
@@ -28,8 +28,8 @@ func TestLimits(t *testing.T) {
 
 	for _, test := range []struct {
 		name string
-		want int64
-		have int64
+		want uint64
+		have uint64
 	}{
 		{name: "cpu time", want: -1, have: l.CPUTime},
 		{name: "open files", want: 2048, have: l.OpenFiles},

--- a/proc_limits_test.go
+++ b/proc_limits_test.go
@@ -31,7 +31,7 @@ func TestLimits(t *testing.T) {
 		want uint64
 		have uint64
 	}{
-		{name: "cpu time", want: -1, have: l.CPUTime},
+		{name: "cpu time", want: 18446744073709551615, have: l.CPUTime},
 		{name: "open files", want: 2048, have: l.OpenFiles},
 		{name: "msgqueue size", want: 819200, have: l.MsqqueueSize},
 		{name: "nice priority", want: 0, have: l.NicePriority},


### PR DESCRIPTION
Fixes regex parsing of large limits as well as changes from `int64` to `uint64`.  Also adjust `unlimited` to be 18446744073709551615.  

This was realized while trying to parse the limits of `ntp` process on a Debian based system.  

https://github.com/prometheus/procfs/issues/338 