### PR TITLE
Add RSSLimit, rt_priority, policy and delay_acct_block to pid/stat

### DIFF
--- a/proc_stat.go
+++ b/proc_stat.go
@@ -100,6 +100,15 @@ type ProcStat struct {
 	VSize uint
 	// Resident set size in pages.
 	RSS int
+	// Soft limit in bytes on the rss of the process.
+	RSSLimit uint64
+	// Real-time scheduling priority, a number in the range 1 to 99 for processes
+	// scheduled under a real-time policy, or 0, for non-real-time processes.
+	RTPriority uint
+	// Scheduling policy.
+	Policy uint
+	// Aggregated block I/O delays, measured in clock ticks (centiseconds).
+	DelayAcctBlkIOTicks uint64
 
 	proc fs.FS
 }
@@ -155,6 +164,24 @@ func (p Proc) Stat() (ProcStat, error) {
 		&s.Starttime,
 		&s.VSize,
 		&s.RSS,
+		&s.RSSLimit,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&ignore,
+		&s.RTPriority,
+		&s.Policy,
+		&s.DelayAcctBlkIOTicks,
 	)
 	if err != nil {
 		return ProcStat{}, err

--- a/proc_stat_test.go
+++ b/proc_stat_test.go
@@ -29,6 +29,7 @@ func TestProcStat(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// pid stat int fields
 	for _, test := range []struct {
 		name string
 		want int
@@ -40,6 +41,34 @@ func TestProcStat(t *testing.T) {
 		{name: "start time", want: 82375, have: int(s.Starttime)},
 		{name: "virtual memory size", want: 56274944, have: int(s.VSize)},
 		{name: "resident set size", want: 1981, have: s.RSS},
+	} {
+		if test.want != test.have {
+			t.Errorf("want %s %d, have %d", test.name, test.want, test.have)
+		}
+	}
+
+	// pid stat uint64 fields
+	for _, test := range []struct {
+		name string
+		want uint64
+		have uint64
+	}{
+		{name: "RSS Limit", want: 18446744073709551615, have: s.RSSLimit},
+		{name: "delayacct_blkio_ticks", want: 31, have: s.DelayAcctBlkIOTicks},
+	} {
+		if test.want != test.have {
+			t.Errorf("want %s %d, have %d", test.name, test.want, test.have)
+		}
+	}
+
+	// pid stat uint fields
+	for _, test := range []struct {
+		name string
+		want uint
+		have uint
+	}{
+		{name: "rt_priority", want: 0, have: s.RTPriority},
+		{name: "policy", want: 0, have: s.Policy},
 	} {
 		if test.want != test.have {
 			t.Errorf("want %s %d, have %d", test.name, test.want, test.have)


### PR DESCRIPTION
fixes #363

We can add more fields, but guest_time and cguest_time requires 2.6.24 and this is a little bit more than `Go requires Linux >= 2.6.23`

Signed-off-by: binjip978 <binjip978@gmail.com>