### PR TITLE
Fix cgroup path computation

### DIFF
--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -90,7 +90,7 @@ func parseCgroups(data []byte) ([]Cgroup, error) {
 // control hierarchy running on this system. On every system (v1 and v2), all hierarchies contain all processes,
 // so the len of the returned struct is equal to the number of active hierarchies on this system
 func (p Proc) Cgroups() ([]Cgroup, error) {
-	data, err := util.ReadFileNoStat(fmt.Sprintf("/proc/%d/cgroup", p.PID))
+	data, err := util.ReadFileNoStat(p.path("cgroup"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In testing scenarios, the process path is not necessarily `/proc/<pid>/cgroup`, but `fixtures/<pid>/cgroup` or similar.

I have encountered this issue while trying to extend process-exporter to support cgroups, which worked fine in practiced but failed the tests because it attempted to read `/proc/<pid>/cgroup` instead of `../fixtures/<pid>/cgroup`.

-> The fix is trivial: `p.path("cgroup")` already exists and is the more flexible alternative for cases where the proc directory isn't `/proc/`. This makes behavior consistent with the rest of the library as far as I can tell.

I haven't found anywhere else that needs fixing by grepping on `Sprintf.*PID`.

---

Tangentially related but I couldn't figure out how to test my changes to process-exporter with my fork of procps without changing all `import`s to point to my fork and updating my fork's master to rename all imports `prometheus/procfs` to `azertyfun/procfs`. What am I doing wrong? Surely importing my fork should be easier?