### PR TITLE
Add support for DMI information

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -3477,6 +3477,122 @@ Mode: 664
 Directory: fixtures/sys/class
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/dmi
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/dmi/id
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/bios_date
+Lines: 1
+04/12/2021
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/bios_release
+Lines: 1
+2.2
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/bios_vendor
+Lines: 1
+Dell Inc.
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/bios_version
+Lines: 1
+2.2.4
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/board_name
+Lines: 1
+07PXPY
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/board_serial
+Lines: 1
+.7N62AI2.GRTCL6944100GP.
+Mode: 400
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/board_vendor
+Lines: 1
+Dell Inc.
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/board_version
+Lines: 1
+A01
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/chassis_asset_tag
+Lines: 1
+
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/chassis_serial
+Lines: 1
+7N62AI2
+Mode: 400
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/chassis_type
+Lines: 1
+23
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/chassis_vendor
+Lines: 1
+Dell Inc.
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/chassis_version
+Lines: 1
+
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/modalias
+Lines: 1
+dmi:bvnDellInc.:bvr2.2.4:bd04/12/2021:br2.2:svnDellInc.:pnPowerEdgeR6515:pvr:rvnDellInc.:rn07PXPY:rvrA01:cvnDellInc.:ct23:cvr:
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/product_family
+Lines: 1
+PowerEdge
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/product_name
+Lines: 1
+PowerEdge R6515
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/product_serial
+Lines: 1
+7N62AI2
+Mode: 400
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/product_sku
+Lines: 1
+SKU=NotProvided;ModelName=PowerEdge R6515
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/product_uuid
+Lines: 1
+83340ca8-cb49-4474-8c29-d2088ca84dd9
+Mode: 400
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/product_version
+Lines: 1
+
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/sys_vendor
+Lines: 1
+Dell Inc.
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/dmi/id/uevent
+Lines: 1
+MODALIAS=dmi:bvnDellInc.:bvr2.2.4:bd04/12/2021:br2.2:svnDellInc.:pnPowerEdgeR6515:pvr:rvnDellInc.:rn07PXPY:rvrA01:cvnDellInc.:ct23:cvr:
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/drm
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/class_dmi.go
+++ b/sysfs/class_dmi.go
@@ -1,0 +1,131 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const dmiClassPath = "class/dmi/id"
+
+// DMIClass contains info from files in /sys/class/dmi/id.
+type DMIClass struct {
+	BiosDate        *string // /sys/class/dmi/id/bios_date
+	BiosRelease     *string // /sys/class/dmi/id/bios_release
+	BiosVendor      *string // /sys/class/dmi/id/bios_vendor
+	BiosVersion     *string // /sys/class/dmi/id/bios_version
+	BoardAssetTag   *string // /sys/class/dmi/id/board_asset_tag
+	BoardName       *string // /sys/class/dmi/id/board_name
+	BoardSerial     *string // /sys/class/dmi/id/board_serial
+	BoardVendor     *string // /sys/class/dmi/id/board_vendor
+	BoardVersion    *string // /sys/class/dmi/id/board_version
+	ChassisAssetTag *string // /sys/class/dmi/id/chassis_asset_tag
+	ChassisSerial   *string // /sys/class/dmi/id/chassis_serial
+	ChassisType     *string // /sys/class/dmi/id/chassis_type
+	ChassisVendor   *string // /sys/class/dmi/id/chassis_vendor
+	ChassisVersion  *string // /sys/class/dmi/id/chassis_version
+	ProductFamily   *string // /sys/class/dmi/id/product_family
+	ProductName     *string // /sys/class/dmi/id/product_name
+	ProductSerial   *string // /sys/class/dmi/id/product_serial
+	ProductSKU      *string // /sys/class/dmi/id/product_sku
+	ProductUUID     *string // /sys/class/dmi/id/product_uuid
+	ProductVersion  *string // /sys/class/dmi/id/product_version
+	SystemVendor    *string // /sys/class/dmi/id/sys_vendor
+}
+
+// DMIClass returns Desktop Management Interface (DMI) information read from /sys/class/dmi.
+func (fs FS) DMIClass() (*DMIClass, error) {
+	path := fs.sys.Path(dmiClassPath)
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %q: %w", path, err)
+	}
+
+	var dmi DMIClass
+	for _, f := range files {
+		if !f.Mode().IsRegular() {
+			continue
+		}
+
+		name := f.Name()
+		if name == "modalias" || name == "uevent" {
+			continue
+		}
+
+		filename := filepath.Join(path, name)
+		value, err := util.SysReadFile(filename)
+		if err != nil {
+			if os.IsPermission(err) {
+				// Only root is allowed to read the serial and product_uuid files!
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", filename, err)
+		}
+
+		switch name {
+		case "bios_date":
+			dmi.BiosDate = &value
+		case "bios_release":
+			dmi.BiosRelease = &value
+		case "bios_vendor":
+			dmi.BiosVendor = &value
+		case "bios_version":
+			dmi.BiosVersion = &value
+		case "board_asset_tag":
+			dmi.BoardAssetTag = &value
+		case "board_name":
+			dmi.BoardName = &value
+		case "board_serial":
+			dmi.BoardSerial = &value
+		case "board_vendor":
+			dmi.BoardVendor = &value
+		case "board_version":
+			dmi.BoardVersion = &value
+		case "chassis_asset_tag":
+			dmi.ChassisAssetTag = &value
+		case "chassis_serial":
+			dmi.ChassisSerial = &value
+		case "chassis_type":
+			dmi.ChassisType = &value
+		case "chassis_vendor":
+			dmi.ChassisVendor = &value
+		case "chassis_version":
+			dmi.ChassisVersion = &value
+		case "product_family":
+			dmi.ProductFamily = &value
+		case "product_name":
+			dmi.ProductName = &value
+		case "product_serial":
+			dmi.ProductSerial = &value
+		case "product_sku":
+			dmi.ProductSKU = &value
+		case "product_uuid":
+			dmi.ProductUUID = &value
+		case "product_version":
+			dmi.ProductVersion = &value
+		case "sys_vendor":
+			dmi.SystemVendor = &value
+		}
+	}
+
+	return &dmi, nil
+}

--- a/sysfs/class_dmi_test.go
+++ b/sysfs/class_dmi_test.go
@@ -1,0 +1,80 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package sysfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDMIClass(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.DMIClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	empty := ""
+	biosDate := "04/12/2021"
+	biosRelease := "2.2"
+	biosVendor := "Dell Inc."
+	biosVersion := "2.2.4"
+	boardName := "07PXPY"
+	boardSerial := ".7N62AI2.GRTCL6944100GP."
+	boardVendor := "Dell Inc."
+	boardVersion := "A01"
+	chassisSerial := "7N62AI2"
+	chassisType := "23"
+	chassisVendor := "Dell Inc."
+	productFamily := "PowerEdge"
+	productName := "PowerEdge R6515"
+	productSerial := "7N62AI2"
+	productSKU := "SKU=NotProvided;ModelName=PowerEdge R6515"
+	productUUID := "83340ca8-cb49-4474-8c29-d2088ca84dd9"
+	systemVendor := "Dell Inc."
+
+	want := &DMIClass{
+		BiosDate:        &biosDate,
+		BiosRelease:     &biosRelease,
+		BiosVendor:      &biosVendor,
+		BiosVersion:     &biosVersion,
+		BoardName:       &boardName,
+		BoardSerial:     &boardSerial,
+		BoardVendor:     &boardVendor,
+		BoardVersion:    &boardVersion,
+		ChassisAssetTag: &empty,
+		ChassisSerial:   &chassisSerial,
+		ChassisType:     &chassisType,
+		ChassisVendor:   &chassisVendor,
+		ChassisVersion:  &empty,
+		ProductFamily:   &productFamily,
+		ProductName:     &productName,
+		ProductSerial:   &productSerial,
+		ProductSKU:      &productSKU,
+		ProductUUID:     &productUUID,
+		ProductVersion:  &empty,
+		SystemVendor:    &systemVendor,
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected DMI class (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
The sysfs contains some useful information about the BIOS, board, chassis, product, and system from the Desktop Management Interface (DMI). The BIOS version should be exported by the Prometheus node exporter to support alerting about outdated BIOS versions. Add a `DMIClass` function to collect the information for the node exporter.