### PR TITLE
Mark sysfs as Linux-only

### DIFF
--- a/sysfs/class_cooling_device.go
+++ b/sysfs/class_cooling_device.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_cooling_device_test.go
+++ b/sysfs/class_cooling_device_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_fibrechannel.go
+++ b/sysfs/class_fibrechannel.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_fibrechannel_test.go
+++ b/sysfs/class_fibrechannel_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_infiniband_test.go
+++ b/sysfs/class_infiniband_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_power_supply.go
+++ b/sysfs/class_power_supply.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_power_supply_test.go
+++ b/sysfs/class_power_supply_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_powercap.go
+++ b/sysfs/class_powercap.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_powercap_test.go
+++ b/sysfs/class_powercap_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_thermal.go
+++ b/sysfs/class_thermal.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows,!freebsd
+// +build linux
 
 package sysfs
 

--- a/sysfs/class_thermal.go
+++ b/sysfs/class_thermal.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build !windows,!freebsd
 
 package sysfs
 

--- a/sysfs/class_thermal_test.go
+++ b/sysfs/class_thermal_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/clocksource.go
+++ b/sysfs/clocksource.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/clocksource_test.go
+++ b/sysfs/clocksource_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/net_class_test.go
+++ b/sysfs/net_class_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/vmstat_numa.go
+++ b/sysfs/vmstat_numa.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package sysfs
 
 import (

--- a/sysfs/vmstat_numa_test.go
+++ b/sysfs/vmstat_numa_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package sysfs
 
 import (

--- a/sysfs/vulnerability.go
+++ b/sysfs/vulnerability.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package sysfs
 
 import (


### PR DESCRIPTION
The sysfs package is imported by node_exporter. `class_thermal` uses `ENODATA`, which doesn't exist on FreeBSD, so the build fails. 

Since sysfs is a Linux concept, this PR marks most of the functions within the package as Linux-only. Closes #359. 
