### PR TITLE
Add isolated cpu parsing

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -6462,6 +6462,11 @@ Mode: 644
 Directory: fixtures/sys/devices/system/cpu/cpufreq/policy1
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/isolated
+Lines: 1
+1,2-7,9
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/devices/system/node
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -244,7 +244,7 @@ func parseCpufreqCpuinfo(cpuPath string) (*SystemCPUCpufreqStats, error) {
 func (fs FS) IsolatedCPUs() ([]uint16, error) {
 	isolcpus, err := ioutil.ReadFile(fs.sys.Path("devices/system/cpu/isolated"))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read isolcpus from sysfs: %w", err)
+		return nil, err
 	}
 
 	return parseIsolatedCPUs(isolcpus)

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -247,10 +247,10 @@ func (fs FS) IsolatedCPUs() ([]uint16, error) {
 		return nil, fmt.Errorf("failed to read isolcpus from sysfs: %w", err)
 	}
 
-	return parseIsolCPUs(isolcpus)
+	return parseIsolatedCPUs(isolcpus)
 }
 
-func parseIsolCPUs(data []byte) ([]uint16, error) {
+func parseIsolatedCPUs(data []byte) ([]uint16, error) {
 
 	var isolcpusInt = []uint16{}
 

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -269,7 +269,7 @@ func parseIsolCPUs(data []byte) ([]uint16, error) {
 			}
 			endRange, err := strconv.Atoi(ranges[1])
 			if err != nil {
-				return nil, fmt.Errorf("invalid cpu start range: %w", err)
+				return nil, fmt.Errorf("invalid cpu end range: %w", err)
 			}
 
 			for i := startRange; i <= endRange; i++ {

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -247,40 +247,42 @@ func (fs FS) IsolatedCPUs() ([]uint16, error) {
 		return nil, fmt.Errorf("failed to read isolcpus from sysfs: %w", err)
 	}
 
-	return parseIsolCpus(isolcpus)
+	return parseIsolCPUs(isolcpus)
 }
 
-func parseIsolCpus(data []byte) ([]uint16, error) {
-	isolcpus_str := strings.TrimRight(string(data), "\n")
+func parseIsolCPUs(data []byte) ([]uint16, error) {
 
-	var isolcpus_int = []uint16{}
+	var isolcpusInt = []uint16{}
 
-	for _, cpu := range strings.Split(isolcpus_str, ",") {
+	for _, cpu := range strings.Split(strings.TrimRight(string(data), "\n"), ",") {
 		if cpu == "" {
 			continue
 		}
 		if strings.Contains(cpu, "-") {
 			ranges := strings.Split(cpu, "-")
+			if len(ranges) != 2 {
+				return nil, fmt.Errorf("invalid cpu range: %s", cpu)
+			}
 			startRange, err := strconv.Atoi(ranges[0])
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("invalid cpu start range: %w", err)
 			}
 			endRange, err := strconv.Atoi(ranges[1])
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("invalid cpu start range: %w", err)
 			}
 
 			for i := startRange; i <= endRange; i++ {
-				isolcpus_int = append(isolcpus_int, uint16(i))
+				isolcpusInt = append(isolcpusInt, uint16(i))
 			}
 			continue
 		}
 
-		_cpu, err := strconv.Atoi(cpu)
+		cpuN, err := strconv.Atoi(cpu)
 		if err != nil {
 			return nil, err
 		}
-		isolcpus_int = append(isolcpus_int, uint16(_cpu))
+		isolcpusInt = append(isolcpusInt, uint16(cpuN))
 	}
-	return isolcpus_int, nil
+	return isolcpusInt, nil
 }

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -164,7 +164,7 @@ func TestIsolatedParsingCPU(t *testing.T) {
 	}
 	for _, params := range testParams {
 		t.Run("blabla", func(t *testing.T) {
-			res, err := parseIsolCPUs(params.in)
+			res, err := parseIsolatedCPUs(params.in)
 			if !reflect.DeepEqual(res, params.res) {
 				t.Fatalf("should have %v result: got %v", params.res, res)
 			}

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -159,7 +159,7 @@ func TestIsolatedParsingCPU(t *testing.T) {
 		{[]byte("1,3-4,7,20-21"), []uint16{1, 3, 4, 7, 20, 21}, nil},
 
 		{[]byte("1,"), []uint16{1}, nil},
-		{[]byte("1,2-"), nil, errors.New(`invalid cpu start range: strconv.Atoi: parsing "": invalid syntax`)},
+		{[]byte("1,2-"), nil, errors.New(`invalid cpu end range: strconv.Atoi: parsing "": invalid syntax`)},
 		{[]byte("1,-3"), nil, errors.New(`invalid cpu start range: strconv.Atoi: parsing "": invalid syntax`)},
 	}
 	for _, params := range testParams {

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -140,3 +140,43 @@ func TestSystemCpufreq(t *testing.T) {
 		t.Errorf("Result not correct: want %v, have %v", systemCpufreq, c)
 	}
 }
+
+func TestIsolatedParsingCPU(t *testing.T) {
+	var testParams = []struct {
+		in  []byte
+		res []uint16
+		err error
+	}{
+		{[]byte(""), []uint16{}, nil},
+		{[]byte("1\n"), []uint16{1}, nil},
+		{[]byte("1"), []uint16{1}, nil},
+		{[]byte("1,2"), []uint16{1, 2}, nil},
+		{[]byte("1-2"), []uint16{1, 2}, nil},
+		{[]byte("1-3"), []uint16{1, 2, 3}, nil},
+		{[]byte("1,2-4"), []uint16{1, 2, 3, 4}, nil},
+		{[]byte("1,3-4"), []uint16{1, 3, 4}, nil},
+		{[]byte("1,3-4,7,20-21"), []uint16{1, 3, 4, 7, 20, 21}, nil},
+	}
+	for _, params := range testParams {
+		t.Run("blabla", func(t *testing.T) {
+			res, err := parseIsolCpus(params.in)
+			if !reflect.DeepEqual(res, params.res) {
+				t.Fatalf("should have %v result: got %v", params.res, res)
+			}
+			if err != params.err {
+				t.Fatalf("should have %v error: got %v", params.err, err)
+			}
+		})
+	}
+}
+func TestIsolatedCPUs(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	isolated, err := fs.IsolatedCPUs()
+	expected := []uint16{1, 2, 3, 4, 5, 6, 7, 9}
+	if !reflect.DeepEqual(isolated, expected) {
+		t.Errorf("Result not correct: want %v, have %v", expected, isolated)
+	}
+}

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -188,4 +188,7 @@ func TestIsolatedCPUs(t *testing.T) {
 	if !reflect.DeepEqual(isolated, expected) {
 		t.Errorf("Result not correct: want %v, have %v", expected, isolated)
 	}
+	if err != nil {
+		t.Errorf("Error not correct: want %v, have %v", nil, err)
+	}
 }


### PR DESCRIPTION
Hi
This PR adds support for parsing `/sys/devices/system/cpu/isolated`
Prompted by [this PR](https://github.com/prometheus/node_exporter/pull/2251) for node_exporter

I am not sure if this should be a `uint16` or not.