### PR TITLE
Swap read and write stats for XFS

### DIFF
--- a/xfs/parse.go
+++ b/xfs/parse.go
@@ -286,8 +286,8 @@ func readWriteStats(us []uint32) (ReadWriteStats, error) {
 	}
 
 	return ReadWriteStats{
-		Read:  us[0],
-		Write: us[1],
+		Write: us[0],
+		Read:  us[1],
 	}, nil
 }
 

--- a/xfs/parse_test.go
+++ b/xfs/parse_test.go
@@ -199,8 +199,8 @@ func TestParseStats(t *testing.T) {
 			s:    "rw 1 2",
 			stats: &xfs.Stats{
 				ReadWrite: xfs.ReadWriteStats{
-					Read:  1,
-					Write: 2,
+					Write: 1,
+					Read:  2,
 				},
 			},
 		},
@@ -577,8 +577,8 @@ func TestParseStats(t *testing.T) {
 					ForceSleep:        739,
 				},
 				ReadWrite: xfs.ReadWriteStats{
-					Read:  107739,
-					Write: 94045,
+					Write: 107739,
+					Read:  94045,
 				},
 				AttributeOperation: xfs.AttributeOperationStats{
 					Get:    4,

--- a/xfs/xfs.go
+++ b/xfs/xfs.go
@@ -124,8 +124,8 @@ type LogOperationStats struct {
 // ReadWriteStats contains statistics regarding the number of read and write
 // system calls for XFS filesystems.
 type ReadWriteStats struct {
-	Read  uint32
 	Write uint32
+	Read  uint32
 }
 
 // AttributeOperationStats contains statistics regarding manipulation of


### PR DESCRIPTION
According to the table in https://xfs.org/index.php/Runtime_Stats, the first number of `rw` stats is write and the second is read. I noticed Prometheus seemed to be reporting the opposite of what I expected.

@discordianfish @pgier