### PR TITLE
Update error message handling

### DIFF
--- a/arp.go
+++ b/arp.go
@@ -36,7 +36,7 @@ type ARPEntry struct {
 func (fs FS) GatherARPEntries() ([]ARPEntry, error) {
 	data, err := ioutil.ReadFile(fs.proc.Path("net/arp"))
 	if err != nil {
-		return nil, fmt.Errorf("error reading arp %s: %s", fs.proc.Path("net/arp"), err)
+		return nil, fmt.Errorf("error reading arp %q: %w", fs.proc.Path("net/arp"), err)
 	}
 
 	return parseARPEntries(data)
@@ -59,7 +59,7 @@ func parseARPEntries(data []byte) ([]ARPEntry, error) {
 		} else if width == expectedDataWidth {
 			entry, err := parseARPEntry(columns)
 			if err != nil {
-				return []ARPEntry{}, fmt.Errorf("failed to parse ARP entry: %s", err)
+				return []ARPEntry{}, fmt.Errorf("failed to parse ARP entry: %w", err)
 			}
 			entries = append(entries, entry)
 		} else {

--- a/bcache/get.go
+++ b/bcache/get.go
@@ -329,12 +329,12 @@ func (p *parser) getPriorityStats() PriorityStats {
 	for scanner.Scan() {
 		err = parsePriorityStats(scanner.Text(), &res)
 		if err != nil {
-			p.err = fmt.Errorf("failed to parse: %s (%s)", path, err)
+			p.err = fmt.Errorf("failed to parse path %q: %w", path, err)
 			return res
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		p.err = fmt.Errorf("failed to parse: %s (%s)", path, err)
+		p.err = fmt.Errorf("failed to parse path %q: %w", path, err)
 		return res
 	}
 	return res
@@ -358,12 +358,12 @@ func (p *parser) getWritebackRateDebug() WritebackRateDebugStats {
 	for scanner.Scan() {
 		err = parseWritebackRateDebug(scanner.Text(), &res)
 		if err != nil {
-			p.err = fmt.Errorf("failed to parse: %s (%s)", path, err)
+			p.err = fmt.Errorf("failed to parse path %q: %w", path, err)
 			return res
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		p.err = fmt.Errorf("failed to parse: %s (%s)", path, err)
+		p.err = fmt.Errorf("failed to parse path %q: %w", path, err)
 		return res
 	}
 	return res

--- a/buddyinfo.go
+++ b/buddyinfo.go
@@ -74,7 +74,7 @@ func parseBuddyInfo(r io.Reader) ([]BuddyInfo, error) {
 		for i := 0; i < arraySize; i++ {
 			sizes[i], err = strconv.ParseFloat(parts[i+4], 64)
 			if err != nil {
-				return nil, fmt.Errorf("invalid value in buddyinfo: %s", err)
+				return nil, fmt.Errorf("invalid value in buddyinfo: %w", err)
 			}
 		}
 

--- a/cpuinfo.go
+++ b/cpuinfo.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -77,7 +78,7 @@ func parseCPUInfoX86(info []byte) ([]CPUInfo, error) {
 	// find the first "processor" line
 	firstLine := firstNonEmptyLine(scanner)
 	if !strings.HasPrefix(firstLine, "processor") || !strings.Contains(firstLine, ":") {
-		return nil, errors.New("invalid cpuinfo file: " + firstLine)
+		return nil, fmt.Errorf("invalid cpuinfo file: %q", firstLine)
 	}
 	field := strings.SplitN(firstLine, ": ", 2)
 	v, err := strconv.ParseUint(field[1], 0, 32)
@@ -192,7 +193,7 @@ func parseCPUInfoARM(info []byte) ([]CPUInfo, error) {
 	firstLine := firstNonEmptyLine(scanner)
 	match, _ := regexp.MatchString("^[Pp]rocessor", firstLine)
 	if !match || !strings.Contains(firstLine, ":") {
-		return nil, errors.New("invalid cpuinfo file: " + firstLine)
+		return nil, fmt.Errorf("invalid cpuinfo file: %q", firstLine)
 	}
 	field := strings.SplitN(firstLine, ": ", 2)
 	cpuinfo := []CPUInfo{}
@@ -256,7 +257,7 @@ func parseCPUInfoS390X(info []byte) ([]CPUInfo, error) {
 
 	firstLine := firstNonEmptyLine(scanner)
 	if !strings.HasPrefix(firstLine, "vendor_id") || !strings.Contains(firstLine, ":") {
-		return nil, errors.New("invalid cpuinfo file: " + firstLine)
+		return nil, fmt.Errorf("invalid cpuinfo file: %q", firstLine)
 	}
 	field := strings.SplitN(firstLine, ": ", 2)
 	cpuinfo := []CPUInfo{}
@@ -281,7 +282,7 @@ func parseCPUInfoS390X(info []byte) ([]CPUInfo, error) {
 		if strings.HasPrefix(line, "processor") {
 			match := cpuinfoS390XProcessorRegexp.FindStringSubmatch(line)
 			if len(match) < 2 {
-				return nil, errors.New("Invalid line found in cpuinfo: " + line)
+				return nil, fmt.Errorf("invalid cpuinfo file: %q", firstLine)
 			}
 			cpu := commonCPUInfo
 			v, err := strconv.ParseUint(match[1], 0, 32)
@@ -341,7 +342,7 @@ func parseCPUInfoMips(info []byte) ([]CPUInfo, error) {
 	// find the first "processor" line
 	firstLine := firstNonEmptyLine(scanner)
 	if !strings.HasPrefix(firstLine, "system type") || !strings.Contains(firstLine, ":") {
-		return nil, errors.New("invalid cpuinfo file: " + firstLine)
+		return nil, fmt.Errorf("invalid cpuinfo file: %q", firstLine)
 	}
 	field := strings.SplitN(firstLine, ": ", 2)
 	cpuinfo := []CPUInfo{}
@@ -383,7 +384,7 @@ func parseCPUInfoPPC(info []byte) ([]CPUInfo, error) {
 
 	firstLine := firstNonEmptyLine(scanner)
 	if !strings.HasPrefix(firstLine, "processor") || !strings.Contains(firstLine, ":") {
-		return nil, errors.New("invalid cpuinfo file: " + firstLine)
+		return nil, fmt.Errorf("invalid cpuinfo file: %q", firstLine)
 	}
 	field := strings.SplitN(firstLine, ": ", 2)
 	v, err := strconv.ParseUint(field[1], 0, 32)
@@ -428,7 +429,7 @@ func parseCPUInfoRISCV(info []byte) ([]CPUInfo, error) {
 
 	firstLine := firstNonEmptyLine(scanner)
 	if !strings.HasPrefix(firstLine, "processor") || !strings.Contains(firstLine, ":") {
-		return nil, errors.New("invalid cpuinfo file: " + firstLine)
+		return nil, fmt.Errorf("invalid cpuinfo file: %q", firstLine)
 	}
 	field := strings.SplitN(firstLine, ": ", 2)
 	v, err := strconv.ParseUint(field[1], 0, 32)

--- a/crypto.go
+++ b/crypto.go
@@ -55,12 +55,12 @@ func (fs FS) Crypto() ([]Crypto, error) {
 	path := fs.proc.Path("crypto")
 	b, err := util.ReadFileNoStat(path)
 	if err != nil {
-		return nil, fmt.Errorf("error reading crypto %s: %s", path, err)
+		return nil, fmt.Errorf("error reading crypto %q: %w", path, err)
 	}
 
 	crypto, err := parseCrypto(bytes.NewReader(b))
 	if err != nil {
-		return nil, fmt.Errorf("error parsing crypto %s: %s", path, err)
+		return nil, fmt.Errorf("error parsing crypto %q: %w", path, err)
 	}
 
 	return crypto, nil

--- a/fscache.go
+++ b/fscache.go
@@ -236,7 +236,7 @@ func (fs FS) Fscacheinfo() (Fscacheinfo, error) {
 
 	m, err := parseFscacheinfo(bytes.NewReader(b))
 	if err != nil {
-		return Fscacheinfo{}, fmt.Errorf("failed to parse Fscacheinfo: %v", err)
+		return Fscacheinfo{}, fmt.Errorf("failed to parse Fscacheinfo: %w", err)
 	}
 
 	return *m, nil

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/prometheus/procfs
 
-go 1.12
+go 1.13
 
 require (
-	github.com/google/go-cmp v0.3.1
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e
+	github.com/google/go-cmp v0.5.4
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
-github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
-github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e h1:LwyF2AFISC9nVbS6MgzsaQNSUsRXI49GS+YQ5KX/QH0=
-golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -39,10 +39,10 @@ type FS string
 func NewFS(mountPoint string) (FS, error) {
 	info, err := os.Stat(mountPoint)
 	if err != nil {
-		return "", fmt.Errorf("could not read %s: %s", mountPoint, err)
+		return "", fmt.Errorf("could not read %q: %w", mountPoint, err)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("mount point %s is not a directory", mountPoint)
+		return "", fmt.Errorf("mount point %q is not a directory", mountPoint)
 	}
 
 	return FS(mountPoint), nil

--- a/loadavg.go
+++ b/loadavg.go
@@ -44,14 +44,14 @@ func parseLoad(loadavgBytes []byte) (*LoadAvg, error) {
 	loads := make([]float64, 3)
 	parts := strings.Fields(string(loadavgBytes))
 	if len(parts) < 3 {
-		return nil, fmt.Errorf("malformed loadavg line: too few fields in loadavg string: %s", string(loadavgBytes))
+		return nil, fmt.Errorf("malformed loadavg line: too few fields in loadavg string: %q", string(loadavgBytes))
 	}
 
 	var err error
 	for i, load := range parts[0:3] {
 		loads[i], err = strconv.ParseFloat(load, 64)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse load '%s': %s", load, err)
+			return nil, fmt.Errorf("could not parse load %q: %w", load, err)
 		}
 	}
 	return &LoadAvg{

--- a/mdstat.go
+++ b/mdstat.go
@@ -59,7 +59,7 @@ func (fs FS) MDStat() ([]MDStat, error) {
 	}
 	mdstat, err := parseMDStat(data)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing mdstat %s: %s", fs.proc.Path("mdstat"), err)
+		return nil, fmt.Errorf("error parsing mdstat %q: %w", fs.proc.Path("mdstat"), err)
 	}
 	return mdstat, nil
 }
@@ -85,10 +85,7 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 		state := deviceFields[2]  // active or inactive
 
 		if len(lines) <= i+3 {
-			return nil, fmt.Errorf(
-				"error parsing %s: too few lines for md device",
-				mdName,
-			)
+			return nil, fmt.Errorf("error parsing %q: too few lines for md device", mdName)
 		}
 
 		// Failed disks have the suffix (F) & Spare disks have the suffix (S).
@@ -97,7 +94,7 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 		active, total, size, err := evalStatusLine(lines[i], lines[i+1])
 
 		if err != nil {
-			return nil, fmt.Errorf("error parsing md device lines: %s", err)
+			return nil, fmt.Errorf("error parsing md device lines: %w", err)
 		}
 
 		syncLineIdx := i + 2
@@ -129,7 +126,7 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 			} else {
 				syncedBlocks, err = evalRecoveryLine(lines[syncLineIdx])
 				if err != nil {
-					return nil, fmt.Errorf("error parsing sync line in md device %s: %s", mdName, err)
+					return nil, fmt.Errorf("error parsing sync line in md device %q: %w", mdName, err)
 				}
 			}
 		}
@@ -155,7 +152,7 @@ func evalStatusLine(deviceLine, statusLine string) (active, total, size int64, e
 	sizeStr := strings.Fields(statusLine)[0]
 	size, err = strconv.ParseInt(sizeStr, 10, 64)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("unexpected statusLine %s: %s", statusLine, err)
+		return 0, 0, 0, fmt.Errorf("unexpected statusLine %q: %w", statusLine, err)
 	}
 
 	if strings.Contains(deviceLine, "raid0") || strings.Contains(deviceLine, "linear") {
@@ -175,12 +172,12 @@ func evalStatusLine(deviceLine, statusLine string) (active, total, size int64, e
 
 	total, err = strconv.ParseInt(matches[2], 10, 64)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("unexpected statusLine %s: %s", statusLine, err)
+		return 0, 0, 0, fmt.Errorf("unexpected statusLine %q: %w", statusLine, err)
 	}
 
 	active, err = strconv.ParseInt(matches[3], 10, 64)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("unexpected statusLine %s: %s", statusLine, err)
+		return 0, 0, 0, fmt.Errorf("unexpected statusLine %q: %w", statusLine, err)
 	}
 
 	return active, total, size, nil
@@ -194,7 +191,7 @@ func evalRecoveryLine(recoveryLine string) (syncedBlocks int64, err error) {
 
 	syncedBlocks, err = strconv.ParseInt(matches[1], 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("%s in recoveryLine: %s", err, recoveryLine)
+		return 0, fmt.Errorf("error parsing int from recoveryLine %q: %w", recoveryLine, err)
 	}
 
 	return syncedBlocks, nil

--- a/meminfo.go
+++ b/meminfo.go
@@ -152,7 +152,7 @@ func (fs FS) Meminfo() (Meminfo, error) {
 
 	m, err := parseMemInfo(bytes.NewReader(b))
 	if err != nil {
-		return Meminfo{}, fmt.Errorf("failed to parse meminfo: %v", err)
+		return Meminfo{}, fmt.Errorf("failed to parse meminfo: %w", err)
 	}
 
 	return *m, nil

--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -393,7 +393,7 @@ func TestMountStats(t *testing.T) {
 			t.Error("expected an error, but none occurred")
 		}
 		if !tt.invalid && err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("unexpected error: %w", err)
 		}
 
 		if want, have := tt.mounts, mounts; !reflect.DeepEqual(want, have) {
@@ -434,7 +434,7 @@ func TestMountStatsExtendedOperationStats(t *testing.T) {
 	r := strings.NewReader(extendedOpsExampleMountstats)
 	_, err := parseMountStats(r)
 	if err != nil {
-		t.Errorf("failed to parse mount stats with extended per-op statistics: %v", err)
+		t.Errorf("failed to parse mount stats with extended per-op statistics: %w", err)
 	}
 }
 

--- a/net_conntrackstat.go
+++ b/net_conntrackstat.go
@@ -55,7 +55,7 @@ func readConntrackStat(path string) ([]ConntrackStatEntry, error) {
 
 	stat, err := parseConntrackStat(bytes.NewReader(b))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read conntrack stats from %q: %v", path, err)
+		return nil, fmt.Errorf("failed to read conntrack stats from %q: %w", path, err)
 	}
 
 	return stat, nil
@@ -147,7 +147,7 @@ func parseConntrackStatEntry(fields []string) (*ConntrackStatEntry, error) {
 func parseConntrackStatField(field string) (uint64, error) {
 	val, err := strconv.ParseUint(field, 16, 64)
 	if err != nil {
-		return 0, fmt.Errorf("couldn't parse \"%s\" field: %s", field, err)
+		return 0, fmt.Errorf("couldn't parse %q field: %w", field, err)
 	}
 	return val, err
 }

--- a/net_ip_socket.go
+++ b/net_ip_socket.go
@@ -129,8 +129,7 @@ func parseIP(hexIP string) (net.IP, error) {
 	var byteIP []byte
 	byteIP, err := hex.DecodeString(hexIP)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"cannot parse address field in socket line: %s", hexIP)
+		return nil, fmt.Errorf("cannot parse address field in socket line %q", hexIP)
 	}
 	switch len(byteIP) {
 	case 4:
@@ -153,7 +152,7 @@ func parseNetIPSocketLine(fields []string) (*netIPSocketLine, error) {
 	line := &netIPSocketLine{}
 	if len(fields) < 8 {
 		return nil, fmt.Errorf(
-			"cannot parse net socket line as it has less then 8 columns: %s",
+			"cannot parse net socket line as it has less then 8 columns %q",
 			strings.Join(fields, " "),
 		)
 	}
@@ -162,66 +161,59 @@ func parseNetIPSocketLine(fields []string) (*netIPSocketLine, error) {
 	// sl
 	s := strings.Split(fields[0], ":")
 	if len(s) != 2 {
-		return nil, fmt.Errorf(
-			"cannot parse sl field in socket line: %s", fields[0])
+		return nil, fmt.Errorf("cannot parse sl field in socket line %q", fields[0])
 	}
 
 	if line.Sl, err = strconv.ParseUint(s[0], 0, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse sl value in socket line: %s", err)
+		return nil, fmt.Errorf("cannot parse sl value in socket line: %w", err)
 	}
 	// local_address
 	l := strings.Split(fields[1], ":")
 	if len(l) != 2 {
-		return nil, fmt.Errorf(
-			"cannot parse local_address field in socket line: %s", fields[1])
+		return nil, fmt.Errorf("cannot parse local_address field in socket line %q", fields[1])
 	}
 	if line.LocalAddr, err = parseIP(l[0]); err != nil {
 		return nil, err
 	}
 	if line.LocalPort, err = strconv.ParseUint(l[1], 16, 64); err != nil {
-		return nil, fmt.Errorf(
-			"cannot parse local_address port value in socket line: %s", err)
+		return nil, fmt.Errorf("cannot parse local_address port value in socket line: %w", err)
 	}
 
 	// remote_address
 	r := strings.Split(fields[2], ":")
 	if len(r) != 2 {
-		return nil, fmt.Errorf(
-			"cannot parse rem_address field in socket line: %s", fields[1])
+		return nil, fmt.Errorf("cannot parse rem_address field in socket line %q", fields[1])
 	}
 	if line.RemAddr, err = parseIP(r[0]); err != nil {
 		return nil, err
 	}
 	if line.RemPort, err = strconv.ParseUint(r[1], 16, 64); err != nil {
-		return nil, fmt.Errorf(
-			"cannot parse rem_address port value in socket line: %s", err)
+		return nil, fmt.Errorf("cannot parse rem_address port value in socket line: %w", err)
 	}
 
 	// st
 	if line.St, err = strconv.ParseUint(fields[3], 16, 64); err != nil {
-		return nil, fmt.Errorf(
-			"cannot parse st value in socket line: %s", err)
+		return nil, fmt.Errorf("cannot parse st value in socket line: %w", err)
 	}
 
 	// tx_queue and rx_queue
 	q := strings.Split(fields[4], ":")
 	if len(q) != 2 {
 		return nil, fmt.Errorf(
-			"cannot parse tx/rx queues in socket line as it has a missing colon: %s",
+			"cannot parse tx/rx queues in socket line as it has a missing colon %q",
 			fields[4],
 		)
 	}
 	if line.TxQueue, err = strconv.ParseUint(q[0], 16, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse tx_queue value in socket line: %s", err)
+		return nil, fmt.Errorf("cannot parse tx_queue value in socket line: %w", err)
 	}
 	if line.RxQueue, err = strconv.ParseUint(q[1], 16, 64); err != nil {
-		return nil, fmt.Errorf("cannot parse rx_queue value in socket line: %s", err)
+		return nil, fmt.Errorf("cannot parse rx_queue value in socket line: %w", err)
 	}
 
 	// uid
 	if line.UID, err = strconv.ParseUint(fields[7], 0, 64); err != nil {
-		return nil, fmt.Errorf(
-			"cannot parse uid value in socket line: %s", err)
+		return nil, fmt.Errorf("cannot parse uid value in socket line: %w", err)
 	}
 
 	return line, nil

--- a/net_sockstat.go
+++ b/net_sockstat.go
@@ -70,7 +70,7 @@ func readSockstat(name string) (*NetSockstat, error) {
 
 	stat, err := parseSockstat(bytes.NewReader(b))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read sockstats from %q: %v", name, err)
+		return nil, fmt.Errorf("failed to read sockstats from %q: %w", name, err)
 	}
 
 	return stat, nil
@@ -90,7 +90,7 @@ func parseSockstat(r io.Reader) (*NetSockstat, error) {
 		// The remaining fields are key/value pairs.
 		kvs, err := parseSockstatKVs(fields[1:])
 		if err != nil {
-			return nil, fmt.Errorf("error parsing sockstat key/value pairs from %q: %v", s.Text(), err)
+			return nil, fmt.Errorf("error parsing sockstat key/value pairs from %q: %w", s.Text(), err)
 		}
 
 		// The first field is the protocol. We must trim its colon suffix.

--- a/net_softnet.go
+++ b/net_softnet.go
@@ -51,7 +51,7 @@ func (fs FS) NetSoftnetStat() ([]SoftnetStat, error) {
 
 	entries, err := parseSoftnet(bytes.NewReader(b))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse /proc/net/softnet_stat: %v", err)
+		return nil, fmt.Errorf("failed to parse /proc/net/softnet_stat: %w", err)
 	}
 
 	return entries, nil

--- a/net_unix.go
+++ b/net_unix.go
@@ -108,14 +108,14 @@ func parseNetUNIX(r io.Reader) (*NetUNIX, error) {
 		line := s.Text()
 		item, err := nu.parseLine(line, hasInode, minFields)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse /proc/net/unix data %q: %v", line, err)
+			return nil, fmt.Errorf("failed to parse /proc/net/unix data %q: %w", line, err)
 		}
 
 		nu.Rows = append(nu.Rows, item)
 	}
 
 	if err := s.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan /proc/net/unix data: %v", err)
+		return nil, fmt.Errorf("failed to scan /proc/net/unix data: %w", err)
 	}
 
 	return &nu, nil
@@ -136,29 +136,29 @@ func (u *NetUNIX) parseLine(line string, hasInode bool, min int) (*NetUNIXLine, 
 
 	users, err := u.parseUsers(fields[1])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse ref count(%s): %v", fields[1], err)
+		return nil, fmt.Errorf("failed to parse ref count %q: %w", fields[1], err)
 	}
 
 	flags, err := u.parseFlags(fields[3])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse flags(%s): %v", fields[3], err)
+		return nil, fmt.Errorf("failed to parse flags %q: %w", fields[3], err)
 	}
 
 	typ, err := u.parseType(fields[4])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse type(%s): %v", fields[4], err)
+		return nil, fmt.Errorf("failed to parse type %q: %w", fields[4], err)
 	}
 
 	state, err := u.parseState(fields[5])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse state(%s): %v", fields[5], err)
+		return nil, fmt.Errorf("failed to parse state %q: %w", fields[5], err)
 	}
 
 	var inode uint64
 	if hasInode {
 		inode, err = u.parseInode(fields[6])
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse inode(%s): %v", fields[6], err)
+			return nil, fmt.Errorf("failed to parse inode %q: %w", fields[6], err)
 		}
 	}
 

--- a/nfs/parse_nfs.go
+++ b/nfs/parse_nfs.go
@@ -37,7 +37,7 @@ func ParseClientRPCStats(r io.Reader) (*ClientRPCStats, error) {
 
 		values, err := util.ParseUint64s(parts[1:])
 		if err != nil {
-			return nil, fmt.Errorf("error parsing NFS metric line: %s", err)
+			return nil, fmt.Errorf("error parsing NFS metric line: %w", err)
 		}
 
 		switch metricLine := parts[0]; metricLine {
@@ -55,12 +55,12 @@ func ParseClientRPCStats(r io.Reader) (*ClientRPCStats, error) {
 			return nil, fmt.Errorf("unknown NFS metric line %q", metricLine)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("errors parsing NFS metric line: %s", err)
+			return nil, fmt.Errorf("errors parsing NFS metric line: %w", err)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error scanning NFS file: %s", err)
+		return nil, fmt.Errorf("error scanning NFS file: %w", err)
 	}
 
 	return stats, nil

--- a/nfs/parse_nfsd.go
+++ b/nfs/parse_nfsd.go
@@ -47,7 +47,7 @@ func ParseServerRPCStats(r io.Reader) (*ServerRPCStats, error) {
 			values, err = util.ParseUint64s(parts[1:])
 		}
 		if err != nil {
-			return nil, fmt.Errorf("error parsing NFSd metric line: %s", err)
+			return nil, fmt.Errorf("error parsing NFSd metric line: %w", err)
 		}
 
 		switch metricLine := parts[0]; metricLine {
@@ -77,12 +77,12 @@ func ParseServerRPCStats(r io.Reader) (*ServerRPCStats, error) {
 			return nil, fmt.Errorf("unknown NFSd metric line %q", metricLine)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("errors parsing NFSd metric line: %s", err)
+			return nil, fmt.Errorf("errors parsing NFSd metric line: %w", err)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error scanning NFSd file: %s", err)
+		return nil, fmt.Errorf("error scanning NFSd file: %w", err)
 	}
 
 	return stats, nil

--- a/proc.go
+++ b/proc.go
@@ -105,7 +105,7 @@ func (fs FS) AllProcs() (Procs, error) {
 
 	names, err := d.Readdirnames(-1)
 	if err != nil {
-		return Procs{}, fmt.Errorf("could not read %s: %s", d.Name(), err)
+		return Procs{}, fmt.Errorf("could not read %q: %w", d.Name(), err)
 	}
 
 	p := Procs{}
@@ -206,7 +206,7 @@ func (p Proc) FileDescriptors() ([]uintptr, error) {
 	for i, n := range names {
 		fd, err := strconv.ParseInt(n, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse fd %s: %s", n, err)
+			return nil, fmt.Errorf("could not parse fd %q: %w", n, err)
 		}
 		fds[i] = uintptr(fd)
 	}
@@ -278,7 +278,7 @@ func (p Proc) fileDescriptors() ([]string, error) {
 
 	names, err := d.Readdirnames(-1)
 	if err != nil {
-		return nil, fmt.Errorf("could not read %s: %s", d.Name(), err)
+		return nil, fmt.Errorf("could not read %q: %w", d.Name(), err)
 	}
 
 	return names, nil

--- a/proc_fdinfo.go
+++ b/proc_fdinfo.go
@@ -16,7 +16,7 @@ package procfs
 import (
 	"bufio"
 	"bytes"
-	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/prometheus/procfs/internal/util"
@@ -112,7 +112,7 @@ func parseInotifyInfo(line string) (*InotifyInfo, error) {
 		}
 		return i, nil
 	}
-	return nil, errors.New("invalid inode entry: " + line)
+	return nil, fmt.Errorf("invalid inode entry: %q", line)
 }
 
 // ProcFDInfos represents a list of ProcFDInfo structs.

--- a/proc_limits.go
+++ b/proc_limits.go
@@ -103,8 +103,7 @@ func (p Proc) Limits() (ProcLimits, error) {
 		//fields := limitsMatch.Split(s.Text(), limitsFields)
 		fields := limitsMatch.FindStringSubmatch(s.Text())
 		if len(fields) != limitsFields {
-			return ProcLimits{}, fmt.Errorf(
-				"couldn't parse %s line %s", f.Name(), s.Text())
+			return ProcLimits{}, fmt.Errorf("couldn't parse %q line %q", f.Name(), s.Text())
 		}
 
 		switch fields[1] {
@@ -155,7 +154,7 @@ func parseUint(s string) (uint64, error) {
 	}
 	i, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("couldn't parse value %s: %s", s, err)
+		return 0, fmt.Errorf("couldn't parse value %q: %w", s, err)
 	}
 	return i, nil
 }

--- a/proc_ns.go
+++ b/proc_ns.go
@@ -40,7 +40,7 @@ func (p Proc) Namespaces() (Namespaces, error) {
 
 	names, err := d.Readdirnames(-1)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read contents of ns dir: %v", err)
+		return nil, fmt.Errorf("failed to read contents of ns dir: %w", err)
 	}
 
 	ns := make(Namespaces, len(names))
@@ -52,13 +52,13 @@ func (p Proc) Namespaces() (Namespaces, error) {
 
 		fields := strings.SplitN(target, ":", 2)
 		if len(fields) != 2 {
-			return nil, fmt.Errorf("failed to parse namespace type and inode from '%v'", target)
+			return nil, fmt.Errorf("failed to parse namespace type and inode from %q", target)
 		}
 
 		typ := fields[0]
 		inode, err := strconv.ParseUint(strings.Trim(fields[1], "[]"), 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse inode from '%v': %v", fields[1], err)
+			return nil, fmt.Errorf("failed to parse inode from %q: %w", fields[1], err)
 		}
 
 		ns[name] = Namespace{typ, uint32(inode)}

--- a/proc_psi.go
+++ b/proc_psi.go
@@ -59,7 +59,7 @@ type PSIStats struct {
 func (fs FS) PSIStatsForResource(resource string) (PSIStats, error) {
 	data, err := util.ReadFileNoStat(fs.proc.Path(fmt.Sprintf("%s/%s", "pressure", resource)))
 	if err != nil {
-		return PSIStats{}, fmt.Errorf("psi_stats: unavailable for %s, err: %s", resource, err)
+		return PSIStats{}, fmt.Errorf("psi_stats: unavailable for %q: %w", resource, err)
 	}
 
 	return parsePSIStats(resource, bytes.NewReader(data))

--- a/proc_stat.go
+++ b/proc_stat.go
@@ -127,10 +127,7 @@ func (p Proc) Stat() (ProcStat, error) {
 	)
 
 	if l < 0 || r < 0 {
-		return ProcStat{}, fmt.Errorf(
-			"unexpected format, couldn't extract comm: %s",
-			data,
-		)
+		return ProcStat{}, fmt.Errorf("unexpected format, couldn't extract comm %q", data)
 	}
 
 	s.Comm = string(data[l+1 : r])

--- a/schedstat.go
+++ b/schedstat.go
@@ -95,24 +95,27 @@ func (fs FS) Schedstat() (*Schedstat, error) {
 	return stats, nil
 }
 
-func parseProcSchedstat(contents string) (stats ProcSchedstat, err error) {
+func parseProcSchedstat(contents string) (ProcSchedstat, error) {
+	var (
+		stats ProcSchedstat
+		err   error
+	)
 	match := procLineRE.FindStringSubmatch(contents)
 
 	if match != nil {
 		stats.RunningNanoseconds, err = strconv.ParseUint(match[1], 10, 64)
 		if err != nil {
-			return
+			return stats, err
 		}
 
 		stats.WaitingNanoseconds, err = strconv.ParseUint(match[2], 10, 64)
 		if err != nil {
-			return
+			return stats, err
 		}
 
 		stats.RunTimeslices, err = strconv.ParseUint(match[3], 10, 64)
-		return
+		return stats, err
 	}
 
-	err = errors.New("could not parse schedstat")
-	return
+	return stats, errors.New("could not parse schedstat")
 }

--- a/slab.go
+++ b/slab.go
@@ -16,7 +16,7 @@ package procfs
 import (
 	"bufio"
 	"bytes"
-	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -68,7 +68,7 @@ func parseV21SlabEntry(line string) (*Slab, error) {
 	l := slabSpace.ReplaceAllString(line, " ")
 	s := strings.Split(l, " ")
 	if len(s) != 16 {
-		return nil, errors.New("unable to parse: " + line)
+		return nil, fmt.Errorf("unable to parse: %q", line)
 	}
 	var err error
 	i := &Slab{Name: s[0]}

--- a/stat.go
+++ b/stat.go
@@ -93,10 +93,10 @@ func parseCPUStat(line string) (CPUStat, int64, error) {
 		&cpuStat.Guest, &cpuStat.GuestNice)
 
 	if err != nil && err != io.EOF {
-		return CPUStat{}, -1, fmt.Errorf("couldn't parse %s (cpu): %s", line, err)
+		return CPUStat{}, -1, fmt.Errorf("couldn't parse %q (cpu): %w", line, err)
 	}
 	if count == 0 {
-		return CPUStat{}, -1, fmt.Errorf("couldn't parse %s (cpu): 0 elements parsed", line)
+		return CPUStat{}, -1, fmt.Errorf("couldn't parse %q (cpu): 0 elements parsed", line)
 	}
 
 	cpuStat.User /= userHZ
@@ -116,7 +116,7 @@ func parseCPUStat(line string) (CPUStat, int64, error) {
 
 	cpuID, err := strconv.ParseInt(cpu[3:], 10, 64)
 	if err != nil {
-		return CPUStat{}, -1, fmt.Errorf("couldn't parse %s (cpu/cpuid): %s", line, err)
+		return CPUStat{}, -1, fmt.Errorf("couldn't parse %q (cpu/cpuid): %w", line, err)
 	}
 
 	return cpuStat, cpuID, nil
@@ -136,7 +136,7 @@ func parseSoftIRQStat(line string) (SoftIRQStat, uint64, error) {
 		&softIRQStat.Hrtimer, &softIRQStat.Rcu)
 
 	if err != nil {
-		return SoftIRQStat{}, 0, fmt.Errorf("couldn't parse %s (softirq): %s", line, err)
+		return SoftIRQStat{}, 0, fmt.Errorf("couldn't parse %q (softirq): %w", line, err)
 	}
 
 	return softIRQStat, total, nil
@@ -184,34 +184,34 @@ func (fs FS) Stat() (Stat, error) {
 		switch {
 		case parts[0] == "btime":
 			if stat.BootTime, err = strconv.ParseUint(parts[1], 10, 64); err != nil {
-				return Stat{}, fmt.Errorf("couldn't parse %s (btime): %s", parts[1], err)
+				return Stat{}, fmt.Errorf("couldn't parse %q (btime): %w", parts[1], err)
 			}
 		case parts[0] == "intr":
 			if stat.IRQTotal, err = strconv.ParseUint(parts[1], 10, 64); err != nil {
-				return Stat{}, fmt.Errorf("couldn't parse %s (intr): %s", parts[1], err)
+				return Stat{}, fmt.Errorf("couldn't parse %q (intr): %w", parts[1], err)
 			}
 			numberedIRQs := parts[2:]
 			stat.IRQ = make([]uint64, len(numberedIRQs))
 			for i, count := range numberedIRQs {
 				if stat.IRQ[i], err = strconv.ParseUint(count, 10, 64); err != nil {
-					return Stat{}, fmt.Errorf("couldn't parse %s (intr%d): %s", count, i, err)
+					return Stat{}, fmt.Errorf("couldn't parse %q (intr%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "ctxt":
 			if stat.ContextSwitches, err = strconv.ParseUint(parts[1], 10, 64); err != nil {
-				return Stat{}, fmt.Errorf("couldn't parse %s (ctxt): %s", parts[1], err)
+				return Stat{}, fmt.Errorf("couldn't parse %q (ctxt): %w", parts[1], err)
 			}
 		case parts[0] == "processes":
 			if stat.ProcessCreated, err = strconv.ParseUint(parts[1], 10, 64); err != nil {
-				return Stat{}, fmt.Errorf("couldn't parse %s (processes): %s", parts[1], err)
+				return Stat{}, fmt.Errorf("couldn't parse %q (processes): %w", parts[1], err)
 			}
 		case parts[0] == "procs_running":
 			if stat.ProcessesRunning, err = strconv.ParseUint(parts[1], 10, 64); err != nil {
-				return Stat{}, fmt.Errorf("couldn't parse %s (procs_running): %s", parts[1], err)
+				return Stat{}, fmt.Errorf("couldn't parse %q (procs_running): %w", parts[1], err)
 			}
 		case parts[0] == "procs_blocked":
 			if stat.ProcessesBlocked, err = strconv.ParseUint(parts[1], 10, 64); err != nil {
-				return Stat{}, fmt.Errorf("couldn't parse %s (procs_blocked): %s", parts[1], err)
+				return Stat{}, fmt.Errorf("couldn't parse %q (procs_blocked): %w", parts[1], err)
 			}
 		case parts[0] == "softirq":
 			softIRQStats, total, err := parseSoftIRQStat(line)
@@ -237,7 +237,7 @@ func (fs FS) Stat() (Stat, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return Stat{}, fmt.Errorf("couldn't parse %s: %s", fileName, err)
+		return Stat{}, fmt.Errorf("couldn't parse %q: %w", fileName, err)
 	}
 
 	return stat, nil

--- a/swaps_test.go
+++ b/swaps_test.go
@@ -102,7 +102,7 @@ func TestParseSwapString(t *testing.T) {
 				t.Error("unexpected success")
 			}
 			if !tt.invalid && err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error: %w", err)
 			}
 
 			if !reflect.DeepEqual(tt.swap, swap) {

--- a/sysfs/class_fibrechannel.go
+++ b/sysfs/class_fibrechannel.go
@@ -92,7 +92,7 @@ func (fs FS) parseFibreChannelHost(name string) (*FibreChannelHost, error) {
 		name := filepath.Join(path, f)
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 
 		switch f {
@@ -164,7 +164,7 @@ func parseFibreChannelStatistics(hostPath string) (*FibreChannelCounters, error)
 			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
 				continue
 			}
-			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 
 		vp := util.NewValueParser(value)

--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -126,7 +126,7 @@ func (fs FS) parseInfiniBandDevice(name string) (*InfiniBandDevice, error) {
 		name := filepath.Join(path, f)
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 
 		switch f {
@@ -142,7 +142,7 @@ func (fs FS) parseInfiniBandDevice(name string) (*InfiniBandDevice, error) {
 	portsPath := filepath.Join(path, "ports")
 	ports, err := ioutil.ReadDir(portsPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list InfiniBand ports at %q: %v", portsPath, err)
+		return nil, fmt.Errorf("failed to list InfiniBand ports at %q: %w", portsPath, err)
 	}
 
 	device.Ports = make(map[uint]InfiniBandPort, len(ports))
@@ -204,7 +204,7 @@ func (fs FS) parseInfiniBandPort(name string, port string) (*InfiniBandPort, err
 	}
 	id, name, err := parseState(string(content))
 	if err != nil {
-		return nil, fmt.Errorf("could not parse state file in %s: %s", portPath, err)
+		return nil, fmt.Errorf("could not parse state file in %q: %w", portPath, err)
 	}
 	ibp.State = name
 	ibp.StateID = id
@@ -215,7 +215,7 @@ func (fs FS) parseInfiniBandPort(name string, port string) (*InfiniBandPort, err
 	}
 	id, name, err = parseState(string(content))
 	if err != nil {
-		return nil, fmt.Errorf("could not parse phys_state file in %s: %s", portPath, err)
+		return nil, fmt.Errorf("could not parse phys_state file in %q: %w", portPath, err)
 	}
 	ibp.PhysState = name
 	ibp.PhysStateID = id
@@ -226,7 +226,7 @@ func (fs FS) parseInfiniBandPort(name string, port string) (*InfiniBandPort, err
 	}
 	ibp.Rate, err = parseRate(string(content))
 	if err != nil {
-		return nil, fmt.Errorf("could not parse rate file in %s: %s", portPath, err)
+		return nil, fmt.Errorf("could not parse rate file in %q: %w", portPath, err)
 	}
 
 	counters, err := parseInfiniBandCounters(portPath)
@@ -258,7 +258,7 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
 				continue
 			}
-			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 
 		// According to Mellanox, the metrics port_rcv_data, port_xmit_data,
@@ -349,7 +349,7 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
 				continue
 			}
-			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 
 		vp := util.NewValueParser(value)

--- a/sysfs/class_power_supply.go
+++ b/sysfs/class_power_supply.go
@@ -145,7 +145,7 @@ func parsePowerSupply(path string) (*PowerSupply, error) {
 			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
 				continue
 			}
-			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 
 		vp := util.NewValueParser(value)

--- a/sysfs/class_powercap.go
+++ b/sysfs/class_powercap.go
@@ -41,7 +41,7 @@ func GetRaplZones(fs FS) ([]RaplZone, error) {
 
 	files, err := ioutil.ReadDir(raplDir)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read class/powercap: %s", err)
+		return nil, fmt.Errorf("unable to read class/powercap: %w", err)
 	}
 
 	var zones []RaplZone

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -69,7 +69,7 @@ func (fs FS) NetClassDevices() ([]string, error) {
 
 	devices, err := ioutil.ReadDir(path)
 	if err != nil {
-		return res, fmt.Errorf("cannot access %s dir %s", path, err)
+		return res, fmt.Errorf("cannot access dir %q: %w", path, err)
 	}
 
 	for _, deviceDir := range devices {
@@ -122,7 +122,7 @@ func (nc NetClass) parseNetClassIface(devicePath string) (*NetClassIface, error)
 			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
 				continue
 			}
-			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 		vp := util.NewValueParser(value)
 		switch f.Name() {

--- a/xfrm.go
+++ b/xfrm.go
@@ -112,8 +112,7 @@ func (fs FS) NewXfrmStat() (XfrmStat, error) {
 		fields := strings.Fields(s.Text())
 
 		if len(fields) != 2 {
-			return XfrmStat{}, fmt.Errorf(
-				"couldn't parse %s line %s", file.Name(), s.Text())
+			return XfrmStat{}, fmt.Errorf("couldn't parse %q line %q", file.Name(), s.Text())
 		}
 
 		name := fields[0]

--- a/zoneinfo.go
+++ b/zoneinfo.go
@@ -74,11 +74,11 @@ var nodeZoneRE = regexp.MustCompile(`(\d+), zone\s+(\w+)`)
 func (fs FS) Zoneinfo() ([]Zoneinfo, error) {
 	data, err := ioutil.ReadFile(fs.proc.Path("zoneinfo"))
 	if err != nil {
-		return nil, fmt.Errorf("error reading zoneinfo %s: %s", fs.proc.Path("zoneinfo"), err)
+		return nil, fmt.Errorf("error reading zoneinfo %q: %w", fs.proc.Path("zoneinfo"), err)
 	}
 	zoneinfo, err := parseZoneinfo(data)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing zoneinfo %s: %s", fs.proc.Path("zoneinfo"), err)
+		return nil, fmt.Errorf("error parsing zoneinfo %q: %w", fs.proc.Path("zoneinfo"), err)
 	}
 	return zoneinfo, nil
 }


### PR DESCRIPTION
Use Go 1.13 `%w` error formatting
* Update minimum Go version to 1.13.
* Bump vendoring.
* Update all error format strings to use %w.
* Cleanup consistency of use.
* Cleanup use of `errors.New("string" + var)` to use `fmt.Errorf()`.

https://github.com/prometheus/procfs/issues/310

Signed-off-by: Ben Kochie <superq@gmail.com>