### PR TITLE
Added fips.go for fips_enabled status parsing

### DIFF
--- a/fips.go
+++ b/fips.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+        "strings"
+        "github.com/prometheus/procfs/internal/util"
+)
+
+// Fips returns fips enabled status of the system.
+func (fs FS) Fips() ([]string, error) {
+        fips_status, err := util.ReadFileNoStat(fs.proc.Path("sys/crypto/fips_enabled"))
+        if err != nil {
+                return nil, err
+        }
+
+        return strings.Fields(string(fips_status)), nil
+}

--- a/fips_test.go
+++ b/fips_test.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package procfs
+
+import (
+        "testing"
+
+        "github.com/google/go-cmp/cmp"
+)
+
+func TestFips(t *testing.T) {
+        fs, err := NewFS(procTestFixtures)
+        if err != nil {
+                t.Fatal(err)
+        }
+
+        got, err := fs.Fips()
+        if err != nil {
+                t.Fatal(err)
+        }
+        want := []string{
+                "0",
+        }
+
+        if diff := cmp.Diff(want, got); diff != "" {
+                t.Fatalf("unexpected fips status (-want +got):\n%s", diff)
+        }
+}

--- a/fixtures.ttar
+++ b/fixtures.ttar
@@ -2712,6 +2712,14 @@ Mode: 644
 Directory: fixtures/proc/sys
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/proc/sys/crypto
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/sys/crypto/fips_enabled
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/proc/sys/kernel
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Hi

Added fips_enabled status parsing from /proc/sys/crypto/fips_enabled.
Had created a pull request earlier in prometheus/node_exporter repo but as per @discordianfish parsing needs to be from this repository. 
PR Link - https://github.com/prometheus/node_exporter/pull/2313

make test had no issues, if anything else needed let me know.

Signed-off-by: Aditya Borgaonkar
<borg.aditya@gmail.com>