### PR TITLE
sysfs/net_class: filter devices by name

### DIFF
--- a/sysfs/net_class_test.go
+++ b/sysfs/net_class_test.go
@@ -17,6 +17,7 @@ package sysfs
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -26,7 +27,12 @@ func TestNewNetClassDevices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	devices, err := fs.NetClassDevices()
+	re, err := regexp.Compile("^$")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	devices, err := fs.NetClassDevices(re)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,13 +45,39 @@ func TestNewNetClassDevices(t *testing.T) {
 	}
 }
 
+func TestNewNetClassDevicesFilter(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	re, err := regexp.Compile("eth")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	devices, err := fs.NetClassDevices(re)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(devices) != 0 {
+		t.Errorf("Unexpected number of devices, want %d, have %d", 0, len(devices))
+	}
+}
+
 func TestNetClass(t *testing.T) {
 	fs, err := NewFS(sysTestFixtures)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	nc, err := fs.NetClass()
+	re, err := regexp.Compile("^$")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nc, err := fs.NetClass(re)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds regexp-based device filtering to the NetClass function in order to avoid
parsing devices files that are uninteresting.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

Fixes: https://github.com/prometheus/node_exporter/issues/1915

This will have an accompanying PR in the node_exporter, but I wanted to check first if the API change should be made more backwards compatible by introducing a new function that takes the regex as an argument, instead of changing the signature of `NetClassDevices()`.