### PR TITLE
Convert %w verb in t.Errorf function to %v

### DIFF
--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -393,7 +393,7 @@ func TestMountStats(t *testing.T) {
 			t.Error("expected an error, but none occurred")
 		}
 		if !tt.invalid && err != nil {
-			t.Errorf("unexpected error: %w", err)
+			t.Errorf("unexpected error: %v", err)
 		}
 
 		if want, have := tt.mounts, mounts; !reflect.DeepEqual(want, have) {
@@ -434,7 +434,7 @@ func TestMountStatsExtendedOperationStats(t *testing.T) {
 	r := strings.NewReader(extendedOpsExampleMountstats)
 	_, err := parseMountStats(r)
 	if err != nil {
-		t.Errorf("failed to parse mount stats with extended per-op statistics: %w", err)
+		t.Errorf("failed to parse mount stats with extended per-op statistics: %v", err)
 	}
 }
 

--- a/swaps_test.go
+++ b/swaps_test.go
@@ -102,7 +102,7 @@ func TestParseSwapString(t *testing.T) {
 				t.Error("unexpected success")
 			}
 			if !tt.invalid && err != nil {
-				t.Errorf("unexpected error: %w", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 
 			if !reflect.DeepEqual(tt.swap, swap) {


### PR DESCRIPTION
Go 1.18 introduced a change where only fmt.Errorf function accepts the %w verb.
Other Errorf function like t.Errorf do not accept it anymore.

See https://github.com/golang/go/issues/47641

Fix: #430