### PR TITLE
Allow cgroup paths containing colons

### DIFF
--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -49,7 +49,7 @@ type Cgroup struct {
 func parseCgroupString(cgroupStr string) (*Cgroup, error) {
 	var err error
 
-	fields := strings.Split(cgroupStr, ":")
+	fields := strings.SplitN(cgroupStr, ":", 3)
 	if len(fields) < 3 {
 		return nil, fmt.Errorf("at least 3 fields required, found %d fields in cgroup string: %s", len(fields), cgroupStr)
 	}

--- a/proc_cgroup_test.go
+++ b/proc_cgroup_test.go
@@ -56,13 +56,13 @@ func TestParseCgroupString(t *testing.T) {
 			},
 		},
 		{
-			name:      "extra fields (such as those added by later kernel versions)",
-			s:         "0::/:foobar",
+			name:      "path containing colons",
+			s:         "0::/some/long/path:foobar",
 			shouldErr: false,
 			cgroup: &Cgroup{
 				HierarchyID: 0,
 				Controllers: nil,
-				Path:        "/",
+				Path:        "/some/long/path:foobar",
 			},
 		},
 		{


### PR DESCRIPTION
This change adds support for cgroup paths containing colons in the /procs/<pid>/cgroup file.

This is prompted by the following:
* The spec specifies that the *three* fields are separated by colons and does not forbid them in the path
* Tools such as containerd joins path components with colons when using systemd as a cgroup provider

This closes #353  
