### PR TITLE
nvme: Wrap underlying errors instead of hiding them

### DIFF
--- a/sysfs/class_nvme.go
+++ b/sysfs/class_nvme.go
@@ -45,7 +45,7 @@ func (fs FS) NVMeClass() (NVMeClass, error) {
 
 	dirs, err := ioutil.ReadDir(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list NVMe devices at %q: %v", path, err)
+		return nil, fmt.Errorf("failed to list NVMe devices at %q: %w", path, err)
 	}
 
 	nc := make(NVMeClass, len(dirs))
@@ -70,7 +70,7 @@ func (fs FS) parseNVMeDevice(name string) (*NVMeDevice, error) {
 		name := filepath.Join(path, f)
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read file %q: %v", name, err)
+			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 		}
 
 		switch f {


### PR DESCRIPTION
Prometheus node exporter checks the returned error variable of `NVMeClass` for being `os.ErrNotExist`. This check will never match, because `NVMeClass` uses `fmt.Errorf` to convert the error.

So wrap the error result using `%w` to allow checking for `os.ErrNotExist`.
