### PR TITLE
Fix build with GopherJS

### DIFF
--- a/proc_maps.go
+++ b/proc_maps.go
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 // +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+// +build !js
 
 package procfs
 


### PR DESCRIPTION
Fixes build with "gopherjs build ." by excluding proc_maps.go from js and wasm.