### PR TITLE
Add CmdLine function to parse /proc/cmdline

### DIFF
--- a/cmdline.go
+++ b/cmdline.go
@@ -1,0 +1,30 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// CmdLine returns the command line of the kernel.
+func (fs FS) CmdLine() ([]string, error) {
+	data, err := util.ReadFileNoStat(fs.proc.Path("cmdline"))
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Fields(string(data)), nil
+}

--- a/cmdline_test.go
+++ b/cmdline_test.go
@@ -1,0 +1,47 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package procfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCmdline(t *testing.T) {
+	fs, err := NewFS(procTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.CmdLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"BOOT_IMAGE=/vmlinuz-5.11.0-22-generic",
+		"root=UUID=456a0345-450d-4f7b-b7c9-43e3241d99ad",
+		"ro",
+		"quiet",
+		"splash",
+		"vt.handoff=7",
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected CmdLine (-want +got):\n%s", diff)
+	}
+}

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -644,6 +644,11 @@ Node 0, zone    DMA32    759    572    791    475    194     45     12      0   
 Node 0, zone   Normal   4381   1093    185   1530    567    102      4      0      0      0      0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/cmdline
+Lines: 1
+BOOT_IMAGE=/vmlinuz-5.11.0-22-generic root=UUID=456a0345-450d-4f7b-b7c9-43e3241d99ad ro quiet splash vt.handoff=7
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/cpuinfo
 Lines: 216
 processor	: 0


### PR DESCRIPTION
Our company internal Prometheus exporter uses the procfs library and needs to read `/proc/cmdline`. Since `fs.proc.Path` cannot be accessed from outside, add `CmdLine` to procfs to read `/proc/cmdline`.