### PR TITLE
proc/sys/kernel: adds support for parsing core_pattern

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -2353,6 +2353,11 @@ Mode: 775
 Directory: fixtures/proc/sys/kernel
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/sys/kernel/core_pattern
+Lines: 1
+|/usr/share/apport/apport %p %s %c %d %P %E
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/proc/sys/kernel/random
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/kernel_corepattern.go
+++ b/kernel_corepattern.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package procfs
+
+import (
+	"bytes"
+	"os"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// KernelCorePattern returns value from /proc/sys/kernel/core_pattern
+func (fs FS) KernelCorePattern() (pattern []byte, err error) {
+	pattern, err = util.ReadFileNoStat(fs.proc.Path("sys", "kernel", "core_pattern"))
+	if err != nil || os.IsNotExist(err) {
+		return
+	}
+
+	return bytes.TrimSpace(pattern), nil
+}

--- a/kernel_corepattern_test.go
+++ b/kernel_corepattern_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package procfs
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestKernelCorePattern(t *testing.T) {
+	have, err := getProcFixtures(t).KernelCorePattern()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []byte("|/usr/share/apport/apport %p %s %c %d %P %E")
+	if !bytes.Equal(want, have) {
+		t.Fatalf("want pattern `%s`, have `%s`", want, have)
+	}
+
+}


### PR DESCRIPTION
Adds support for parsing `/proc/sys/kernel/core_pattern`.

Closes #342 