### PR TITLE
Move fixtures to testdata folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/fixtures/
+/testdata/fixtures/
+/fixtures

--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,18 @@
 include Makefile.common
 
 %/.unpacked: %.ttar
-	@echo ">> extracting fixtures"
+	@echo ">> extracting fixtures $*"
 	./ttar -C $(dir $*) -x -f $*.ttar
 	touch $@
 
-fixtures: fixtures/.unpacked
+fixtures: testdata/fixtures/.unpacked
 
 update_fixtures:
-	rm -vf fixtures/.unpacked
-	./ttar -c -f fixtures.ttar fixtures/
+	rm -vf testdata/fixtures/.unpacked
+	./ttar -c -f testdata/fixtures.ttar -C testdata/ fixtures/
 
 .PHONY: build
 build:
 
 .PHONY: test
-test: fixtures/.unpacked common-test
+test: testdata/fixtures/.unpacked common-test

--- a/bcache/get_test.go
+++ b/bcache/get_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestFSBcacheStats(t *testing.T) {
-	bcache, err := NewFS("../fixtures/sys")
+	bcache, err := NewFS("testdata/fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access bcache fs: %v", err)
 	}

--- a/bcache/testdata/fixtures
+++ b/bcache/testdata/fixtures
@@ -1,0 +1,1 @@
+../../testdata/fixtures

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -21,8 +21,8 @@ import (
 
 const (
 	failMsgFormat  = "%v, expected %v, actual %v"
-	procfsFixtures = "../fixtures/proc"
-	sysfsFixtures  = "../fixtures/sys"
+	procfsFixtures = "testdata/fixtures/proc"
+	sysfsFixtures  = "testdata/fixtures/sys"
 )
 
 func TestDiskstats(t *testing.T) {
@@ -65,7 +65,7 @@ func TestDiskstats(t *testing.T) {
 }
 
 func TestBlockDevice(t *testing.T) {
-	blockdevice, err := NewFS("../fixtures/proc", "../fixtures/sys")
+	blockdevice, err := NewFS("testdata/fixtures/proc", "testdata/fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access blockdevice fs: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestBlockDevice(t *testing.T) {
 }
 
 func TestBlockDmInfo(t *testing.T) {
-	blockdevice, err := NewFS("../fixtures/proc", "../fixtures/sys")
+	blockdevice, err := NewFS("testdata/fixtures/proc", "testdata/fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access blockdevice fs: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestBlockDmInfo(t *testing.T) {
 }
 
 func TestSysBlockDeviceUnderlyingDevices(t *testing.T) {
-	blockdevice, err := NewFS("../fixtures/proc", "../fixtures/sys")
+	blockdevice, err := NewFS("testdata/fixtures/proc", "testdata/fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access blockdevice fs: %v", err)
 	}

--- a/blockdevice/testdata/fixtures
+++ b/blockdevice/testdata/fixtures
@@ -1,0 +1,1 @@
+../../testdata/fixtures

--- a/btrfs/get_test.go
+++ b/btrfs/get_test.go
@@ -28,7 +28,7 @@ type alloc struct {
 }
 
 func TestFSBtrfsStats(t *testing.T) {
-	btrfs, err := NewFS("../fixtures/sys")
+	btrfs, err := NewFS("testdata/fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access Btrfs filesystem: %v", err)
 	}

--- a/btrfs/testdata/fixtures
+++ b/btrfs/testdata/fixtures
@@ -1,0 +1,1 @@
+../../testdata/fixtures

--- a/fs_test.go
+++ b/fs_test.go
@@ -16,7 +16,7 @@ package procfs
 import "testing"
 
 const (
-	procTestFixtures = "fixtures/proc"
+	procTestFixtures = "testdata/fixtures/proc"
 )
 
 func TestNewFS(t *testing.T) {

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -16,7 +16,7 @@ package fs
 import "testing"
 
 const (
-	sysTestFixtures = "../../fixtures/sys"
+	sysTestFixtures = "testdata/fixtures/sys"
 )
 
 func TestNewFS(t *testing.T) {

--- a/internal/fs/testdata/fixtures
+++ b/internal/fs/testdata/fixtures
@@ -1,0 +1,1 @@
+../../../testdata/fixtures

--- a/iscsi/get_test.go
+++ b/iscsi/get_test.go
@@ -30,12 +30,12 @@ func TestGetStats(t *testing.T) {
 				Tpgt: []iscsi.TPGT{
 					{
 						Name:     "tpgt_1",
-						TpgtPath: "../fixtures/sys/kernel/config/target/iscsi/iqn.2003-01.org.linux-iscsi.osd1.x8664:sn.8888bbbbddd0/tpgt_1",
+						TpgtPath: "testdata/fixtures/sys/kernel/config/target/iscsi/iqn.2003-01.org.linux-iscsi.osd1.x8664:sn.8888bbbbddd0/tpgt_1",
 						IsEnable: true,
 						Luns: []iscsi.LUN{
 							{
 								Name:       "lun_0",
-								LunPath:    "../fixtures/sys/kernel/config/target/iscsi/iqn.2003-01.org.linux-iscsi.osd1.x8664:sn.8888bbbbddd0/tpgt_1/lun/lun_0",
+								LunPath:    "testdata/fixtures/sys/kernel/config/target/iscsi/iqn.2003-01.org.linux-iscsi.osd1.x8664:sn.8888bbbbddd0/tpgt_1/lun/lun_0",
 								Backstore:  "rd_mcp",
 								ObjectName: "ramdisk_lio_1G",
 								TypeNumber: "119",
@@ -43,7 +43,7 @@ func TestGetStats(t *testing.T) {
 						},
 					},
 				},
-				RootPath: "../fixtures/sys/kernel/config/target/iscsi",
+				RootPath: "testdata/fixtures/sys/kernel/config/target/iscsi",
 			},
 		},
 		{
@@ -52,12 +52,12 @@ func TestGetStats(t *testing.T) {
 				Tpgt: []iscsi.TPGT{
 					{
 						Name:     "tpgt_1",
-						TpgtPath: "../fixtures/sys/kernel/config/target/iscsi/iqn.2003-01.org.linux-iscsi.osd1.x8664:sn.abcd1abcd2ab/tpgt_1",
+						TpgtPath: "testdata/fixtures/sys/kernel/config/target/iscsi/iqn.2003-01.org.linux-iscsi.osd1.x8664:sn.abcd1abcd2ab/tpgt_1",
 						IsEnable: true,
 						Luns: []iscsi.LUN{
 							{
 								Name:       "lun_0",
-								LunPath:    "../fixtures/sys/kernel/config/target/iscsi/iqn.2003-01.org.linux-iscsi.osd1.x8664:sn.abcd1abcd2ab/tpgt_1/lun/lun_0",
+								LunPath:    "testdata/fixtures/sys/kernel/config/target/iscsi/iqn.2003-01.org.linux-iscsi.osd1.x8664:sn.abcd1abcd2ab/tpgt_1/lun/lun_0",
 								Backstore:  "iblock",
 								ObjectName: "block_lio_rbd1",
 								TypeNumber: "0",
@@ -65,7 +65,7 @@ func TestGetStats(t *testing.T) {
 						},
 					},
 				},
-				RootPath: "../fixtures/sys/kernel/config/target/iscsi",
+				RootPath: "testdata/fixtures/sys/kernel/config/target/iscsi",
 			},
 		},
 		{
@@ -74,12 +74,12 @@ func TestGetStats(t *testing.T) {
 				Tpgt: []iscsi.TPGT{
 					{
 						Name:     "tpgt_1",
-						TpgtPath: "../fixtures/sys/kernel/config/target/iscsi/iqn.2016-11.org.linux-iscsi.igw.x86:dev.rbd0/tpgt_1",
+						TpgtPath: "testdata/fixtures/sys/kernel/config/target/iscsi/iqn.2016-11.org.linux-iscsi.igw.x86:dev.rbd0/tpgt_1",
 						IsEnable: true,
 						Luns: []iscsi.LUN{
 							{
 								Name:       "lun_0",
-								LunPath:    "../fixtures/sys/kernel/config/target/iscsi/iqn.2016-11.org.linux-iscsi.igw.x86:dev.rbd0/tpgt_1/lun/lun_0",
+								LunPath:    "testdata/fixtures/sys/kernel/config/target/iscsi/iqn.2016-11.org.linux-iscsi.igw.x86:dev.rbd0/tpgt_1/lun/lun_0",
 								Backstore:  "fileio",
 								ObjectName: "file_lio_1G",
 								TypeNumber: "1",
@@ -87,7 +87,7 @@ func TestGetStats(t *testing.T) {
 						},
 					},
 				},
-				RootPath: "../fixtures/sys/kernel/config/target/iscsi",
+				RootPath: "testdata/fixtures/sys/kernel/config/target/iscsi",
 			},
 		},
 		{
@@ -96,12 +96,12 @@ func TestGetStats(t *testing.T) {
 				Tpgt: []iscsi.TPGT{
 					{
 						Name:     "tpgt_1",
-						TpgtPath: "../fixtures/sys/kernel/config/target/iscsi/iqn.2016-11.org.linux-iscsi.igw.x86:sn.ramdemo/tpgt_1",
+						TpgtPath: "testdata/fixtures/sys/kernel/config/target/iscsi/iqn.2016-11.org.linux-iscsi.igw.x86:sn.ramdemo/tpgt_1",
 						IsEnable: true,
 						Luns: []iscsi.LUN{
 							{
 								Name:       "lun_0",
-								LunPath:    "../fixtures/sys/kernel/config/target/iscsi/iqn.2016-11.org.linux-iscsi.igw.x86:sn.ramdemo/tpgt_1/lun/lun_0",
+								LunPath:    "testdata/fixtures/sys/kernel/config/target/iscsi/iqn.2016-11.org.linux-iscsi.igw.x86:sn.ramdemo/tpgt_1/lun/lun_0",
 								Backstore:  "rbd",
 								ObjectName: "iscsi-images-demo",
 								TypeNumber: "0",
@@ -109,7 +109,7 @@ func TestGetStats(t *testing.T) {
 						},
 					},
 				},
-				RootPath: "../fixtures/sys/kernel/config/target/iscsi",
+				RootPath: "testdata/fixtures/sys/kernel/config/target/iscsi",
 			},
 		},
 	}
@@ -125,7 +125,7 @@ func TestGetStats(t *testing.T) {
 		{1504, 4733, 1234},
 	}
 
-	sysconfigfs, err := iscsi.NewFS("../fixtures/sys", "../fixtures/sys/kernel/config")
+	sysconfigfs, err := iscsi.NewFS("testdata/fixtures/sys", "testdata/fixtures/sys/kernel/config")
 	if err != nil {
 		t.Fatalf("failed to access xfs fs: %v", err)
 	}

--- a/iscsi/testdata/fixtures
+++ b/iscsi/testdata/fixtures
@@ -1,0 +1,1 @@
+../../testdata/fixtures

--- a/kernel_random_test.go
+++ b/kernel_random_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-const procfsFixtures = "fixtures/proc"
+const procfsFixtures = "testdata/fixtures/proc"
 
 func TestKernelRandom(t *testing.T) {
 	fs, err := NewFS(procfsFixtures)

--- a/net_tcp_test.go
+++ b/net_tcp_test.go
@@ -28,7 +28,7 @@ func Test_newNetTCP(t *testing.T) {
 	}{
 		{
 			name: "tcp file found, no error should come up",
-			file: "fixtures/proc/net/tcp",
+			file: "testdata/fixtures/proc/net/tcp",
 			want: []*netIPSocketLine{
 				&netIPSocketLine{
 					Sl:        0,
@@ -71,7 +71,7 @@ func Test_newNetTCP(t *testing.T) {
 		},
 		{
 			name: "tcp6 file found, no error should come up",
-			file: "fixtures/proc/net/tcp6",
+			file: "testdata/fixtures/proc/net/tcp6",
 			want: []*netIPSocketLine{
 				&netIPSocketLine{
 					Sl:        1315,
@@ -108,7 +108,7 @@ func Test_newNetTCP(t *testing.T) {
 		},
 		{
 			name:    "error case - parse error",
-			file:    "fixtures/proc/net/tcp_broken",
+			file:    "testdata/fixtures/proc/net/tcp_broken",
 			want:    nil,
 			wantErr: true,
 		},
@@ -136,13 +136,13 @@ func Test_newNetTCPSummary(t *testing.T) {
 	}{
 		{
 			name:    "tcp file found, no error should come up",
-			file:    "fixtures/proc/net/tcp",
+			file:    "testdata/fixtures/proc/net/tcp",
 			want:    &NetTCPSummary{TxQueueLength: 2, RxQueueLength: 2, UsedSockets: 3},
 			wantErr: false,
 		},
 		{
 			name:    "tcp6 file found, no error should come up",
-			file:    "fixtures/proc/net/tcp6",
+			file:    "testdata/fixtures/proc/net/tcp6",
 			want:    &NetTCPSummary{TxQueueLength: 0, RxQueueLength: 0, UsedSockets: 2},
 			wantErr: false,
 		},
@@ -154,7 +154,7 @@ func Test_newNetTCPSummary(t *testing.T) {
 		},
 		{
 			name:    "error case - parse error",
-			file:    "fixtures/proc/net/tcp_broken",
+			file:    "testdata/fixtures/proc/net/tcp_broken",
 			want:    nil,
 			wantErr: true,
 		},

--- a/net_udp_test.go
+++ b/net_udp_test.go
@@ -28,7 +28,7 @@ func Test_newNetUDP(t *testing.T) {
 	}{
 		{
 			name: "udp file found, no error should come up",
-			file: "fixtures/proc/net/udp",
+			file: "testdata/fixtures/proc/net/udp",
 			want: []*netIPSocketLine{
 				&netIPSocketLine{
 					Sl:        0,
@@ -71,7 +71,7 @@ func Test_newNetUDP(t *testing.T) {
 		},
 		{
 			name: "udp6 file found, no error should come up",
-			file: "fixtures/proc/net/udp6",
+			file: "testdata/fixtures/proc/net/udp6",
 			want: []*netIPSocketLine{
 				&netIPSocketLine{
 					Sl:        1315,
@@ -108,7 +108,7 @@ func Test_newNetUDP(t *testing.T) {
 		},
 		{
 			name:    "error case - parse error",
-			file:    "fixtures/proc/net/udp_broken",
+			file:    "testdata/fixtures/proc/net/udp_broken",
 			want:    nil,
 			wantErr: true,
 		},
@@ -136,13 +136,13 @@ func Test_newNetUDPSummary(t *testing.T) {
 	}{
 		{
 			name:    "udp file found, no error should come up",
-			file:    "fixtures/proc/net/udp",
+			file:    "testdata/fixtures/proc/net/udp",
 			want:    &NetUDPSummary{TxQueueLength: 2, RxQueueLength: 2, UsedSockets: 3},
 			wantErr: false,
 		},
 		{
 			name:    "udp6 file found, no error should come up",
-			file:    "fixtures/proc/net/udp6",
+			file:    "testdata/fixtures/proc/net/udp6",
 			want:    &NetUDPSummary{TxQueueLength: 0, RxQueueLength: 0, UsedSockets: 2},
 			wantErr: false,
 		},
@@ -154,7 +154,7 @@ func Test_newNetUDPSummary(t *testing.T) {
 		},
 		{
 			name:    "error case - parse error",
-			file:    "fixtures/proc/net/udp_broken",
+			file:    "testdata/fixtures/proc/net/udp_broken",
 			want:    nil,
 			wantErr: true,
 		},

--- a/sysfs/fs_test.go
+++ b/sysfs/fs_test.go
@@ -19,7 +19,7 @@ package sysfs
 import "testing"
 
 const (
-	sysTestFixtures = "../fixtures/sys"
+	sysTestFixtures = "testdata/fixtures/sys"
 )
 
 func TestNewFS(t *testing.T) {

--- a/sysfs/testdata/fixtures
+++ b/sysfs/testdata/fixtures
@@ -1,0 +1,1 @@
+../../testdata/fixtures

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -1,4 +1,4 @@
-# Archive created by ttar -c -f fixtures.ttar fixtures/
+# Archive created by ttar -c -f testdata/fixtures.ttar -C testdata/ fixtures/
 Directory: fixtures
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/xfs/parse_test.go
+++ b/xfs/parse_test.go
@@ -731,7 +731,7 @@ func TestParseStats(t *testing.T) {
 			stats, err = xfs.ParseStats(strings.NewReader(tt.s))
 		}
 		if tt.fs {
-			xfs, err := xfs.NewFS("../fixtures/proc", "../fixtures/sys")
+			xfs, err := xfs.NewFS("testdata/fixtures/proc", "testdata/fixtures/sys")
 			if err != nil {
 				t.Fatalf("failed to access xfs fs: %v", err)
 			}

--- a/xfs/testdata/fixtures
+++ b/xfs/testdata/fixtures
@@ -1,0 +1,1 @@
+../../testdata/fixtures

--- a/xfs/xfs_test.go
+++ b/xfs/xfs_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestReadProcStat(t *testing.T) {
-	xfs, err := xfs.NewFS("../fixtures/proc", "../fixtures/sys")
+	xfs, err := xfs.NewFS("testdata/fixtures/proc", "testdata/fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access xfs fs: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestReadProcStat(t *testing.T) {
 }
 
 func TestReadSysStats(t *testing.T) {
-	xfs, err := xfs.NewFS("../fixtures/proc", "../fixtures/sys")
+	xfs, err := xfs.NewFS("testdata/fixtures/proc", "testdata/fixtures/sys")
 	if err != nil {
 		t.Fatalf("failed to access xfs fs: %v", err)
 	}


### PR DESCRIPTION
This prevents the test fixtures from being shipped around in the module
cache. ie. Prior if project A has a dependency on this project then running
`go mod vendor` will pull the fixtures.ttar into the vendor folder
