### PR TITLE
Use /proc/self/net instead of /proc/net to avoid kernel crash.

### DIFF
--- a/arp.go
+++ b/arp.go
@@ -34,9 +34,9 @@ type ARPEntry struct {
 // GatherARPEntries retrieves all the ARP entries, parse the relevant columns,
 // and then return a slice of ARPEntry's.
 func (fs FS) GatherARPEntries() ([]ARPEntry, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("net/arp"))
+	data, err := ioutil.ReadFile(fs.proc.Path("self/net/arp"))
 	if err != nil {
-		return nil, fmt.Errorf("error reading arp %q: %w", fs.proc.Path("net/arp"), err)
+		return nil, fmt.Errorf("error reading arp %q: %w", fs.proc.Path("self/net/arp"), err)
 	}
 
 	return parseARPEntries(data)

--- a/ipvs.go
+++ b/ipvs.go
@@ -67,7 +67,7 @@ type IPVSBackendStatus struct {
 
 // IPVSStats reads the IPVS statistics from the specified `proc` filesystem.
 func (fs FS) IPVSStats() (IPVSStats, error) {
-	data, err := util.ReadFileNoStat(fs.proc.Path("net/ip_vs_stats"))
+	data, err := util.ReadFileNoStat(fs.proc.Path("self/net/ip_vs_stats"))
 	if err != nil {
 		return IPVSStats{}, err
 	}
@@ -125,7 +125,7 @@ func parseIPVSStats(r io.Reader) (IPVSStats, error) {
 
 // IPVSBackendStatus reads and returns the status of all (virtual,real) server pairs from the specified `proc` filesystem.
 func (fs FS) IPVSBackendStatus() ([]IPVSBackendStatus, error) {
-	file, err := os.Open(fs.proc.Path("net/ip_vs"))
+	file, err := os.Open(fs.proc.Path("self/net/ip_vs"))
 	if err != nil {
 		return nil, err
 	}

--- a/net_conntrackstat.go
+++ b/net_conntrackstat.go
@@ -40,7 +40,7 @@ type ConntrackStatEntry struct {
 
 // ConntrackStat retrieves netfilter's conntrack statistics, split by CPU cores
 func (fs FS) ConntrackStat() ([]ConntrackStatEntry, error) {
-	return readConntrackStat(fs.proc.Path("net", "stat", "nf_conntrack"))
+	return readConntrackStat(fs.proc.Path("self", "net", "stat", "nf_conntrack"))
 }
 
 // Parses a slice of ConntrackStatEntries from the given filepath

--- a/net_dev.go
+++ b/net_dev.go
@@ -49,12 +49,12 @@ type NetDev map[string]NetDevLine
 
 // NetDev returns kernel/system statistics read from /proc/net/dev.
 func (fs FS) NetDev() (NetDev, error) {
-	return newNetDev(fs.proc.Path("net/dev"))
+	return newNetDev(fs.proc.Path("self/net/dev"))
 }
 
 // NetDev returns kernel/system statistics read from /proc/[pid]/net/dev.
 func (p Proc) NetDev() (NetDev, error) {
-	return newNetDev(p.path("net/dev"))
+	return newNetDev(p.path("self/net/dev"))
 }
 
 // newNetDev creates a new NetDev from the contents of the given file.

--- a/net_protocols.go
+++ b/net_protocols.go
@@ -71,7 +71,7 @@ type NetProtocolCapabilities struct {
 // Linux 2.6.12-rc2 - https://elixir.bootlin.com/linux/v2.6.12-rc2/source/net/core/sock.c#L1452
 // Linux 5.10 - https://elixir.bootlin.com/linux/v5.10.4/source/net/core/sock.c#L3586
 func (fs FS) NetProtocols() (NetProtocolStats, error) {
-	data, err := util.ReadFileNoStat(fs.proc.Path("net/protocols"))
+	data, err := util.ReadFileNoStat(fs.proc.Path("self/net/protocols"))
 	if err != nil {
 		return NetProtocolStats{}, err
 	}

--- a/net_sockstat.go
+++ b/net_sockstat.go
@@ -47,7 +47,7 @@ type NetSockstatProtocol struct {
 
 // NetSockstat retrieves IPv4 socket statistics.
 func (fs FS) NetSockstat() (*NetSockstat, error) {
-	return readSockstat(fs.proc.Path("net", "sockstat"))
+	return readSockstat(fs.proc.Path("self", "net", "sockstat"))
 }
 
 // NetSockstat6 retrieves IPv6 socket statistics.
@@ -55,7 +55,7 @@ func (fs FS) NetSockstat() (*NetSockstat, error) {
 // If IPv6 is disabled on this kernel, the returned error can be checked with
 // os.IsNotExist.
 func (fs FS) NetSockstat6() (*NetSockstat, error) {
-	return readSockstat(fs.proc.Path("net", "sockstat6"))
+	return readSockstat(fs.proc.Path("self", "net", "sockstat6"))
 }
 
 // readSockstat opens and parses a NetSockstat from the input file.

--- a/net_softnet.go
+++ b/net_softnet.go
@@ -40,7 +40,7 @@ type SoftnetStat struct {
 	TimeSqueezed uint32
 }
 
-var softNetProcFile = "net/softnet_stat"
+var softNetProcFile = "self/net/softnet_stat"
 
 // NetSoftnetStat reads data from /proc/net/softnet_stat.
 func (fs FS) NetSoftnetStat() ([]SoftnetStat, error) {

--- a/net_softnet_test.go
+++ b/net_softnet_test.go
@@ -46,7 +46,7 @@ func TestNetSoftnet(t *testing.T) {
 }
 
 func TestBadSoftnet(t *testing.T) {
-	softNetProcFile = "net/softnet_stat.broken"
+	softNetProcFile = "self/net/softnet_stat.broken"
 	fs, err := NewFS(procTestFixtures)
 	if err != nil {
 		t.Fatal(err)

--- a/net_tcp.go
+++ b/net_tcp.go
@@ -26,25 +26,25 @@ type (
 // NetTCP returns the IPv4 kernel/networking statistics for TCP datagrams
 // read from /proc/net/tcp.
 func (fs FS) NetTCP() (NetTCP, error) {
-	return newNetTCP(fs.proc.Path("net/tcp"))
+	return newNetTCP(fs.proc.Path("self/net/tcp"))
 }
 
 // NetTCP6 returns the IPv6 kernel/networking statistics for TCP datagrams
 // read from /proc/net/tcp6.
 func (fs FS) NetTCP6() (NetTCP, error) {
-	return newNetTCP(fs.proc.Path("net/tcp6"))
+	return newNetTCP(fs.proc.Path("self/net/tcp6"))
 }
 
 // NetTCPSummary returns already computed statistics like the total queue lengths
 // for TCP datagrams read from /proc/net/tcp.
 func (fs FS) NetTCPSummary() (*NetTCPSummary, error) {
-	return newNetTCPSummary(fs.proc.Path("net/tcp"))
+	return newNetTCPSummary(fs.proc.Path("self/net/tcp"))
 }
 
 // NetTCP6Summary returns already computed statistics like the total queue lengths
 // for TCP datagrams read from /proc/net/tcp6.
 func (fs FS) NetTCP6Summary() (*NetTCPSummary, error) {
-	return newNetTCPSummary(fs.proc.Path("net/tcp6"))
+	return newNetTCPSummary(fs.proc.Path("self/net/tcp6"))
 }
 
 // newNetTCP creates a new NetTCP{,6} from the contents of the given file.

--- a/net_udp.go
+++ b/net_udp.go
@@ -26,25 +26,25 @@ type (
 // NetUDP returns the IPv4 kernel/networking statistics for UDP datagrams
 // read from /proc/net/udp.
 func (fs FS) NetUDP() (NetUDP, error) {
-	return newNetUDP(fs.proc.Path("net/udp"))
+	return newNetUDP(fs.proc.Path("self/net/udp"))
 }
 
 // NetUDP6 returns the IPv6 kernel/networking statistics for UDP datagrams
 // read from /proc/net/udp6.
 func (fs FS) NetUDP6() (NetUDP, error) {
-	return newNetUDP(fs.proc.Path("net/udp6"))
+	return newNetUDP(fs.proc.Path("self/net/udp6"))
 }
 
 // NetUDPSummary returns already computed statistics like the total queue lengths
 // for UDP datagrams read from /proc/net/udp.
 func (fs FS) NetUDPSummary() (*NetUDPSummary, error) {
-	return newNetUDPSummary(fs.proc.Path("net/udp"))
+	return newNetUDPSummary(fs.proc.Path("self/net/udp"))
 }
 
 // NetUDP6Summary returns already computed statistics like the total queue lengths
 // for UDP datagrams read from /proc/net/udp6.
 func (fs FS) NetUDP6Summary() (*NetUDPSummary, error) {
-	return newNetUDPSummary(fs.proc.Path("net/udp6"))
+	return newNetUDPSummary(fs.proc.Path("self/net/udp6"))
 }
 
 // newNetUDP creates a new NetUDP{,6} from the contents of the given file.

--- a/net_unix.go
+++ b/net_unix.go
@@ -70,7 +70,7 @@ type NetUNIX struct {
 
 // NetUNIX returns data read from /proc/net/unix.
 func (fs FS) NetUNIX() (*NetUNIX, error) {
-	return readNetUNIX(fs.proc.Path("net/unix"))
+	return readNetUNIX(fs.proc.Path("self/net/unix"))
 }
 
 // readNetUNIX reads data in /proc/net/unix format from the specified file.

--- a/net_unix_test.go
+++ b/net_unix_test.go
@@ -45,7 +45,7 @@ func TestNetUnixNoInode(t *testing.T) {
 		t.Fatalf("failed to open procfs: %v", err)
 	}
 
-	got, err := readNetUNIX(fs.proc.Path("net/unix_without_inode"))
+	got, err := readNetUNIX(fs.proc.Path("self/net/unix_without_inode"))
 	if err != nil {
 		t.Fatalf("failed to read UNIX socket data: %v", err)
 	}

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -297,7 +297,7 @@ func NewFS(mountPoint string) (FS, error) {
 // ClientRPCStats retrieves NFS client RPC statistics
 // from proc/net/rpc/nfs.
 func (fs FS) ClientRPCStats() (*ClientRPCStats, error) {
-	f, err := os.Open(fs.proc.Path("net/rpc/nfs"))
+	f, err := os.Open(fs.proc.Path("self/net/rpc/nfs"))
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func (fs FS) ClientRPCStats() (*ClientRPCStats, error) {
 // ServerRPCStats retrieves NFS daemon RPC statistics
 // from proc/net/rpc/nfsd.
 func (fs FS) ServerRPCStats() (*ServerRPCStats, error) {
-	f, err := os.Open(fs.proc.Path("net/rpc/nfsd"))
+	f, err := os.Open(fs.proc.Path("self/net/rpc/nfsd"))
 	if err != nil {
 		return nil, err
 	}

--- a/xfrm.go
+++ b/xfrm.go
@@ -97,7 +97,7 @@ func NewXfrmStat() (XfrmStat, error) {
 
 // NewXfrmStat reads the xfrm_stat statistics from the 'proc' filesystem.
 func (fs FS) NewXfrmStat() (XfrmStat, error) {
-	file, err := os.Open(fs.proc.Path("net/xfrm_stat"))
+	file, err := os.Open(fs.proc.Path("self/net/xfrm_stat"))
 	if err != nil {
 		return XfrmStat{}, err
 	}


### PR DESCRIPTION
This change is to fix this issue
https://github.com/prometheus/node_exporter/issues/2027 .