### PR TITLE
Fix error returns

### DIFF
--- a/proc_psi.go
+++ b/proc_psi.go
@@ -59,7 +59,7 @@ type PSIStats struct {
 func (fs FS) PSIStatsForResource(resource string) (PSIStats, error) {
 	data, err := util.ReadFileNoStat(fs.proc.Path(fmt.Sprintf("%s/%s", "pressure", resource)))
 	if err != nil {
-		return PSIStats{}, fmt.Errorf("psi_stats: unavailable for %s", resource)
+		return PSIStats{}, fmt.Errorf("psi_stats: unavailable for %s, err: %s", resource, err)
 	}
 
 	return parsePSIStats(resource, bytes.NewReader(data))

--- a/sysfs/class_powercap.go
+++ b/sysfs/class_powercap.go
@@ -16,7 +16,7 @@
 package sysfs
 
 import (
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
@@ -41,8 +41,7 @@ func GetRaplZones(fs FS) ([]RaplZone, error) {
 
 	files, err := ioutil.ReadDir(raplDir)
 	if err != nil {
-		return nil, errors.New(
-			"no sysfs powercap / RAPL power metrics files found")
+		return nil, fmt.Errorf("unable to read class/powercap: %s", err)
 	}
 
 	var zones []RaplZone


### PR DESCRIPTION
Include `err` in some error returns to allow `error.Is()` to work.

Signed-off-by: Ben Kochie <superq@gmail.com>