### PR TITLE
Add device-mapper-specific block device properties

### DIFF
--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -342,7 +342,7 @@ func (fs FS) SysBlockDeviceStat(device string) (IOStats, int, error) {
 // SysBlockDeviceQueueStats returns stats for /sys/block/xxx/queue where xxx is a device name.
 func (fs FS) SysBlockDeviceQueueStats(device string) (BlockQueueStats, error) {
 	stat := BlockQueueStats{}
-	// files with uint64 fields
+	// Files with uint64 fields
 	for file, p := range map[string]*uint64{
 		"add_random":             &stat.AddRandom,
 		"dax":                    &stat.DAX,
@@ -380,7 +380,7 @@ func (fs FS) SysBlockDeviceQueueStats(device string) (BlockQueueStats, error) {
 		}
 		*p = val
 	}
-	// files with int64 fields
+	// Files with int64 fields
 	for file, p := range map[string]*int64{
 		"io_poll_delay": &stat.IOPollDelay,
 		"wbt_lat_usec":  &stat.WBTLatUSec,
@@ -391,7 +391,7 @@ func (fs FS) SysBlockDeviceQueueStats(device string) (BlockQueueStats, error) {
 		}
 		*p = val
 	}
-	// files with string fields
+	// Files with string fields
 	for file, p := range map[string]*string{
 		"write_cache": &stat.WriteCache,
 		"zoned":       &stat.Zoned,
@@ -426,7 +426,7 @@ func (fs FS) SysBlockDeviceQueueStats(device string) (BlockQueueStats, error) {
 
 func (fs FS) SysBlockDeviceMapperInfo(device string) (DeviceMapperInfo, error) {
 	info := DeviceMapperInfo{}
-	// files with uint64 fields
+	// Files with uint64 fields
 	for file, p := range map[string]*uint64{
 		"rq_based_seq_io_merge_deadline": &info.RqBasedSeqIOMergeDeadline,
 		"suspended":                      &info.Suspended,
@@ -438,7 +438,7 @@ func (fs FS) SysBlockDeviceMapperInfo(device string) (DeviceMapperInfo, error) {
 		}
 		*p = val
 	}
-	// files with string fields
+	// Files with string fields
 	for file, p := range map[string]*string{
 		"name": &info.Name,
 		"uuid": &info.UUID,

--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -189,10 +189,10 @@ type DeviceMapperInfo struct {
 	RqBasedSeqIOMergeDeadline uint64
 	// Suspended indicates if the device is suspended (1 is on, 0 is off).
 	Suspended uint64
-	// UseBlkMq indicates if the device is using the request-based blk-mq I/O path mode (1 is on, 0 is off).
-	UseBlkMq uint64
-	// Uuid is the DM-UUID string or empty string if DM-UUID is not set.
-	Uuid string
+	// UseBlkMQ indicates if the device is using the request-based blk-mq I/O path mode (1 is on, 0 is off).
+	UseBlkMQ uint64
+	// UUID is the DM-UUID string or empty string if DM-UUID is not set.
+	UUID string
 }
 
 // UnderlyingDevices models the list of devices that this device is built from.
@@ -207,7 +207,7 @@ const (
 	sysBlockPath        = "block"
 	sysBlockStatFormat  = "%d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d"
 	sysBlockQueue       = "queue"
-	sysBlockDm          = "dm"
+	sysBlockDM          = "dm"
 	sysUnderlyingDev    = "slaves"
 )
 
@@ -430,9 +430,9 @@ func (fs FS) SysBlockDeviceMapperInfo(device string) (DeviceMapperInfo, error) {
 	for file, p := range map[string]*uint64{
 		"rq_based_seq_io_merge_deadline": &info.RqBasedSeqIOMergeDeadline,
 		"suspended":                      &info.Suspended,
-		"use_blk_mq":                     &info.UseBlkMq,
+		"use_blk_mq":                     &info.UseBlkMQ,
 	} {
-		val, err := util.ReadUintFromFile(fs.sys.Path(sysBlockPath, device, sysBlockDm, file))
+		val, err := util.ReadUintFromFile(fs.sys.Path(sysBlockPath, device, sysBlockDM, file))
 		if err != nil {
 			return DeviceMapperInfo{}, err
 		}
@@ -441,9 +441,9 @@ func (fs FS) SysBlockDeviceMapperInfo(device string) (DeviceMapperInfo, error) {
 	// files with string fields
 	for file, p := range map[string]*string{
 		"name": &info.Name,
-		"uuid": &info.Uuid,
+		"uuid": &info.UUID,
 	} {
-		val, err := util.SysReadFile(fs.sys.Path(sysBlockPath, device, sysBlockDm, file))
+		val, err := util.SysReadFile(fs.sys.Path(sysBlockPath, device, sysBlockDM, file))
 		if err != nil {
 			return DeviceMapperInfo{}, err
 		}

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -172,8 +172,8 @@ func TestBlockDmInfo(t *testing.T) {
 		Name:                      "vg0--lv_root",
 		RqBasedSeqIOMergeDeadline: 0,
 		Suspended:                 0,
-		UseBlkMq:                  0,
-		Uuid:                      "LVM-3zSHSR5Nbf4j7g6auAAefWY2CMaX01theZYEvQyecVsm2WtX3iY5q51qq5dWWOq7",
+		UseBlkMQ:                  0,
+		UUID:                      "LVM-3zSHSR5Nbf4j7g6auAAefWY2CMaX01theZYEvQyecVsm2WtX3iY5q51qq5dWWOq7",
 	}
 	if !reflect.DeepEqual(dm0Info, dm0InfoExpected) {
 		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", dm0InfoExpected, dm0Info)

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -152,3 +152,29 @@ func TestBlockDevice(t *testing.T) {
 		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", blockQueueStatExpected, blockQueueStat)
 	}
 }
+
+func TestBlockDmInfo(t *testing.T) {
+	blockdevice, err := NewFS("../fixtures/proc", "../fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access blockdevice fs: %v", err)
+	}
+	devices, err := blockdevice.SysBlockDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm0Info, err := blockdevice.SysBlockDeviceMapperInfo(devices[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dm0InfoExpected := DeviceMapperInfo{
+		Name:                      "vg0--lv_root",
+		RqBasedSeqIOMergeDeadline: 0,
+		Suspended:                 0,
+		UseBlkMq:                  0,
+		Uuid:                      "LVM-3zSHSR5Nbf4j7g6auAAefWY2CMaX01theZYEvQyecVsm2WtX3iY5q51qq5dWWOq7",
+	}
+	if !reflect.DeepEqual(dm0Info, dm0InfoExpected) {
+		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", dm0InfoExpected, dm0Info)
+	}
+}

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -14,6 +14,7 @@
 package blockdevice
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
@@ -176,5 +177,45 @@ func TestBlockDmInfo(t *testing.T) {
 	}
 	if !reflect.DeepEqual(dm0Info, dm0InfoExpected) {
 		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", dm0InfoExpected, dm0Info)
+	}
+
+	dm1Info, err := blockdevice.SysBlockDeviceMapperInfo(devices[1])
+	if err != nil {
+		if _, ok := err.(*os.PathError); ok {
+			// Fail the test if there's an error other than PathError.
+			if !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+		} else {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal("SysBlockDeviceMapperInfo on sda was supposed to fail.")
+	}
+	dm1InfoExpected := DeviceMapperInfo{}
+	if !reflect.DeepEqual(dm1Info, dm1InfoExpected) {
+		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", dm0InfoExpected, dm0Info)
+	}
+}
+
+func TestSysBlockDeviceUnderlyingDevices(t *testing.T) {
+	blockdevice, err := NewFS("../fixtures/proc", "../fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access blockdevice fs: %v", err)
+	}
+	devices, err := blockdevice.SysBlockDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	underlying0, err := blockdevice.SysBlockDeviceUnderlyingDevices(devices[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	underlying0Expected := UnderlyingDeviceInfo{
+		DeviceNames: []string{"sda"},
+	}
+	if !reflect.DeepEqual(underlying0, underlying0Expected) {
+		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", underlying0Expected, underlying0)
 	}
 }

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -3231,6 +3231,34 @@ Mode: 775
 Directory: fixtures/sys/block/dm-0
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/dm-0/dm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/dm-0/dm/name
+Lines: 1
+vg0--lv_rootEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/dm-0/dm/rq_based_seq_io_merge_deadline
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/dm-0/dm/suspended
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/dm-0/dm/use_blk_mq
+Lines: 1
+0EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/dm-0/dm/uuid
+Lines: 1
+LVM-3zSHSR5Nbf4j7g6auAAefWY2CMaX01theZYEvQyecVsm2WtX3iY5q51qq5dWWOq7EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/block/dm-0/stat
 Lines: 1
 6447303        0 710266738  1529043   953216        0 31201176  4557464        0   796160  6088971
@@ -3478,6 +3506,7 @@ Mode: 664
 Directory: fixtures/sys/class
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+<<<<<<< HEAD
 Directory: fixtures/sys/class/dmi
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3593,6 +3622,28 @@ Path: fixtures/sys/class/dmi/id/uevent
 Lines: 1
 MODALIAS=dmi:bvnDellInc.:bvr2.2.4:bd04/12/2021:br2.2:svnDellInc.:pnPowerEdgeR6515:pvr:rvnDellInc.:rn07PXPY:rvrA01:cvnDellInc.:ct23:cvr:
 Mode: 644
+=======
+Directory: fixtures/sys/class/block
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-0
+SymlinkTo: ../../devices/virtual/block/dm-0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-1
+SymlinkTo: ../../devices/virtual/block/dm-1
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-2
+SymlinkTo: ../../devices/virtual/block/dm-2
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-3
+SymlinkTo: ../../devices/virtual/block/dm-3
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-4
+SymlinkTo: ../../devices/virtual/block/dm-4
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-5
+SymlinkTo: ../../devices/virtual/block/dm-5
+>>>>>>> fdb88ff (Expose device-mapper information as DeviceMapperInfo)
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/drm
 Mode: 755
@@ -6490,6 +6541,15 @@ nr_zone_inactive_file 10
 nr_zone_active_file 11
 nr_zone_unevictable 12
 Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/devices/virtual
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/devices/virtual/block
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/devices/virtual/block/dm-0
+Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/fs
 Mode: 755

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -3259,13 +3259,6 @@ Lines: 1
 LVM-3zSHSR5Nbf4j7g6auAAefWY2CMaX01theZYEvQyecVsm2WtX3iY5q51qq5dWWOq7EOF
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: fixtures/sys/block/dm-0/slaves
-Mode: 755
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/block/dm-0/slaves/sda
-Lines: 0
-Mode: 664
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/block/dm-0/stat
 Lines: 1
 6447303        0 710266738  1529043   953216        0 31201176  4557464        0   796160  6088971
@@ -3513,7 +3506,6 @@ Mode: 664
 Directory: fixtures/sys/class
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-<<<<<<< HEAD
 Directory: fixtures/sys/class/dmi
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3629,7 +3621,6 @@ Path: fixtures/sys/class/dmi/id/uevent
 Lines: 1
 MODALIAS=dmi:bvnDellInc.:bvr2.2.4:bd04/12/2021:br2.2:svnDellInc.:pnPowerEdgeR6515:pvr:rvnDellInc.:rn07PXPY:rvrA01:cvnDellInc.:ct23:cvr:
 Mode: 644
-=======
 Directory: fixtures/sys/class/block
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3650,7 +3641,6 @@ SymlinkTo: ../../devices/virtual/block/dm-4
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/class/block/dm-5
 SymlinkTo: ../../devices/virtual/block/dm-5
->>>>>>> fdb88ff (Expose device-mapper information as DeviceMapperInfo)
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/drm
 Mode: 755

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -3513,6 +3513,27 @@ Mode: 664
 Directory: fixtures/sys/class
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/block
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-0
+SymlinkTo: ../../devices/virtual/block/dm-0
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-1
+SymlinkTo: ../../devices/virtual/block/dm-1
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-2
+SymlinkTo: ../../devices/virtual/block/dm-2
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-3
+SymlinkTo: ../../devices/virtual/block/dm-3
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-4
+SymlinkTo: ../../devices/virtual/block/dm-4
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/block/dm-5
+SymlinkTo: ../../devices/virtual/block/dm-5
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/dmi
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -3628,26 +3649,6 @@ Path: fixtures/sys/class/dmi/id/uevent
 Lines: 1
 MODALIAS=dmi:bvnDellInc.:bvr2.2.4:bd04/12/2021:br2.2:svnDellInc.:pnPowerEdgeR6515:pvr:rvnDellInc.:rn07PXPY:rvrA01:cvnDellInc.:ct23:cvr:
 Mode: 644
-Directory: fixtures/sys/class/block
-Mode: 775
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/block/dm-0
-SymlinkTo: ../../devices/virtual/block/dm-0
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/block/dm-1
-SymlinkTo: ../../devices/virtual/block/dm-1
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/block/dm-2
-SymlinkTo: ../../devices/virtual/block/dm-2
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/block/dm-3
-SymlinkTo: ../../devices/virtual/block/dm-3
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/block/dm-4
-SymlinkTo: ../../devices/virtual/block/dm-4
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/block/dm-5
-SymlinkTo: ../../devices/virtual/block/dm-5
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/drm
 Mode: 755

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -3259,6 +3259,13 @@ Lines: 1
 LVM-3zSHSR5Nbf4j7g6auAAefWY2CMaX01theZYEvQyecVsm2WtX3iY5q51qq5dWWOq7EOF
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/dm-0/slaves
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/dm-0/slaves/sda
+Lines: 0
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/block/dm-0/stat
 Lines: 1
 6447303        0 710266738  1529043   953216        0 31201176  4557464        0   796160  6088971


### PR DESCRIPTION
Expose block device-mapper properties. This will enable node_exporter to expose the device-mapper information in a node_disk_info metric. (PR on that to follow.)
Closes #211.

Signed-off-by: W. Andrew Denton <git@flying-snail.net>