### PR TITLE
parsing /proc/stat by CPU ID

### DIFF
--- a/stat.go
+++ b/stat.go
@@ -62,7 +62,7 @@ type Stat struct {
 	// Summed up cpu statistics.
 	CPUTotal CPUStat
 	// Per-CPU statistics.
-	CPU []CPUStat
+	CPU map[int64]CPUStat
 	// Number of times interrupts were handled, which contains numbered and unnumbered IRQs.
 	IRQTotal uint64
 	// Number of times a numbered IRQ was triggered.
@@ -171,7 +171,9 @@ func (fs FS) Stat() (Stat, error) {
 		return Stat{}, err
 	}
 
-	stat := Stat{}
+	stat := Stat{
+		CPU: make(map[int64]CPUStat),
+	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
@@ -228,9 +230,6 @@ func (fs FS) Stat() (Stat, error) {
 			if cpuID == -1 {
 				stat.CPUTotal = cpuStat
 			} else {
-				for int64(len(stat.CPU)) <= cpuID {
-					stat.CPU = append(stat.CPU, CPUStat{})
-				}
 				stat.CPU[cpuID] = cpuStat
 			}
 		}


### PR DESCRIPTION
We have a case that some of the cpu (threads) are offline intentionally (see lscpu below),  procfs will "interpolate" those offline values. This patch made the /proc/stat parsing with the real cpu ID.

```
Architecture:         x86_64
CPU op-mode(s):       32-bit, 64-bit
Byte Order:           Little Endian
CPU(s):               16
On-line CPU(s) list:  0,2,4,6,8,10,12,14
Off-line CPU(s) list: 1,3,5,7,9,11,13,15
Thread(s) per core:   1
Core(s) per socket:   8
Socket(s):            1
NUMA node(s):         1
Vendor ID:            GenuineIntel
CPU family:           6
Model:                106
Model name:           Intel(R) Xeon(R) Gold 6354 CPU @ 3.00GHz
Stepping:             6
CPU MHz:              2993.062
BogoMIPS:             5986.12
Virtualization:       VT-x
Hypervisor vendor:    KVM
Virtualization type:  full
L1d cache:            32K
L1i cache:            32K
L2 cache:             4096K
L3 cache:             16384K
NUMA node0 CPU(s):    0,2,4,6,8,10,12,14
Flags:                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq vmx ssse3 fma cx16 pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves wbnoinvd arat avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid md_clear arch_capabilities
```