### PR TITLE
fix bug when /proc/net/dev contains unexpected line

### DIFF
--- a/net_dev.go
+++ b/net_dev.go
@@ -16,7 +16,6 @@ package procfs
 import (
 	"bufio"
 	"errors"
-	"fmt"
 	"os"
 	"sort"
 	"strconv"
@@ -76,8 +75,7 @@ func newNetDev(file string) (NetDev, error) {
 
 		line, err := netDev.parseLine(s.Text())
 		if err != nil {
-			fmt.Printf("[ERROR] failed to parse line: %v", s.Text())
-			continue
+			return netDev, err
 		}
 
 		netDev[line.Name] = *line
@@ -89,17 +87,17 @@ func newNetDev(file string) (NetDev, error) {
 // parseLine parses a single line from the /proc/net/dev file. Header lines
 // must be filtered prior to calling this method.
 func (netDev NetDev) parseLine(rawLine string) (*NetDevLine, error) {
-	parts := strings.SplitN(rawLine, ":", 2)
-	if len(parts) != 2 {
+	idx := strings.LastIndex(rawLine, ":")
+	if idx == -1 {
 		return nil, errors.New("invalid net/dev line, missing colon")
 	}
-	fields := strings.Fields(strings.TrimSpace(parts[1]))
+	fields := strings.Fields(strings.TrimSpace(rawLine[idx+1:]))
 
 	var err error
 	line := &NetDevLine{}
 
 	// Interface Name
-	line.Name = strings.TrimSpace(parts[0])
+	line.Name = strings.TrimSpace(rawLine[:idx])
 	if line.Name == "" {
 		return nil, errors.New("invalid net/dev line, empty interface name")
 	}

--- a/net_dev.go
+++ b/net_dev.go
@@ -16,6 +16,7 @@ package procfs
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"os"
 	"sort"
 	"strconv"
@@ -75,7 +76,8 @@ func newNetDev(file string) (NetDev, error) {
 
 		line, err := netDev.parseLine(s.Text())
 		if err != nil {
-			return netDev, err
+			fmt.Printf("[ERROR] failed to parse line: %v", s.Text())
+			continue
 		}
 
 		netDev[line.Name] = *line

--- a/net_dev_test.go
+++ b/net_dev_test.go
@@ -14,21 +14,24 @@
 package procfs
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestNetDevParseLine(t *testing.T) {
-	const rawLine = `  eth0: 1 2 3    4    5     6          7         8 9  10    11    12    13     14       15          16`
-
-	have, err := NetDev{}.parseLine(rawLine)
-	if err != nil {
-		t.Fatal(err)
+	tc := []string{"eth0", "eth0:1"}
+	for i := range tc {
+		rawLine := fmt.Sprintf(`  %v: 1 2 3    4    5     6          7         8 9  10    11    12    13     14       15          16`, tc[i])
+		have, err := NetDev{}.parseLine(rawLine)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := NetDevLine{tc[i], 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+		if want != *have {
+			t.Errorf("want %v, have %v", want, have)
+		}
 	}
 
-	want := NetDevLine{"eth0", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-	if want != *have {
-		t.Errorf("want %v, have %v", want, have)
-	}
 }
 
 func TestNetDev(t *testing.T) {


### PR DESCRIPTION
In centos 8(4.18.0-193.28.1.el8_2.x86_64) if I try this command:
```
ip link add team0:1 type dummy
```
I will get a message: 
```
"RTNETLINK answers: Invalid argument". 

```
However if I do the same thing on Centos 7(3.10.0-862.14.4.el7.x86_64), there is no error ! And If I cat /proc/net/dev I can see there is a sub interface:
```
Inter-|   Receive                                                |  Transmit
 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
  eth0: 2489766199  690315    0    0    0     0          0         0 96022876  713917    0    0    0     0       0          0
    lo: 402582904  916378    0    0    0     0          0         0 402582904  916378    0    0    0     0       0          0
team0:1:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
```
So the problem is currently 'procfs' cann't parse /proc/net/dev that contains odd line of interfaces.