### PR TITLE
Prevent panic if status line is empty in mdstat

### DIFF
--- a/mdstat.go
+++ b/mdstat.go
@@ -166,8 +166,12 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 }
 
 func evalStatusLine(deviceLine, statusLine string) (active, total, down, size int64, err error) {
+	statusFields := strings.Fields(statusLine)
+	if len(statusFields) < 1 {
+		return 0, 0, 0, 0, fmt.Errorf("unexpected statusLine %q", statusLine)
+	}
 
-	sizeStr := strings.Fields(statusLine)[0]
+	sizeStr := statusFields[0]
 	size, err = strconv.ParseInt(sizeStr, 10, 64)
 	if err != nil {
 		return 0, 0, 0, 0, fmt.Errorf("unexpected statusLine %q: %w", statusLine, err)

--- a/mdstat_test.go
+++ b/mdstat_test.go
@@ -56,16 +56,23 @@ func TestFS_MDStat(t *testing.T) {
 }
 
 func TestInvalidMdstat(t *testing.T) {
-	invalidMount := []byte(`
+	invalidMount := [][]byte{[]byte(`
 Personalities : [invalid]
 md3 : invalid
       314159265 blocks 64k chunks
 
 unused devices: <none>
-`)
+`),
+		[]byte(`
+md12 : active raid0 sdc2[0] sdd2[1]
 
-	_, err := parseMDStat(invalidMount)
-	if err == nil {
-		t.Fatalf("parsing of invalid reference file did not find any errors")
+      3886394368 blocks super 1.2 512k chunks
+`)}
+
+	for _, invalid := range invalidMount {
+		_, err := parseMDStat(invalid)
+		if err == nil {
+			t.Fatalf("parsing of invalid reference file did not find any errors")
+		}
 	}
 }


### PR DESCRIPTION
This change fixes a potential source of panic when the status line in
mdstat is empty and the code is trying to reference the first item in a
zero-sized slice.

@discordianfish @pgier

Signed-off-by: Artur Makutunowicz <artur@makutunowicz.net>