### PR TITLE
Add check for sysfs build tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
     - checkout
     - run: make check_license
+    - run: ./scripts/check_build_tags.sh
     - run: make fixtures
     - run: make update_fixtures
     - run: git diff --exit-code

--- a/scripts/check_build_tags.sh
+++ b/scripts/check_build_tags.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+fail=0
+while read -r f ; do 
+  if ! grep -q '+build linux' "$f" ; then
+    echo "missing linux build tag: $f"
+    fail=1
+  fi
+done < <(find sysfs -name '*.go')
+
+exit "${fail}"
+

--- a/sysfs/class_nvme.go
+++ b/sysfs/class_nvme.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package sysfs
 
 import (

--- a/sysfs/class_nvme_test.go
+++ b/sysfs/class_nvme_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build linux
 
 package sysfs
 

--- a/sysfs/doc.go
+++ b/sysfs/doc.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 // Package sysfs provides functions to retrieve system and kernel metrics
 // from the pseudo-filesystem sys.
 package sysfs

--- a/sysfs/fs.go
+++ b/sysfs/fs.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package sysfs
 
 import (

--- a/sysfs/fs_test.go
+++ b/sysfs/fs_test.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build linux
+
 package sysfs
 
 import "testing"


### PR DESCRIPTION
CI check to validate that all sysfs files contain a linux-only build
tag.

Signed-off-by: Ben Kochie <superq@gmail.com>