### PR TITLE
Fix Limits type

### DIFF
--- a/proc_limits_test.go
+++ b/proc_limits_test.go
@@ -28,10 +28,10 @@ func TestLimits(t *testing.T) {
 
 	for _, test := range []struct {
 		name string
-		want int64
-		have int64
+		want uint64
+		have uint64
 	}{
-		{name: "cpu time", want: -1, have: l.CPUTime},
+		{name: "cpu time", want: 18446744073709551615, have: l.CPUTime},
 		{name: "open files", want: 2048, have: l.OpenFiles},
 		{name: "msgqueue size", want: 819200, have: l.MsqqueueSize},
 		{name: "nice priority", want: 0, have: l.NicePriority},


### PR DESCRIPTION
Linux limits are uint64, not int64[0]. "unlimited" is also defined as
max uint64.

[0]: https://github.com/torvalds/linux/blob/7c53f6b671f4aba70ff15e1b05148b10d58c2837/include/uapi/linux/resource.h#L48-L53

Signed-off-by: Ben Kochie <superq@gmail.com>