### PR TITLE
Parsing for /proc/softirqs

### DIFF
--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -2654,6 +2654,21 @@ kmem_cache_node      904    928    512   32    4 : tunables    0    0    0 : sla
 kmem_cache           904    936    832   39    8 : tunables    0    0    0 : slabdata     24     24      0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/softirqs
+Lines: 11
+                    CPU0       CPU1       
+          HI:          3          0
+       TIMER:    2776180     247490
+      NET_TX:       2419        772
+      NET_RX:      55919      28694
+       BLOCK:     174915     262755
+    IRQ_POLL:          0          0
+     TASKLET:        209         75
+       SCHED:    2278692     815209
+     HRTIMER:       1281        220
+         RCU:     605871     532783
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/stat
 Lines: 16
 cpu  301854 612 111922 8979004 3552 2 3944 0 0 0

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -156,6 +156,14 @@ Inter-|   Receive                                                |  Transmit
   eth0:     438       5    0    0    0     0          0         0      648       8    0    0    0     0       0          0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/26231/net/netstat
+Lines: 4
+TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPSlowStartRetrans TCPTimeouts TCPLossProbes TCPLossProbeRecovery TCPRenoRecoveryFail TCPSackRecoveryFail TCPRcvCollapsed TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop PFMemallocDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPRcvCoalesce TCPOFOQueue TCPOFODrop TCPOFOMerge TCPChallengeACK TCPSYNChallenge TCPFastOpenActive TCPFastOpenActiveFail TCPFastOpenPassive TCPFastOpenPassiveFail TCPFastOpenListenOverflow TCPFastOpenCookieReqd TCPFastOpenBlackhole TCPSpuriousRtxHostQueues BusyPollRxPackets TCPAutoCorking TCPFromZeroWindowAdv TCPToZeroWindowAdv TCPWantZeroWindowAdv TCPSynRetrans TCPOrigDataSent TCPHystartTrainDetect TCPHystartTrainCwnd TCPHystartDelayDetect TCPHystartDelayCwnd TCPACKSkippedSynRecv TCPACKSkippedPAWS TCPACKSkippedSeq TCPACKSkippedFinWait2 TCPACKSkippedTimeWait TCPACKSkippedChallenge TCPWinProbe TCPKeepAlive TCPMTUPFail TCPMTUPSuccess TCPWqueueTooBig
+TcpExt: 0 0 0 1 0 0 0 0 0 0 83 0 0 0 3640 287 1 7460 0 0 134193 1335 829 0 4 0 1 0 0 0 0 1 19 0 0 0 0 3 0 32 100 4 0 0 0 7460 2421 49 1 62 6 0 23 0 7 0 0 0 0 19 2 0 0 0 0 0 6 0 0 0 0 3 0 0 0 0 92425 65515 0 2421 4 4 0 0 0 0 0 0 0 0 0 10 0 0 0 16 2221 0 0 2 45 0 0 3 0 0 0 0 456 0 0 0
+IpExt: InNoRoutes InTruncatedPkts InMcastPkts OutMcastPkts InBcastPkts OutBcastPkts InOctets OutOctets InMcastOctets OutMcastOctets InBcastOctets OutBcastOctets InCsumErrors InNoECTPkts InECT1Pkts InECT0Pkts InCEPkts ReasmOverlaps
+IpExt: 0 0 208 214 118 111 190585481 7512674 26093 25903 14546 13628 0 134215 0 0 0 0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/26231/net/snmp
 Lines: 12
 Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates
@@ -170,14 +178,6 @@ Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumE
 Udp: 10179 50 0 9846 0 0 0 58
 UdpLite: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti
 UdpLite: 0 0 0 0 0 0 0 0
-Mode: 644
-# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/proc/26231/net/netstat
-Lines: 4
-TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPSlowStartRetrans TCPTimeouts TCPLossProbes TCPLossProbeRecovery TCPRenoRecoveryFail TCPSackRecoveryFail TCPRcvCollapsed TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop PFMemallocDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPRcvCoalesce TCPOFOQueue TCPOFODrop TCPOFOMerge TCPChallengeACK TCPSYNChallenge TCPFastOpenActive TCPFastOpenActiveFail TCPFastOpenPassive TCPFastOpenPassiveFail TCPFastOpenListenOverflow TCPFastOpenCookieReqd TCPFastOpenBlackhole TCPSpuriousRtxHostQueues BusyPollRxPackets TCPAutoCorking TCPFromZeroWindowAdv TCPToZeroWindowAdv TCPWantZeroWindowAdv TCPSynRetrans TCPOrigDataSent TCPHystartTrainDetect TCPHystartTrainCwnd TCPHystartDelayDetect TCPHystartDelayCwnd TCPACKSkippedSynRecv TCPACKSkippedPAWS TCPACKSkippedSeq TCPACKSkippedFinWait2 TCPACKSkippedTimeWait TCPACKSkippedChallenge TCPWinProbe TCPKeepAlive TCPMTUPFail TCPMTUPSuccess TCPWqueueTooBig
-TcpExt: 0 0 0 1 0 0 0 0 0 0 83 0 0 0 3640 287 1 7460 0 0 134193 1335 829 0 4 0 1 0 0 0 0 1 19 0 0 0 0 3 0 32 100 4 0 0 0 7460 2421 49 1 62 6 0 23 0 7 0 0 0 0 19 2 0 0 0 0 0 6 0 0 0 0 3 0 0 0 0 92425 65515 0 2421 4 4 0 0 0 0 0 0 0 0 0 10 0 0 0 16 2221 0 0 2 45 0 0 3 0 0 0 0 456 0 0 0
-IpExt: InNoRoutes InTruncatedPkts InMcastPkts OutMcastPkts InBcastPkts OutBcastPkts InOctets OutOctets InMcastOctets OutMcastOctets InBcastOctets OutBcastOctets InCsumErrors InNoECTPkts InECT1Pkts InECT0Pkts InCEPkts ReasmOverlaps
-IpExt: 0 0 208 214 118 111 190585481 7512674 26093 25903 14546 13628 0 134215 0 0 0 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/26231/net/snmp6
@@ -274,6 +274,7 @@ UdpLite6RcvbufErrors            	0
 UdpLite6SndbufErrors            	0
 UdpLite6InCsumErrors            	0
 Mode: 644
+Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/proc/26231/ns
 Mode: 755

--- a/proc_netstat.go
+++ b/proc_netstat.go
@@ -183,7 +183,7 @@ func (p Proc) Netstat() (ProcNetstat, error) {
 // and returns a ProcNetstat structure.
 func parseNetstat(r io.Reader, fileName string) (ProcNetstat, error) {
 	var (
-		scanner  = bufio.NewScanner(r)
+		scanner     = bufio.NewScanner(r)
 		procNetstat = ProcNetstat{}
 	)
 

--- a/proc_netstat_test.go
+++ b/proc_netstat_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package procfs
 
 import (

--- a/proc_snmp6.go
+++ b/proc_snmp6.go
@@ -160,7 +160,7 @@ func (p Proc) Snmp6() (ProcSnmp6, error) {
 // and returns a map contains those metrics.
 func parseSNMP6Stats(r io.Reader) (ProcSnmp6, error) {
 	var (
-		scanner  = bufio.NewScanner(r)
+		scanner   = bufio.NewScanner(r)
 		procSnmp6 = ProcSnmp6{}
 	)
 

--- a/proc_snmp6_test.go
+++ b/proc_snmp6_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package procfs
 
 import "testing"

--- a/softirqs.go
+++ b/softirqs.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2022 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/softirqs.go
+++ b/softirqs.go
@@ -1,0 +1,181 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	// "github.com/prometheus/procfs/internal/fs"
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// Softirqs represents the softirq statistics.
+type Softirqs struct {
+	Hi          []uint64
+	Timer       []uint64
+	NetTx       []uint64
+	NetRx       []uint64
+	Block       []uint64
+	IrqPoll 		[]uint64
+	Tasklet     []uint64
+	Sched       []uint64
+	Hrtimer     []uint64
+	Rcu         []uint64
+}
+
+func (fs FS) Softirqs() (Softirqs, error) {
+	fileName := fs.proc.Path("softirqs")
+	data, err := util.ReadFileNoStat(fileName)
+	if err != nil {
+		return Softirqs{}, err
+	}
+
+	reader := bytes.NewReader(data)
+
+ 	return parseSoftirqs(reader)
+ }
+
+func parseSoftirqs(r io.Reader) (Softirqs, error) {
+ 	var (
+ 		softirqs = Softirqs{}
+ 		scanner  = bufio.NewScanner(r)
+ 	)
+
+ 	if !scanner.Scan() {
+ 		return Softirqs{}, fmt.Errorf("softirqs empty")
+ 	}
+
+ 	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		var err error
+
+		// require at least one cpu
+		if len(parts) < 2 {
+			continue
+		}
+		switch {
+		case parts[0] == "HI:":
+			perCpu := parts[1:]
+			softirqs.Hi = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.Hi[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (HI%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "TIMER:":
+			perCpu := parts[1:]
+			softirqs.Timer = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.Timer[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (TIMER%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "NET_TX:":
+			perCpu := parts[1:]
+			softirqs.NetTx = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.NetTx[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (NET_TX%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "NET_RX:":
+			perCpu := parts[1:]
+			softirqs.NetRx = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.NetRx[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (NET_RX%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "BLOCK:":
+			perCpu := parts[1:]
+			softirqs.Block = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.Block[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (BLOCK%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "IRQ_POLL:":
+			perCpu := parts[1:]
+			softirqs.IrqPoll = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.IrqPoll[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (IRQ_POLL%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "TASKLET:":
+			perCpu := parts[1:]
+			softirqs.Tasklet = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.Tasklet[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (TASKLET%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "SCHED:":
+			perCpu := parts[1:]
+			softirqs.Sched = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.Sched[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (SCHED%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "HRTIMER:":
+			perCpu := parts[1:]
+			softirqs.Hrtimer = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.Hrtimer[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (HRTIMER%d): %w", count, i, err)
+				}
+			}
+		case parts[0] == "RCU:":
+			perCpu := parts[1:]
+			softirqs.Rcu = make([]uint64, len(perCpu))
+			for i, count := range perCpu {
+				print(count)
+				print(i)
+				if softirqs.Rcu[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+					return Softirqs{}, fmt.Errorf("couldn't parse %q (RCU%d): %w", count, i, err)
+				}
+			}
+		}
+ 	}
+
+	if err := scanner.Err(); err != nil {
+		return Softirqs{}, fmt.Errorf("couldn't parse softirqs: %w", err)
+	}
+
+ 	return softirqs, scanner.Err()
+ }

--- a/softirqs.go
+++ b/softirqs.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	// "github.com/prometheus/procfs/internal/fs"
 	"github.com/prometheus/procfs/internal/util"
 )
 
@@ -32,7 +31,7 @@ type Softirqs struct {
 	NetTx       []uint64
 	NetRx       []uint64
 	Block       []uint64
-	IrqPoll 		[]uint64
+	IrqPoll     []uint64
 	Tasklet     []uint64
 	Sched       []uint64
 	Hrtimer     []uint64

--- a/softirqs.go
+++ b/softirqs.go
@@ -26,15 +26,15 @@ import (
 
 // Softirqs represents the softirq statistics.
 type Softirqs struct {
-	HI      []uint64
-	TIMER   []uint64
-	NETTX   []uint64
-	NETRX   []uint64
-	BLOCK   []uint64
-	IRQPOLL []uint64
-	TASKLET []uint64
-	SCHED   []uint64
-	HRTIMER []uint64
+	Hi      []uint64
+	Timer   []uint64
+	NetTx   []uint64
+	NetRx   []uint64
+	Block   []uint64
+	IRQPoll []uint64
+	Tasklet []uint64
+	Sched   []uint64
+	HRTimer []uint64
 	RCU     []uint64
 }
 
@@ -71,73 +71,73 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 		switch {
 		case parts[0] == "HI:":
 			perCpu := parts[1:]
-			softirqs.HI = make([]uint64, len(perCpu))
+			softirqs.Hi = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.HI[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.Hi[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (HI%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "TIMER:":
 			perCpu := parts[1:]
-			softirqs.TIMER = make([]uint64, len(perCpu))
+			softirqs.Timer = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.TIMER[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.Timer[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (TIMER%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "NET_TX:":
 			perCpu := parts[1:]
-			softirqs.NETTX = make([]uint64, len(perCpu))
+			softirqs.NetTx = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.NETTX[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.NetTx[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (NET_TX%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "NET_RX:":
 			perCpu := parts[1:]
-			softirqs.NETRX = make([]uint64, len(perCpu))
+			softirqs.NetRx = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.NETRX[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.NetRx[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (NET_RX%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "BLOCK:":
 			perCpu := parts[1:]
-			softirqs.BLOCK = make([]uint64, len(perCpu))
+			softirqs.Block = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.BLOCK[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.Block[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (BLOCK%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "IRQ_POLL:":
 			perCpu := parts[1:]
-			softirqs.IRQPOLL = make([]uint64, len(perCpu))
+			softirqs.IRQPoll = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.IRQPOLL[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.IRQPoll[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (IRQ_POLL%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "TASKLET:":
 			perCpu := parts[1:]
-			softirqs.TASKLET = make([]uint64, len(perCpu))
+			softirqs.Tasklet = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.TASKLET[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.Tasklet[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (TASKLET%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "SCHED:":
 			perCpu := parts[1:]
-			softirqs.SCHED = make([]uint64, len(perCpu))
+			softirqs.Sched = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.SCHED[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.Sched[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (SCHED%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "HRTIMER:":
 			perCpu := parts[1:]
-			softirqs.HRTIMER = make([]uint64, len(perCpu))
+			softirqs.HRTimer = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				if softirqs.HRTIMER[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.HRTimer[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (HRTIMER%d): %w", count, i, err)
 				}
 			}

--- a/softirqs.go
+++ b/softirqs.go
@@ -73,8 +73,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.HI = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.HI[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (HI%d): %w", count, i, err)
 				}
@@ -83,8 +81,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.TIMER = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.TIMER[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (TIMER%d): %w", count, i, err)
 				}
@@ -93,8 +89,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.NETTX = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.NETTX[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (NET_TX%d): %w", count, i, err)
 				}
@@ -103,8 +97,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.NETRX = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.NETRX[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (NET_RX%d): %w", count, i, err)
 				}
@@ -113,8 +105,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.BLOCK = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.BLOCK[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (BLOCK%d): %w", count, i, err)
 				}
@@ -123,8 +113,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.IRQPOLL = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.IRQPOLL[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (IRQ_POLL%d): %w", count, i, err)
 				}
@@ -133,8 +121,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.TASKLET = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.TASKLET[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (TASKLET%d): %w", count, i, err)
 				}
@@ -143,8 +129,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.SCHED = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.SCHED[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (SCHED%d): %w", count, i, err)
 				}
@@ -153,8 +137,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.HRTIMER = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.HRTIMER[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (HRTIMER%d): %w", count, i, err)
 				}
@@ -163,8 +145,6 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 			perCpu := parts[1:]
 			softirqs.RCU = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
-				print(count)
-				print(i)
 				if softirqs.RCU[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (RCU%d): %w", count, i, err)
 				}

--- a/softirqs.go
+++ b/softirqs.go
@@ -26,16 +26,16 @@ import (
 
 // Softirqs represents the softirq statistics.
 type Softirqs struct {
-	Hi          []uint64
-	Timer       []uint64
-	NetTx       []uint64
-	NetRx       []uint64
-	Block       []uint64
-	IrqPoll     []uint64
-	Tasklet     []uint64
-	Sched       []uint64
-	Hrtimer     []uint64
-	Rcu         []uint64
+	Hi      []uint64
+	Timer   []uint64
+	NetTx   []uint64
+	NetRx   []uint64
+	Block   []uint64
+	IrqPoll []uint64
+	Tasklet []uint64
+	Sched   []uint64
+	Hrtimer []uint64
+	Rcu     []uint64
 }
 
 func (fs FS) Softirqs() (Softirqs, error) {
@@ -47,20 +47,20 @@ func (fs FS) Softirqs() (Softirqs, error) {
 
 	reader := bytes.NewReader(data)
 
- 	return parseSoftirqs(reader)
- }
+	return parseSoftirqs(reader)
+}
 
 func parseSoftirqs(r io.Reader) (Softirqs, error) {
- 	var (
- 		softirqs = Softirqs{}
- 		scanner  = bufio.NewScanner(r)
- 	)
+	var (
+		softirqs = Softirqs{}
+		scanner  = bufio.NewScanner(r)
+	)
 
- 	if !scanner.Scan() {
- 		return Softirqs{}, fmt.Errorf("softirqs empty")
- 	}
+	if !scanner.Scan() {
+		return Softirqs{}, fmt.Errorf("softirqs empty")
+	}
 
- 	for scanner.Scan() {
+	for scanner.Scan() {
 		parts := strings.Fields(scanner.Text())
 		var err error
 
@@ -170,11 +170,11 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 				}
 			}
 		}
- 	}
+	}
 
 	if err := scanner.Err(); err != nil {
 		return Softirqs{}, fmt.Errorf("couldn't parse softirqs: %w", err)
 	}
 
- 	return softirqs, scanner.Err()
- }
+	return softirqs, scanner.Err()
+}

--- a/softirqs.go
+++ b/softirqs.go
@@ -26,16 +26,16 @@ import (
 
 // Softirqs represents the softirq statistics.
 type Softirqs struct {
-	Hi      []uint64
-	Timer   []uint64
-	NetTx   []uint64
-	NetRx   []uint64
-	Block   []uint64
-	IrqPoll []uint64
-	Tasklet []uint64
-	Sched   []uint64
-	Hrtimer []uint64
-	Rcu     []uint64
+	HI      []uint64
+	TIMER   []uint64
+	NETTX   []uint64
+	NETRX   []uint64
+	BLOCK   []uint64
+	IRQPOLL []uint64
+	TASKLET []uint64
+	SCHED   []uint64
+	HRTIMER []uint64
+	RCU     []uint64
 }
 
 func (fs FS) Softirqs() (Softirqs, error) {
@@ -71,101 +71,101 @@ func parseSoftirqs(r io.Reader) (Softirqs, error) {
 		switch {
 		case parts[0] == "HI:":
 			perCpu := parts[1:]
-			softirqs.Hi = make([]uint64, len(perCpu))
+			softirqs.HI = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.Hi[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.HI[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (HI%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "TIMER:":
 			perCpu := parts[1:]
-			softirqs.Timer = make([]uint64, len(perCpu))
+			softirqs.TIMER = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.Timer[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.TIMER[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (TIMER%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "NET_TX:":
 			perCpu := parts[1:]
-			softirqs.NetTx = make([]uint64, len(perCpu))
+			softirqs.NETTX = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.NetTx[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.NETTX[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (NET_TX%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "NET_RX:":
 			perCpu := parts[1:]
-			softirqs.NetRx = make([]uint64, len(perCpu))
+			softirqs.NETRX = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.NetRx[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.NETRX[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (NET_RX%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "BLOCK:":
 			perCpu := parts[1:]
-			softirqs.Block = make([]uint64, len(perCpu))
+			softirqs.BLOCK = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.Block[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.BLOCK[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (BLOCK%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "IRQ_POLL:":
 			perCpu := parts[1:]
-			softirqs.IrqPoll = make([]uint64, len(perCpu))
+			softirqs.IRQPOLL = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.IrqPoll[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.IRQPOLL[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (IRQ_POLL%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "TASKLET:":
 			perCpu := parts[1:]
-			softirqs.Tasklet = make([]uint64, len(perCpu))
+			softirqs.TASKLET = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.Tasklet[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.TASKLET[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (TASKLET%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "SCHED:":
 			perCpu := parts[1:]
-			softirqs.Sched = make([]uint64, len(perCpu))
+			softirqs.SCHED = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.Sched[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.SCHED[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (SCHED%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "HRTIMER:":
 			perCpu := parts[1:]
-			softirqs.Hrtimer = make([]uint64, len(perCpu))
+			softirqs.HRTIMER = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.Hrtimer[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.HRTIMER[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (HRTIMER%d): %w", count, i, err)
 				}
 			}
 		case parts[0] == "RCU:":
 			perCpu := parts[1:]
-			softirqs.Rcu = make([]uint64, len(perCpu))
+			softirqs.RCU = make([]uint64, len(perCpu))
 			for i, count := range perCpu {
 				print(count)
 				print(i)
-				if softirqs.Rcu[i], err = strconv.ParseUint(count, 10, 64); err != nil {
+				if softirqs.RCU[i], err = strconv.ParseUint(count, 10, 64); err != nil {
 					return Softirqs{}, fmt.Errorf("couldn't parse %q (RCU%d): %w", count, i, err)
 				}
 			}

--- a/softirqs_test.go
+++ b/softirqs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2022 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/softirqs_test.go
+++ b/softirqs_test.go
@@ -1,0 +1,64 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import "testing"
+
+func TestSoftirqs(t *testing.T) {
+	s, err := getProcFixtures(t).Softirqs()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// hi
+	if want, have := uint64(3), s.Hi[0]; want != have {
+		t.Errorf("want softirq HI count %d, have %d", want, have)
+	}
+	// timer
+	if want, have := uint64(247490), s.Timer[1]; want != have {
+		t.Errorf("want softirq TIMER count %d, have %d", want, have)
+	}
+	// net_tx
+	if want, have := uint64(2419), s.NetTx[0]; want != have {
+		t.Errorf("want softirq NET_TX count %d, have %d", want, have)
+	}
+	// net_rx
+	if want, have := uint64(28694), s.NetRx[1]; want != have {
+		t.Errorf("want softirq NET_RX count %d, have %d", want, have)
+	}
+	// block
+	if want, have := uint64(262755), s.Block[1]; want != have {
+		t.Errorf("want softirq BLOCK count %d, have %d", want, have)
+	}
+	// irq_poll
+	if want, have := uint64(0), s.IrqPoll[0]; want != have {
+		t.Errorf("want softirq IRQ_POLL count %d, have %d", want, have)
+	}
+	// tasklet
+	if want, have := uint64(209), s.Tasklet[0]; want != have {
+		t.Errorf("want softirq TASKLET count %d, have %d", want, have)
+	}
+	// sched
+	if want, have := uint64(2278692), s.Sched[0]; want != have {
+		t.Errorf("want softirq SCHED count %d, have %d", want, have)
+	}
+	// hrtimer
+	if want, have := uint64(1281), s.Hrtimer[0]; want != have {
+		t.Errorf("want softirq HRTIMER count %d, have %d", want, have)
+	}
+	// rcu
+	if want, have := uint64(532783), s.Rcu[1]; want != have {
+		t.Errorf("want softirq RCU count %d, have %d", want, have)
+	}
+}

--- a/softirqs_test.go
+++ b/softirqs_test.go
@@ -22,39 +22,39 @@ func TestSoftirqs(t *testing.T) {
 	}
 
 	// hi
-	if want, have := uint64(3), s.HI[0]; want != have {
+	if want, have := uint64(3), s.Hi[0]; want != have {
 		t.Errorf("want softirq HI count %d, have %d", want, have)
 	}
 	// timer
-	if want, have := uint64(247490), s.TIMER[1]; want != have {
+	if want, have := uint64(247490), s.Timer[1]; want != have {
 		t.Errorf("want softirq TIMER count %d, have %d", want, have)
 	}
 	// net_tx
-	if want, have := uint64(2419), s.NETTX[0]; want != have {
+	if want, have := uint64(2419), s.NetTx[0]; want != have {
 		t.Errorf("want softirq NET_TX count %d, have %d", want, have)
 	}
 	// net_rx
-	if want, have := uint64(28694), s.NETRX[1]; want != have {
+	if want, have := uint64(28694), s.NetRx[1]; want != have {
 		t.Errorf("want softirq NET_RX count %d, have %d", want, have)
 	}
 	// block
-	if want, have := uint64(262755), s.BLOCK[1]; want != have {
+	if want, have := uint64(262755), s.Block[1]; want != have {
 		t.Errorf("want softirq BLOCK count %d, have %d", want, have)
 	}
 	// irq_poll
-	if want, have := uint64(0), s.IRQPOLL[0]; want != have {
+	if want, have := uint64(0), s.IRQPoll[0]; want != have {
 		t.Errorf("want softirq IRQ_POLL count %d, have %d", want, have)
 	}
 	// tasklet
-	if want, have := uint64(209), s.TASKLET[0]; want != have {
+	if want, have := uint64(209), s.Tasklet[0]; want != have {
 		t.Errorf("want softirq TASKLET count %d, have %d", want, have)
 	}
 	// sched
-	if want, have := uint64(2278692), s.SCHED[0]; want != have {
+	if want, have := uint64(2278692), s.Sched[0]; want != have {
 		t.Errorf("want softirq SCHED count %d, have %d", want, have)
 	}
 	// hrtimer
-	if want, have := uint64(1281), s.HRTIMER[0]; want != have {
+	if want, have := uint64(1281), s.HRTimer[0]; want != have {
 		t.Errorf("want softirq HRTIMER count %d, have %d", want, have)
 	}
 	// rcu

--- a/softirqs_test.go
+++ b/softirqs_test.go
@@ -22,43 +22,43 @@ func TestSoftirqs(t *testing.T) {
 	}
 
 	// hi
-	if want, have := uint64(3), s.Hi[0]; want != have {
+	if want, have := uint64(3), s.HI[0]; want != have {
 		t.Errorf("want softirq HI count %d, have %d", want, have)
 	}
 	// timer
-	if want, have := uint64(247490), s.Timer[1]; want != have {
+	if want, have := uint64(247490), s.TIMER[1]; want != have {
 		t.Errorf("want softirq TIMER count %d, have %d", want, have)
 	}
 	// net_tx
-	if want, have := uint64(2419), s.NetTx[0]; want != have {
+	if want, have := uint64(2419), s.NETTX[0]; want != have {
 		t.Errorf("want softirq NET_TX count %d, have %d", want, have)
 	}
 	// net_rx
-	if want, have := uint64(28694), s.NetRx[1]; want != have {
+	if want, have := uint64(28694), s.NETRX[1]; want != have {
 		t.Errorf("want softirq NET_RX count %d, have %d", want, have)
 	}
 	// block
-	if want, have := uint64(262755), s.Block[1]; want != have {
+	if want, have := uint64(262755), s.BLOCK[1]; want != have {
 		t.Errorf("want softirq BLOCK count %d, have %d", want, have)
 	}
 	// irq_poll
-	if want, have := uint64(0), s.IrqPoll[0]; want != have {
+	if want, have := uint64(0), s.IRQPOLL[0]; want != have {
 		t.Errorf("want softirq IRQ_POLL count %d, have %d", want, have)
 	}
 	// tasklet
-	if want, have := uint64(209), s.Tasklet[0]; want != have {
+	if want, have := uint64(209), s.TASKLET[0]; want != have {
 		t.Errorf("want softirq TASKLET count %d, have %d", want, have)
 	}
 	// sched
-	if want, have := uint64(2278692), s.Sched[0]; want != have {
+	if want, have := uint64(2278692), s.SCHED[0]; want != have {
 		t.Errorf("want softirq SCHED count %d, have %d", want, have)
 	}
 	// hrtimer
-	if want, have := uint64(1281), s.Hrtimer[0]; want != have {
+	if want, have := uint64(1281), s.HRTIMER[0]; want != have {
 		t.Errorf("want softirq HRTIMER count %d, have %d", want, have)
 	}
 	// rcu
-	if want, have := uint64(532783), s.Rcu[1]; want != have {
+	if want, have := uint64(532783), s.RCU[1]; want != have {
 		t.Errorf("want softirq RCU count %d, have %d", want, have)
 	}
 }


### PR DESCRIPTION
Parsing of detailed softirq statistics found in /proc/softirqs.

Relating to pull request node_exporter: https://github.com/prometheus/node_exporter/pull/2294

Hopefully this is what you had in mind @discordianfish - once pulled in I'll return to the original PR and replace the parsing.