### PR TITLE
Fix data types for ignored stat fields #401

### DIFF
--- a/proc_stat.go
+++ b/proc_stat.go
@@ -128,7 +128,8 @@ func (p Proc) Stat() (ProcStat, error) {
 	}
 
 	var (
-		ignore int
+		ignoreInt64  int64
+		ignoreUint64 uint64
 
 		s = ProcStat{PID: p.PID, proc: p.fs}
 		l = bytes.Index(data, []byte("("))
@@ -160,25 +161,25 @@ func (p Proc) Stat() (ProcStat, error) {
 		&s.Priority,
 		&s.Nice,
 		&s.NumThreads,
-		&ignore,
+		&ignoreInt64,
 		&s.Starttime,
 		&s.VSize,
 		&s.RSS,
 		&s.RSSLimit,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
-		&ignore,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreUint64,
+		&ignoreInt64,
+		&ignoreInt64,
 		&s.RTPriority,
 		&s.Policy,
 		&s.DelayAcctBlkIOTicks,

--- a/proc_stat_test.go
+++ b/proc_stat_test.go
@@ -76,6 +76,18 @@ func TestProcStat(t *testing.T) {
 	}
 }
 
+func TestProcStatIgnored(t *testing.T) {
+	p, err := getProcFixtures(t).Proc(26232)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.Stat()
+	if err != nil {
+		t.Errorf("want not error, have %s", err)
+	}
+}
+
 func TestProcStatComm(t *testing.T) {
 	s1, err := testProcStat(26231)
 	if err != nil {


### PR DESCRIPTION
Some ignored fields in the `/proc/[pid]/stat` file may have values that are bigger than the max value of the current Go type that is used for the ignored variable. That leads to issues in runtime on some systems that use the maximum possible values for the related fields.

Please note, that this PR fixes data types only for the ignored fields. Other fields in the stat file may be still affected especially on nodes that use 32-bit arch.

@pgier @discordianfish please have a look.

See for details:
* https://man7.org/linux/man-pages/man5/proc.5.html
* https://man7.org/linux/man-pages/man3/scanf.3.html

Fixes: https://github.com/prometheus/procfs/issues/401

Signed-off-by: Vyacheslav Kulakov <kulakov.home@gmail.com>