### PR TITLE
Initial fix for non-detection of OmniPath cards

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -3592,6 +3592,128 @@ Mode: 644
 Directory: fixtures/sys/class/infiniband
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/infiniband/hfi1_0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/board_id
+Lines: 1
+HPE 100Gb 1-port OP101 QSFP28 x16 PCIe Gen3 with Intel Omni-Path Adapter
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/fw_ver
+Lines: 1
+1.27.0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/infiniband/hfi1_0/ports
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/infiniband/hfi1_0/ports/1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/VL15_dropped
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/excessive_buffer_overrun_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/link_downed
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/link_error_recovery
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/local_link_integrity_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_rcv_constraint_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_rcv_data
+Lines: 1
+345091702026
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_rcv_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_rcv_packets
+Lines: 1
+638036947
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_rcv_remote_physical_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_rcv_switch_relay_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_xmit_constraint_errors
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_xmit_data
+Lines: 1
+273558326543
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_xmit_discards
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_xmit_packets
+Lines: 1
+568318856
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/port_xmit_wait
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/counters/symbol_error
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/phys_state
+Lines: 1
+5: LinkUp
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/rate
+Lines: 1
+100 Gb/sec (4X EDR)
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/infiniband/hfi1_0/ports/1/state
+Lines: 1
+4: ACTIVE
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/infiniband/mlx4_0
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -128,6 +128,10 @@ func (fs FS) parseInfiniBandDevice(name string) (*InfiniBandDevice, error) {
 		name := filepath.Join(path, f)
 		value, err := util.SysReadFile(name)
 		if err != nil {
+			// Not all InfiniBand drivers provide hca_type.
+			if os.IsNotExist(err) && (f == "hca_type") {
+				continue
+			}
 			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 

--- a/sysfs/class_infiniband_test.go
+++ b/sysfs/class_infiniband_test.go
@@ -63,44 +63,100 @@ func TestInfiniBandClass(t *testing.T) {
 	}
 
 	var (
-		port1ExcessiveBufferOverrunErrors uint64
-		port1LinkDowned                   uint64
-		port1LinkErrorRecovery            uint64
-		port1LocalLinkIntegrityErrors     uint64
-		port1PortRcvConstraintErrors      uint64
-		port1PortRcvData                  uint64 = 8884894436
-		port1PortRcvErrors                uint64
-		port1PortRcvPackets               uint64 = 87169372
-		port1PortRcvRemotePhysicalErrors  uint64
-		port1PortRcvSwitchRelayErrors     uint64
-		port1PortXmitConstraintErrors     uint64
-		port1PortXmitData                 uint64 = 106036453180
-		port1PortXmitDiscards             uint64
-		port1PortXmitPackets              uint64 = 85734114
-		port1PortXmitWait                 uint64 = 3599
-		port1SymbolError                  uint64
-		port1VL15Dropped                  uint64
+		hfi1Port1ExcessiveBufferOverrunErrors uint64
+		hfi1Port1LinkDowned                   uint64
+		hfi1Port1LinkErrorRecovery            uint64
+		hfi1Port1LocalLinkIntegrityErrors     uint64
+		hfi1Port1LinkDowned                   uint64
+		hfi1Port1LinkErrorRecovery            uint64
+		hfi1Port1PortRcvConstraintErrors      uint64
+		hfi1Port1PortRcvData                  uint64 = 1380366808104
+		hfi1Port1PortRcvErrors                uint64
+		hfi1Port1PortRcvPackets               uint64 = 638036947
+		hfi1Port1PortRcvRemotePhysicalErrors  uint64
+		hfi1Port1PortRcvSwitchRelayErrors     uint64
+		hfi1Port1PortXmitConstraintErrors     uint64
+		hfi1Port1PortXmitData                 uint64 = 1094233306172
+		hfi1Port1PortXmitDiscards             uint64
+		hfi1Port1PortXmitPackets              uint64 = 568318856
+		hfi1Port1PortXmitWait                 uint64
+		hfi1Port1SymbolError                  uint64
+		hfi1Port1VL15Dropped                  uint64
 
-		port2ExcessiveBufferOverrunErrors uint64
-		port2LinkDowned                   uint64
-		port2LinkErrorRecovery            uint64
-		port2LocalLinkIntegrityErrors     uint64
-		port2PortRcvConstraintErrors      uint64
-		port2PortRcvData                  uint64 = 9841747136
-		port2PortRcvErrors                uint64
-		port2PortRcvPackets               uint64 = 89332064
-		port2PortRcvRemotePhysicalErrors  uint64
-		port2PortRcvSwitchRelayErrors     uint64
-		port2PortXmitConstraintErrors     uint64
-		port2PortXmitData                 uint64 = 106161427560
-		port2PortXmitDiscards             uint64
-		port2PortXmitPackets              uint64 = 88622850
-		port2PortXmitWait                 uint64 = 3846
-		port2SymbolError                  uint64
-		port2VL15Dropped                  uint64
+		mlx4Port1ExcessiveBufferOverrunErrors uint64
+		mlx4Port1LinkDowned                   uint64
+		mlx4Port1LinkErrorRecovery            uint64
+		mlx4Port1LocalLinkIntegrityErrors     uint64
+		mlx4Port1PortRcvConstraintErrors      uint64
+		mlx4Port1PortRcvData                  uint64 = 8884894436
+		mlx4Port1PortRcvErrors                uint64
+		mlx4Port1PortRcvPackets               uint64 = 87169372
+		mlx4Port1PortRcvRemotePhysicalErrors  uint64
+		mlx4Port1PortRcvSwitchRelayErrors     uint64
+		mlx4Port1PortXmitConstraintErrors     uint64
+		mlx4Port1PortXmitData                 uint64 = 106036453180
+		mlx4Port1PortXmitDiscards             uint64
+		mlx4Port1PortXmitPackets              uint64 = 85734114
+		mlx4Port1PortXmitWait                 uint64 = 3599
+		mlx4Port1SymbolError                  uint64
+		mlx4Port1VL15Dropped                  uint64
+
+		mlx4Port2ExcessiveBufferOverrunErrors uint64
+		mlx4Port2LinkDowned                   uint64
+		mlx4Port2LinkErrorRecovery            uint64
+		mlx4Port2LocalLinkIntegrityErrors     uint64
+		mlx4Port2PortRcvConstraintErrors      uint64
+		mlx4Port2PortRcvData                  uint64 = 9841747136
+		mlx4Port2PortRcvErrors                uint64
+		mlx4Port2PortRcvPackets               uint64 = 89332064
+		mlx4Port2PortRcvRemotePhysicalErrors  uint64
+		mlx4Port2PortRcvSwitchRelayErrors     uint64
+		mlx4Port2PortXmitConstraintErrors     uint64
+		mlx4Port2PortXmitData                 uint64 = 106161427560
+		mlx4Port2PortXmitDiscards             uint64
+		mlx4Port2PortXmitPackets              uint64 = 88622850
+		mlx4Port2PortXmitWait                 uint64 = 3846
+		mlx4Port2SymbolError                  uint64
+		mlx4Port2VL15Dropped                  uint64
 	)
 
 	want := InfiniBandClass{
+		"hfi1_0": InfiniBandDevice{
+			Name:            "hfi1_0",
+			BoardID:         "HPE 100Gb 1-port OP101 QSFP28 x16 PCIe Gen3 with Intel Omni-Path Adapter",
+			FirmwareVersion: "1.27.0",
+			HCAType:         "",
+			Ports: map[uint]InfiniBandPort{
+				1: {
+					Name:        "hfi1_0",
+					Port:        1,
+					State:       "ACTIVE",
+					StateID:     4,
+					PhysState:   "LinkUp",
+					PhysStateID: 5,
+					Rate:        12500000000,
+					Counters: InfiniBandCounters{
+						ExcessiveBufferOverrunErrors: &hfi1Port1ExcessiveBufferOverrunErrors,
+						LinkDowned:                   &hfi1Port1LinkDowned,
+						LinkErrorRecovery:            &hfi1Port1LinkErrorRecovery,
+						LocalLinkIntegrityErrors:     &hfi1Port1LocalLinkIntegrityErrors,
+						PortRcvConstraintErrors:      &hfi1Port1PortRcvConstraintErrors,
+						PortRcvData:                  &hfi1Port1PortRcvData,
+						PortRcvErrors:                &hfi1Port1PortRcvErrors,
+						PortRcvPackets:               &hfi1Port1PortRcvPackets,
+						PortRcvRemotePhysicalErrors:  &hfi1Port1PortRcvRemotePhysicalErrors,
+						PortRcvSwitchRelayErrors:     &hfi1Port1PortRcvSwitchRelayErrors,
+						PortXmitConstraintErrors:     &hfi1Port1PortXmitConstraintErrors,
+						PortXmitData:                 &hfi1Port1PortXmitData,
+						PortXmitDiscards:             &hfi1Port1PortXmitDiscards,
+						PortXmitPackets:              &hfi1Port1PortXmitPackets,
+						PortXmitWait:                 &hfi1Port1PortXmitWait,
+						SymbolError:                  &hfi1Port1SymbolError,
+						VL15Dropped:                  &hfi1Port1VL15Dropped,
+					},
+				},
+			},
+		},
 		"mlx4_0": InfiniBandDevice{
 			Name:            "mlx4_0",
 			BoardID:         "SM_1141000001000",
@@ -116,23 +172,23 @@ func TestInfiniBandClass(t *testing.T) {
 					PhysStateID: 5,
 					Rate:        5000000000,
 					Counters: InfiniBandCounters{
-						ExcessiveBufferOverrunErrors: &port1ExcessiveBufferOverrunErrors,
-						LinkDowned:                   &port1LinkDowned,
-						LinkErrorRecovery:            &port1LinkErrorRecovery,
-						LocalLinkIntegrityErrors:     &port1LocalLinkIntegrityErrors,
-						PortRcvConstraintErrors:      &port1PortRcvConstraintErrors,
-						PortRcvData:                  &port1PortRcvData,
-						PortRcvErrors:                &port1PortRcvErrors,
-						PortRcvPackets:               &port1PortRcvPackets,
-						PortRcvRemotePhysicalErrors:  &port1PortRcvRemotePhysicalErrors,
-						PortRcvSwitchRelayErrors:     &port1PortRcvSwitchRelayErrors,
-						PortXmitConstraintErrors:     &port1PortXmitConstraintErrors,
-						PortXmitData:                 &port1PortXmitData,
-						PortXmitDiscards:             &port1PortXmitDiscards,
-						PortXmitPackets:              &port1PortXmitPackets,
-						PortXmitWait:                 &port1PortXmitWait,
-						SymbolError:                  &port1SymbolError,
-						VL15Dropped:                  &port1VL15Dropped,
+						ExcessiveBufferOverrunErrors: &mlx4Port1ExcessiveBufferOverrunErrors,
+						LinkDowned:                   &mlx4Port1LinkDowned,
+						LinkErrorRecovery:            &mlx4Port1LinkErrorRecovery,
+						LocalLinkIntegrityErrors:     &mlx4Port1LocalLinkIntegrityErrors,
+						PortRcvConstraintErrors:      &mlx4Port1PortRcvConstraintErrors,
+						PortRcvData:                  &mlx4Port1PortRcvData,
+						PortRcvErrors:                &mlx4Port1PortRcvErrors,
+						PortRcvPackets:               &mlx4Port1PortRcvPackets,
+						PortRcvRemotePhysicalErrors:  &mlx4Port1PortRcvRemotePhysicalErrors,
+						PortRcvSwitchRelayErrors:     &mlx4Port1PortRcvSwitchRelayErrors,
+						PortXmitConstraintErrors:     &mlx4Port1PortXmitConstraintErrors,
+						PortXmitData:                 &mlx4Port1PortXmitData,
+						PortXmitDiscards:             &mlx4Port1PortXmitDiscards,
+						PortXmitPackets:              &mlx4Port1PortXmitPackets,
+						PortXmitWait:                 &mlx4Port1PortXmitWait,
+						SymbolError:                  &mlx4Port1SymbolError,
+						VL15Dropped:                  &mlx4Port1VL15Dropped,
 					},
 				},
 				2: {
@@ -144,23 +200,23 @@ func TestInfiniBandClass(t *testing.T) {
 					PhysStateID: 5,
 					Rate:        5000000000,
 					Counters: InfiniBandCounters{
-						ExcessiveBufferOverrunErrors: &port2ExcessiveBufferOverrunErrors,
-						LinkDowned:                   &port2LinkDowned,
-						LinkErrorRecovery:            &port2LinkErrorRecovery,
-						LocalLinkIntegrityErrors:     &port2LocalLinkIntegrityErrors,
-						PortRcvConstraintErrors:      &port2PortRcvConstraintErrors,
-						PortRcvData:                  &port2PortRcvData,
-						PortRcvErrors:                &port2PortRcvErrors,
-						PortRcvPackets:               &port2PortRcvPackets,
-						PortRcvRemotePhysicalErrors:  &port2PortRcvRemotePhysicalErrors,
-						PortRcvSwitchRelayErrors:     &port2PortRcvSwitchRelayErrors,
-						PortXmitConstraintErrors:     &port2PortXmitConstraintErrors,
-						PortXmitData:                 &port2PortXmitData,
-						PortXmitDiscards:             &port2PortXmitDiscards,
-						PortXmitPackets:              &port2PortXmitPackets,
-						PortXmitWait:                 &port2PortXmitWait,
-						SymbolError:                  &port2SymbolError,
-						VL15Dropped:                  &port2VL15Dropped,
+						ExcessiveBufferOverrunErrors: &mlx4Port2ExcessiveBufferOverrunErrors,
+						LinkDowned:                   &mlx4Port1LinkDowned,
+						LinkErrorRecovery:            &mlx4Port1LinkErrorRecovery,
+						LocalLinkIntegrityErrors:     &mlx4Port2LocalLinkIntegrityErrors,
+						PortRcvConstraintErrors:      &mlx4Port2PortRcvConstraintErrors,
+						PortRcvData:                  &mlx4Port2PortRcvData,
+						PortRcvErrors:                &mlx4Port2PortRcvErrors,
+						PortRcvPackets:               &mlx4Port2PortRcvPackets,
+						PortRcvRemotePhysicalErrors:  &mlx4Port2PortRcvRemotePhysicalErrors,
+						PortRcvSwitchRelayErrors:     &mlx4Port2PortRcvSwitchRelayErrors,
+						PortXmitConstraintErrors:     &mlx4Port2PortXmitConstraintErrors,
+						PortXmitData:                 &mlx4Port2PortXmitData,
+						PortXmitDiscards:             &mlx4Port2PortXmitDiscards,
+						PortXmitPackets:              &mlx4Port2PortXmitPackets,
+						PortXmitWait:                 &mlx4Port2PortXmitWait,
+						SymbolError:                  &mlx4Port2SymbolError,
+						VL15Dropped:                  &mlx4Port2VL15Dropped,
 					},
 				},
 			},

--- a/sysfs/class_infiniband_test.go
+++ b/sysfs/class_infiniband_test.go
@@ -67,8 +67,6 @@ func TestInfiniBandClass(t *testing.T) {
 		hfi1Port1LinkDowned                   uint64
 		hfi1Port1LinkErrorRecovery            uint64
 		hfi1Port1LocalLinkIntegrityErrors     uint64
-		hfi1Port1LinkDowned                   uint64
-		hfi1Port1LinkErrorRecovery            uint64
 		hfi1Port1PortRcvConstraintErrors      uint64
 		hfi1Port1PortRcvData                  uint64 = 1380366808104
 		hfi1Port1PortRcvErrors                uint64
@@ -201,8 +199,8 @@ func TestInfiniBandClass(t *testing.T) {
 					Rate:        5000000000,
 					Counters: InfiniBandCounters{
 						ExcessiveBufferOverrunErrors: &mlx4Port2ExcessiveBufferOverrunErrors,
-						LinkDowned:                   &mlx4Port1LinkDowned,
-						LinkErrorRecovery:            &mlx4Port1LinkErrorRecovery,
+						LinkDowned:                   &mlx4Port2LinkDowned,
+						LinkErrorRecovery:            &mlx4Port2LinkErrorRecovery,
 						LocalLinkIntegrityErrors:     &mlx4Port2LocalLinkIntegrityErrors,
 						PortRcvConstraintErrors:      &mlx4Port2PortRcvConstraintErrors,
 						PortRcvData:                  &mlx4Port2PortRcvData,


### PR DESCRIPTION
Mellanox drivers provide a particular file in the `/sys` pseudo-filesystem that not all InfiniBand drivers do, and OmniPath drivers don't. This means that the InfiniBand detection fails to detect these cards.

This naïve fix makes OmniPath cards detectable by making the InfiniBand detection happy to ignore whether that file is missing.

It could probably use a look in future from someone with more expertise (or at least, more documentation) on the specific info provided by the driver.

This fixes #341 and I think also the downstream issue in the node_exporter: <https://github.com/prometheus/node_exporter/issues/2023>.