### PR TITLE
Fixed ARP table MAC address parsing, added Flags field

### DIFF
--- a/arp.go
+++ b/arp.go
@@ -24,17 +24,17 @@ import (
 // Learned from include/uapi/linux/if_arp.h
 const (
 	// completed entry (ha valid)
-	ATF_Complete = 0x02
+	ATFComplete = 0x02
 	// permanent entry
-	ATF_Permanent = 0x04
+	ATFPermanent = 0x04
 	// Publish entry
-	ATF_Publish = 0x08
+	ATFPublish = 0x08
 	// Has requested trailers
-	ATF_UseTrailers = 0x10
+	ATFUseTrailers = 0x10
 	// Obsoleted: Want to use a netmask (only for proxy entries)
-	ATF_Netmask = 0x20
+	ATFNetmask = 0x20
 	// Don't answer this addresses
-	ATF_DontPublish = 0x40
+	ATFDontPublish = 0x40
 )
 
 // ARPEntry contains a single row of the columnar data represented in
@@ -110,6 +110,7 @@ func parseARPEntry(columns []string) (ARPEntry, error) {
 	return entry, nil
 }
 
+// IsComplete returns true if ARP entry is marked with complete flag
 func (entry *ARPEntry) IsComplete() bool {
-	return entry.Flags&ATF_Complete != 0
+	return entry.Flags&ATFComplete != 0
 }

--- a/arp_test.go
+++ b/arp_test.go
@@ -33,11 +33,35 @@ func TestARP(t *testing.T) {
 		t.Errorf("want 192.168.224.1, got %s", got)
 	}
 
-	if want, got := net.HardwareAddr("00:50:56:c0:00:08").String(), arpFile[0].HWAddr.String(); want != got {
-		t.Errorf("want 00:50:56:c0:00:08, got %s", got)
+	if want, got := "00:50:56:c0:00:08", arpFile[0].HWAddr.String(); want != got {
+		t.Errorf("want %s, got %s", want, got)
 	}
 
 	if want, got := "ens33", arpFile[0].Device; want != got {
 		t.Errorf("want ens33, got %s", got)
+	}
+
+	if want, got := true, arpFile[0].IsComplete(); want != got {
+		t.Errorf("want %t, got %t", want, got)
+	}
+
+	if want, got := "192.168.224.2", arpFile[1].IPAddr.String(); want != got {
+		t.Errorf("want 192.168.224.2, got %s", got)
+	}
+
+	if want, got := make(net.HardwareAddr, 6).String(), arpFile[1].HWAddr.String(); want != got {
+		t.Errorf("expected empty MAC, got %s", got)
+	}
+
+	if want, got := "ens33", arpFile[1].Device; want != got {
+		t.Errorf("want %s, got %s", want, got)
+	}
+
+	if want, got := byte(0x0), arpFile[1].Flags; want != got {
+		t.Errorf("want %b, got %b", want, got)
+	}
+
+	if want, got := false, arpFile[1].IsComplete(); want != got {
+		t.Errorf("want %t, got %t", want, got)
 	}
 }

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -2084,9 +2084,10 @@ Directory: fixtures/proc/net
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/net/arp
-Lines: 2
+Lines: 3
 IP address       HW type     Flags       HW address            Mask     Device
 192.168.224.1    0x1         0x2         00:50:56:c0:00:08     *        ens33
+192.168.224.2    0x1         0x0         00:00:00:00:00:00     *        ens33
 Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/net/dev


### PR DESCRIPTION
- Added ARPEntry.Flags field related to entry flags
- Added ARPEntry.IsComplete() to check if entry is complete
- Fixed mac address parsing and error handling
- Test improved with incomplete entry information
Closes #413.

Signed-off-by: Serhii Zasenko <sergii@zasenko.name>