### PR TITLE
Add a missing name to the *testing.T argument.

### DIFF
--- a/proc_psi_test.go
+++ b/proc_psi_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestPSIStats(t *testing.T) {
-	t.Run("fake", func(*testing.T) {
+	t.Run("fake", func(t *testing.T) {
 		stats, err := getProcFixtures(t).PSIStatsForResource("fake")
 		if err == nil {
 			t.Fatal("fake resource does not have PSI statistics")


### PR DESCRIPTION
When using t.Run, the subtest must take a named *testing.T argument. Otherwise, inner calls to t.Error etc. are invoked on the outer test object, which is pretty much always wrong.

@discordianfish please review.