### PR TITLE
Add support for several /sys/class/sas_* classes

### DIFF
--- a/sysfs/class_sas_device.go
+++ b/sysfs/class_sas_device.go
@@ -17,10 +17,12 @@
 package sysfs
 
 import (
-	"github.com/prometheus/procfs/internal/util"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/prometheus/procfs/internal/util"
 )
 
 const (
@@ -159,9 +161,12 @@ func (fs FS) blockSASDeviceBlockDevices(name string) ([]string, error) {
 				}
 
 				blocks, err := ioutil.ReadDir(filepath.Join(devicepath, targetdir, targetsubdir.Name(), "block"))
-
 				if err != nil {
-					return nil, err
+					if os.IsNotExist(err) {
+						continue
+					} else {
+						return nil, err
+					}
 				}
 
 				for _, blockdevice := range blocks {

--- a/sysfs/class_sas_device.go
+++ b/sysfs/class_sas_device.go
@@ -39,7 +39,7 @@ type SASDevice struct {
 	BlockDevices []string // /sys/class/sas_device/<Name>/device/target*/*/block/*
 }
 
-type SASDeviceClass map[string]SASDevice
+type SASDeviceClass map[string]*SASDevice
 
 var (
 	sasTargetDeviceRegexp    = regexp.MustCompile(`^target[0-9:]+$`)
@@ -66,7 +66,7 @@ func (fs FS) parseSASDeviceClass(dir string) (SASDeviceClass, error) {
 			return nil, err
 		}
 
-		sdc[device.Name] = *device
+		sdc[device.Name] = device
 	}
 
 	return sdc, nil
@@ -177,4 +177,33 @@ func (fs FS) blockSASDeviceBlockDevices(name string) ([]string, error) {
 	}
 
 	return devices, nil
+}
+
+// GetByName returns the SASDevice with the provided name.
+func (sdc *SASDeviceClass) GetByName(name string) *SASDevice {
+	return (*sdc)[name]
+}
+
+// GetByPhy finds the SASDevice that contains the provided PHY name.
+func (sdc *SASDeviceClass) GetByPhy(name string) *SASDevice {
+	for _, d := range *sdc {
+		for _, p := range d.SASPhys {
+			if p == name {
+				return d
+			}
+		}
+	}
+	return nil
+}
+
+// GetByPort finds the SASDevice that contains the provided SAS Port name.
+func (sdc *SASDeviceClass) GetByPort(name string) *SASDevice {
+	for _, d := range *sdc {
+		for _, p := range d.SASPorts {
+			if p == name {
+				return d
+			}
+		}
+	}
+	return nil
 }

--- a/sysfs/class_sas_device.go
+++ b/sysfs/class_sas_device.go
@@ -1,0 +1,145 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"github.com/prometheus/procfs/internal/util"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+)
+
+const sasDeviceClassPath = "class/sas_device"
+const sasEndDeviceClassPath = "class/sas_end_device"
+const sasExpanderClassPath = "class/sas_expander"
+
+type SASDevice struct {
+	Name       string   // /sys/class/sas_device/<Name>
+	SASAddress string   // /sys/class/sas_device/<Name>/sas_address
+	SASPhys    []string // /sys/class/sas_device/<Name>/device/phy-*
+	SASPorts   []string // /sys/class/sas_device/<Name>/device/ports-*
+}
+
+type SASDeviceClass map[string]SASDevice
+
+// SASDeviceClass parses devices in /sys/class/sas_device.
+func (fs FS) SASDeviceClass() (SASDeviceClass, error) {
+	path := fs.sys.Path(sasDeviceClassPath)
+
+	dirs, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	sdc := make(SASDeviceClass, len(dirs))
+
+	for _, d := range dirs {
+		device, err := fs.parseSASDevice(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		sdc[device.Name] = *device
+	}
+
+	return sdc, nil
+}
+
+// SASEndDeviceClass parses devices in /sys/class/sas_end_device.
+// This is *almost* identical to sas_device, just with a different
+// base directory.  The major difference is that end_devices don't
+// include expanders and other infrastructure devices.
+func (fs FS) SASEndDeviceClass() (SASDeviceClass, error) {
+	path := fs.sys.Path(sasEndDeviceClassPath)
+
+	dirs, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	sdc := make(SASDeviceClass, len(dirs))
+
+	for _, d := range dirs {
+		device, err := fs.parseSASDevice(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		sdc[device.Name] = *device
+	}
+
+	return sdc, nil
+}
+
+// SASExpanderClass parses devices in /sys/class/sas_expander.
+// This is *almost* identical to sas_device, but only includes expanders.
+func (fs FS) SASExpanderClass() (SASDeviceClass, error) {
+	path := fs.sys.Path(sasExpanderClassPath)
+
+	dirs, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	sdc := make(SASDeviceClass, len(dirs))
+
+	for _, d := range dirs {
+		device, err := fs.parseSASDevice(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		sdc[device.Name] = *device
+	}
+
+	return sdc, nil
+}
+
+// Parse a single sas_device.
+func (fs FS) parseSASDevice(name string) (*SASDevice, error) {
+	device := SASDevice{Name: name}
+
+	devicepath := fs.sys.Path(filepath.Join(sasDeviceClassPath, name, "device"))
+
+	dirs, err := ioutil.ReadDir(devicepath)
+	if err != nil {
+		return nil, err
+	}
+
+	phyDevice := regexp.MustCompile(`^phy-[0-9:]+$`)
+	portDevice := regexp.MustCompile(`^port-[0-9:]+$`)
+
+	for _, d := range dirs {
+		if phyDevice.Match([]byte(d.Name())) {
+			device.SASPhys = append(device.SASPhys, d.Name())
+		}
+		if portDevice.Match([]byte(d.Name())) {
+			device.SASPorts = append(device.SASPorts, d.Name())
+		}
+	}
+
+	address := fs.sys.Path(sasDeviceClassPath, name, "sas_address")
+	value, err := util.SysReadFile(address)
+
+	if err != nil {
+		return &device, err
+	} else {
+		device.SASAddress = value
+	}
+
+	return &device, nil
+}

--- a/sysfs/class_sas_device_test.go
+++ b/sysfs/class_sas_device_test.go
@@ -1,0 +1,125 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSASDeviceClass(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.SASDeviceClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := SASDeviceClass{
+		"end_device-11:0:0": {Name: "end_device-11:0:0", SASAddress: "0x5000ccab02009402"},
+		"end_device-11:0:1": {Name: "end_device-11:0:1", SASAddress: "0x5000cca26128b1f5"},
+		"end_device-11:0:2": {Name: "end_device-11:0:2", SASAddress: "0x5000ccab02009406"},
+		"end_device-11:2":   {Name: "end_device-11:2", SASAddress: "0x5000cca0506b5f1d"},
+		"expander-11:0": {
+			Name:       "expander-11:0",
+			SASAddress: "0x5000ccab0200947e",
+			SASPhys: []string{
+				"phy-11:0:10", "phy-11:0:11", "phy-11:0:12",
+				"phy-11:0:13", "phy-11:0:14", "phy-11:0:15",
+				"phy-11:0:2", "phy-11:0:4", "phy-11:0:6",
+				"phy-11:0:7", "phy-11:0:8", "phy-11:0:9",
+			},
+			SASPorts: []string{
+				"port-11:0:0", "port-11:0:1",
+				"port-11:0:2",
+			},
+		},
+		"expander-11:1": {
+			Name:       "expander-11:1",
+			SASAddress: "0x5003048001e8967f",
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
+	}
+}
+
+func TestSASEndDeviceClass(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.SASEndDeviceClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := SASDeviceClass{
+		"end_device-11:0:0": {Name: "end_device-11:0:0", SASAddress: "0x5000ccab02009402"},
+		"end_device-11:0:1": {Name: "end_device-11:0:1", SASAddress: "0x5000cca26128b1f5"},
+		"end_device-11:0:2": {Name: "end_device-11:0:2", SASAddress: "0x5000ccab02009406"},
+		"end_device-11:2":   {Name: "end_device-11:2", SASAddress: "0x5000cca0506b5f1d"},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
+	}
+}
+
+func TestSASExpanderClass(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.SASExpanderClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := SASDeviceClass{
+		"expander-11:0": {
+			Name:       "expander-11:0",
+			SASAddress: "0x5000ccab0200947e",
+			SASPhys: []string{
+				"phy-11:0:10", "phy-11:0:11", "phy-11:0:12",
+				"phy-11:0:13", "phy-11:0:14", "phy-11:0:15",
+				"phy-11:0:2", "phy-11:0:4", "phy-11:0:6",
+				"phy-11:0:7", "phy-11:0:8", "phy-11:0:9",
+			},
+			SASPorts: []string{
+				"port-11:0:0", "port-11:0:1",
+				"port-11:0:2",
+			},
+		},
+		"expander-11:1": {
+			Name:       "expander-11:1",
+			SASAddress: "0x5003048001e8967f",
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
+	}
+}
+

--- a/sysfs/class_sas_device_test.go
+++ b/sysfs/class_sas_device_test.go
@@ -34,10 +34,26 @@ func TestSASDeviceClass(t *testing.T) {
 	}
 
 	want := SASDeviceClass{
-		"end_device-11:0:0": {Name: "end_device-11:0:0", SASAddress: "0x5000ccab02009402"},
-		"end_device-11:0:1": {Name: "end_device-11:0:1", SASAddress: "0x5000cca26128b1f5"},
-		"end_device-11:0:2": {Name: "end_device-11:0:2", SASAddress: "0x5000ccab02009406"},
-		"end_device-11:2":   {Name: "end_device-11:2", SASAddress: "0x5000cca0506b5f1d"},
+		"end_device-11:0:0": {
+			Name:         "end_device-11:0:0",
+			SASAddress:   "0x5000ccab02009402",
+			BlockDevices: []string{"sdv"},
+		},
+		"end_device-11:0:1": {
+			Name:         "end_device-11:0:1",
+			SASAddress:   "0x5000cca26128b1f5",
+			BlockDevices: []string{"sdw"},
+		},
+		"end_device-11:0:2": {
+			Name:         "end_device-11:0:2",
+			SASAddress:   "0x5000ccab02009406",
+			BlockDevices: []string{"sdx"},
+		},
+		"end_device-11:2": {
+			Name:         "end_device-11:2",
+			SASAddress:   "0x5000cca0506b5f1d",
+			BlockDevices: []string{"sdp"},
+		},
 		"expander-11:0": {
 			Name:       "expander-11:0",
 			SASAddress: "0x5000ccab0200947e",
@@ -75,10 +91,26 @@ func TestSASEndDeviceClass(t *testing.T) {
 	}
 
 	want := SASDeviceClass{
-		"end_device-11:0:0": {Name: "end_device-11:0:0", SASAddress: "0x5000ccab02009402"},
-		"end_device-11:0:1": {Name: "end_device-11:0:1", SASAddress: "0x5000cca26128b1f5"},
-		"end_device-11:0:2": {Name: "end_device-11:0:2", SASAddress: "0x5000ccab02009406"},
-		"end_device-11:2":   {Name: "end_device-11:2", SASAddress: "0x5000cca0506b5f1d"},
+		"end_device-11:0:0": {
+			Name:         "end_device-11:0:0",
+			SASAddress:   "0x5000ccab02009402",
+			BlockDevices: []string{"sdv"},
+		},
+		"end_device-11:0:1": {
+			Name:         "end_device-11:0:1",
+			SASAddress:   "0x5000cca26128b1f5",
+			BlockDevices: []string{"sdw"},
+		},
+		"end_device-11:0:2": {
+			Name:         "end_device-11:0:2",
+			SASAddress:   "0x5000ccab02009406",
+			BlockDevices: []string{"sdx"},
+		},
+		"end_device-11:2": {
+			Name:         "end_device-11:2",
+			SASAddress:   "0x5000cca0506b5f1d",
+			BlockDevices: []string{"sdp"},
+		},
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
@@ -122,4 +154,3 @@ func TestSASExpanderClass(t *testing.T) {
 		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
 	}
 }
-

--- a/sysfs/class_sas_device_test.go
+++ b/sysfs/class_sas_device_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Prometheus Authors
+// Copyright 2022 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -17,9 +17,8 @@
 package sysfs
 
 import (
-	"testing"
-
 	"github.com/google/go-cmp/cmp"
+	"testing"
 )
 
 func TestSASDeviceClass(t *testing.T) {

--- a/sysfs/class_sas_device_test.go
+++ b/sysfs/class_sas_device_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSASDeviceClass(t *testing.T) {
@@ -151,5 +152,77 @@ func TestSASExpanderClass(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
+	}
+}
+
+func TestSASDeviceGetByName(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dc, err := fs.SASDeviceClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "expander-11:0"
+	got := dc.GetByName("expander-11:0").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASDevice name (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := dc.GetByName("expander-15")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByName response: got %v want nil", got2)
+	}
+}
+
+func TestSASDeviceGetByPhy(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dc, err := fs.SASDeviceClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "expander-11:0"
+	got := dc.GetByPhy("phy-11:0:11").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := dc.GetByPhy("phy-12:0")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByPhy response: got %v want nil", got2)
+	}
+}
+
+func TestSASDeviceGetByPort(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dc, err := fs.SASDeviceClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "expander-11:0"
+	got := dc.GetByPort("port-11:0:0").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := dc.GetByPort("port-12:0")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByPhy response: got %v want nil", got2)
 	}
 }

--- a/sysfs/class_sas_host.go
+++ b/sysfs/class_sas_host.go
@@ -30,7 +30,7 @@ type SASHost struct {
 	SASPorts []string // /sys/class/sas_host/<Name>/device/ports-*
 }
 
-type SASHostClass map[string]SASHost
+type SASHostClass map[string]*SASHost
 
 var (
 	sasPhyDeviceRegexp  = regexp.MustCompile(`^phy-[0-9:]+$`)
@@ -62,7 +62,7 @@ func (fs FS) SASHostClass() (SASHostClass, error) {
 			return nil, err
 		}
 
-		shc[host.Name] = *host
+		shc[host.Name] = host
 	}
 
 	return shc, nil
@@ -90,4 +90,33 @@ func (fs FS) parseSASHost(name string) (*SASHost, error) {
 	}
 
 	return &host, nil
+}
+
+// GetByName returns the SASHost with the provided name.
+func (shc *SASHostClass) GetByName(hostName string) *SASHost {
+	return (*shc)[hostName]
+}
+
+// GetByPhy finds the SASHost that contains the provided PHY name.
+func (shc *SASHostClass) GetByPhy(phyName string) *SASHost {
+	for _, h := range *shc {
+		for _, p := range h.SASPhys {
+			if p == phyName {
+				return h
+			}
+		}
+	}
+	return nil
+}
+
+// GetByPort finds the SASHost that contains the provided SAS Port name.
+func (shc *SASHostClass) GetByPort(portName string) *SASHost {
+	for _, h := range *shc {
+		for _, p := range h.SASPorts {
+			if p == portName {
+				return h
+			}
+		}
+	}
+	return nil
 }

--- a/sysfs/class_sas_host.go
+++ b/sysfs/class_sas_host.go
@@ -32,6 +32,11 @@ type SASHost struct {
 
 type SASHostClass map[string]SASHost
 
+var (
+	sasPhyDeviceRegexp  = regexp.MustCompile(`^phy-[0-9:]+$`)
+	sasPortDeviceRegexp = regexp.MustCompile(`^port-[0-9:]+$`)
+)
+
 // SASHostClass parses host[0-9]+ devices in /sys/class/sas_host.
 // This generally only exists so that it can pull in SAS Port and SAS
 // PHY entries.
@@ -75,14 +80,11 @@ func (fs FS) parseSASHost(name string) (*SASHost, error) {
 		return nil, err
 	}
 
-	phyDevice := regexp.MustCompile(`^phy-[0-9:]+$`)
-	portDevice := regexp.MustCompile(`^port-[0-9:]+$`)
-
 	for _, d := range dirs {
-		if phyDevice.MatchString(d.Name()) {
+		if sasPhyDeviceRegexp.MatchString(d.Name()) {
 			host.SASPhys = append(host.SASPhys, d.Name())
 		}
-		if portDevice.MatchString(d.Name()) {
+		if sasPortDeviceRegexp.MatchString(d.Name()) {
 			host.SASPorts = append(host.SASPorts, d.Name())
 		}
 	}

--- a/sysfs/class_sas_host.go
+++ b/sysfs/class_sas_host.go
@@ -1,0 +1,90 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"io/ioutil"
+        "path/filepath"
+	"regexp"
+)
+
+const sasHostClassPath = "class/sas_host"
+
+type SASHost struct {
+	Name     string           // /sys/class/sas_host/<Name>
+	SASPhys []string         // /sys/class/sas_host/<Name>/device/phy-*
+	SASPorts []string       // /sys/class/sas_host/<Name>/device/ports-*
+}
+
+type SASHostClass map[string]SASHost
+
+// SASHostClass parses host[0-9]+ devices in /sys/class/sas_host.
+// This generally only exists so that it can pull in SAS Port and SAS
+// PHY entries.
+//
+// The sas_host class doesn't collect any obvious statistics.  Each
+// sas_host contains a scsi_host, which seems to collect a couple
+// minor stats (ioc_reset_count and reply_queue_count), but they're
+// not worth collecting at this time.
+func (fs FS) SASHostClass() (SASHostClass, error) {
+	path := fs.sys.Path(sasHostClassPath)
+
+	dirs, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	shc := make(SASHostClass, len(dirs))
+
+	for _, d := range dirs {
+		host, err := fs.parseSASHost(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		shc[host.Name] = *host
+	}
+
+	return shc, nil
+}
+
+// Parse a single sas_host.
+func (fs FS) parseSASHost(name string) (*SASHost, error) {
+	//path := fs.sys.Path(sasHostClassPath, name)
+	host := SASHost{Name: name}
+
+	devicepath := fs.sys.Path(filepath.Join(sasHostClassPath,name,"device"))
+
+	dirs, err := ioutil.ReadDir(devicepath)
+	if err != nil {
+		return nil, err
+	}
+
+	phyDevice := regexp.MustCompile(`^phy-[0-9:]+$`)
+	portDevice := regexp.MustCompile(`^port-[0-9:]+$`)
+
+	for _, d := range dirs {
+		if phyDevice.Match([]byte(d.Name())) {
+			host.SASPhys = append(host.SASPhys, d.Name())
+		}
+		if portDevice.Match([]byte(d.Name())) {
+			host.SASPorts = append(host.SASPorts, d.Name())
+		}
+	}
+
+	return &host, nil
+}

--- a/sysfs/class_sas_host_test.go
+++ b/sysfs/class_sas_host_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSASHostClass(t *testing.T) {
@@ -33,7 +34,7 @@ func TestSASHostClass(t *testing.T) {
 	}
 
 	want := SASHostClass{
-		"host11": SASHost{
+		"host11": &SASHost{
 			Name: "host11",
 			SASPhys: []string{
 				"phy-11:10", "phy-11:11", "phy-11:12", "phy-11:13",
@@ -48,5 +49,77 @@ func TestSASHostClass(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("unexpected SASHost class (-want +got):\n%s", diff)
+	}
+}
+
+func TestSASHostGetByName(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hc, err := fs.SASHostClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "host11"
+	got := hc.GetByName("host11").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASHost class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := hc.GetByName("host12")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByName response: got %v want nil", got2)
+	}
+}
+
+func TestSASHostGetByPhy(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hc, err := fs.SASHostClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "host11"
+	got := hc.GetByPhy("phy-11:11").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASHost class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := hc.GetByPhy("phy-12:0")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByPhy response: got %v want nil", got2)
+	}
+}
+
+func TestSASHostGetByPort(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hc, err := fs.SASHostClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "host11"
+	got := hc.GetByPort("port-11:0").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASHost class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := hc.GetByPort("port-12:0")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByPhy response: got %v want nil", got2)
 	}
 }

--- a/sysfs/class_sas_host_test.go
+++ b/sysfs/class_sas_host_test.go
@@ -17,9 +17,8 @@
 package sysfs
 
 import (
-	"testing"
-
 	"github.com/google/go-cmp/cmp"
+	"testing"
 )
 
 func TestSASHostClass(t *testing.T) {
@@ -36,13 +35,14 @@ func TestSASHostClass(t *testing.T) {
 	want := SASHostClass{
 		"host11": SASHost{
 			Name: "host11",
-        		SASPhys: []string{
-        			"phy-11:10", "phy-11:11", "phy-11:12", "phy-11:13",
-        			"phy-11:14", "phy-11:15", "phy-11:7", "phy-11:8", "phy-11:9",
-        		},
+			SASPhys: []string{
+				"phy-11:10", "phy-11:11", "phy-11:12", "phy-11:13",
+				"phy-11:14", "phy-11:15", "phy-11:7", "phy-11:8",
+				"phy-11:9",
+			},
 			SASPorts: []string{
-        			"port-11:0", "port-11:1", "port-11:2",
-        		},
+				"port-11:0", "port-11:1", "port-11:2",
+			},
 		},
 	}
 

--- a/sysfs/class_sas_host_test.go
+++ b/sysfs/class_sas_host_test.go
@@ -1,0 +1,52 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSASHostClass(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.SASHostClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := SASHostClass{
+		"host11": SASHost{
+			Name: "host11",
+        		SASPhys: []string{
+        			"phy-11:10", "phy-11:11", "phy-11:12", "phy-11:13",
+        			"phy-11:14", "phy-11:15", "phy-11:7", "phy-11:8", "phy-11:9",
+        		},
+			SASPorts: []string{
+        			"port-11:0", "port-11:1", "port-11:2",
+        		},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASHost class (-want +got):\n%s", diff)
+	}
+}

--- a/sysfs/class_sas_phy.go
+++ b/sysfs/class_sas_phy.go
@@ -48,7 +48,7 @@ type SASPhy struct {
 	TargetPortProtocols        []string // /sys/class/sas_phy/<Name>/target_port_protocols
 }
 
-type SASPhyClass map[string]SASPhy
+type SASPhyClass map[string]*SASPhy
 
 // SASPhyClass parses entries in /sys/class/sas_phy.
 func (fs FS) SASPhyClass() (SASPhyClass, error) {
@@ -67,7 +67,7 @@ func (fs FS) SASPhyClass() (SASPhyClass, error) {
 			return nil, err
 		}
 
-		spc[phy.Name] = *phy
+		spc[phy.Name] = phy
 	}
 
 	return spc, nil
@@ -158,4 +158,9 @@ func parseLinkrate(value string) float64 {
 		return 0
 	}
 	return gb
+}
+
+// GetByName returns the SASPhy with the provided name.
+func (spc *SASPhyClass) GetByName(name string) *SASPhy {
+	return (*spc)[name]
 }

--- a/sysfs/class_sas_phy.go
+++ b/sysfs/class_sas_phy.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -83,8 +82,7 @@ func (fs FS) parseSASPhy(name string) (*SASPhy, error) {
 	link, err := os.Readlink(fs.sys.Path(phydevicepath, "port"))
 
 	if err == nil {
-		portDevice := regexp.MustCompile(`^port-[0-9:]+$`)
-		if portDevice.MatchString(filepath.Base(link)) {
+		if sasPortDeviceRegexp.MatchString(filepath.Base(link)) {
 			phy.SASPort = filepath.Base(link)
 		}
 	}

--- a/sysfs/class_sas_phy.go
+++ b/sysfs/class_sas_phy.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 const sasPhyClassPath = "class/sas_phy"
@@ -143,8 +143,13 @@ func (fs FS) parseSASPhy(name string) (*SASPhy, error) {
 	return &phy, nil
 }
 
+// parseLinkRate turns the kernel's SAS linkrate values into floats.
+// The kernel returns values like "12.0 Gbit".  Valid speeds are
+// currently 1.5, 3.0, 6.0, 12.0, and up.  This is a float to cover
+// the 1.5 Gbps case.  A value of 0 is returned if the speed can't be
+// parsed.
 func parseLinkrate(value string) float64 {
-	f := strings.Split(value," ")[0]
+	f := strings.Split(value, " ")[0]
 	gb, err := strconv.ParseFloat(f, 64)
 	if err != nil {
 		return 0

--- a/sysfs/class_sas_phy.go
+++ b/sysfs/class_sas_phy.go
@@ -1,0 +1,153 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"github.com/prometheus/procfs/internal/util"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"strconv"
+)
+
+const sasPhyClassPath = "class/sas_phy"
+
+type SASPhy struct {
+	Name                       string   // /sys/class/sas_phy/<Name>
+	SASAddress                 string   // /sys/class/sas_phy/<Name>/sas_address
+	SASPort                    string   // /sys/class/sas_phy/<Name>/device/ports
+	DeviceType                 string   // /sys/class/sas_phy/<Name>/device_type
+	InitiatorPortProtocols     []string // /sys/class/sas_phy/<Name>/initiator_port_protocols
+	InvalidDwordCount          int      // /sys/class/sas_phy/<Name>/invalid_dword_count
+	LossOfDwordSyncCount       int      // /sys/class/sas_phy/<Name>/loss_of_dword_sync_count
+	MaximumLinkrate            float64  // /sys/class/sas_phy/<Name>/maximum_linkrate
+	MaximumLinkrateHW          float64  // /sys/class/sas_phy/<Name>/maximum_linkrate_hw
+	MinimumLinkrate            float64  // /sys/class/sas_phy/<Name>/minimum_linkrate
+	MinimumLinkrateHW          float64  // /sys/class/sas_phy/<Name>/minimum_linkrate_hw
+	NegotiatedLinkrate         float64  // /sys/class/sas_phy/<Name>/negotiated_linkrate
+	PhyIdentifier              string   // /sys/class/sas_phy/<Name>/phy_identifier
+	PhyResetProblemCount       int      // /sys/class/sas_phy/<Name>/phy_reset_problem_count
+	RunningDisparityErrorCount int      // /sys/class/sas_phy/<Name>/running_disparity_error_count
+	TargetPortProtocols        []string // /sys/class/sas_phy/<Name>/target_port_protocols
+}
+
+type SASPhyClass map[string]SASPhy
+
+// SASPhyClass parses entries in /sys/class/sas_phy.
+func (fs FS) SASPhyClass() (SASPhyClass, error) {
+	path := fs.sys.Path(sasPhyClassPath)
+
+	dirs, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	spc := make(SASPhyClass, len(dirs))
+
+	for _, d := range dirs {
+		phy, err := fs.parseSASPhy(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		spc[phy.Name] = *phy
+	}
+
+	return spc, nil
+}
+
+// Parse a single sas_phy.
+func (fs FS) parseSASPhy(name string) (*SASPhy, error) {
+	phy := SASPhy{Name: name}
+
+	phypath := fs.sys.Path(filepath.Join(sasPhyClassPath, name))
+	phydevicepath := filepath.Join(phypath, "device")
+
+	link, err := os.Readlink(fs.sys.Path(phydevicepath, "port"))
+
+	if err == nil {
+		portDevice := regexp.MustCompile(`^port-[0-9:]+$`)
+		if portDevice.MatchString(filepath.Base(link)) {
+			phy.SASPort = filepath.Base(link)
+		}
+	}
+
+	files, err := ioutil.ReadDir(phypath)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range files {
+		name := filepath.Join(phypath, f.Name())
+		fileinfo, _ := os.Stat(name)
+		if fileinfo.Mode().IsRegular() {
+			value, err := util.SysReadFile(name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read file %q: %w", name, err)
+			}
+
+			vp := util.NewValueParser(value)
+			switch f.Name() {
+			case "sas_address":
+				phy.SASAddress = value
+			case "device_type":
+				phy.DeviceType = value
+			case "initiator_port_protocols":
+				phy.InitiatorPortProtocols = strings.Split(value, ", ")
+			case "invalid_dword_count":
+				phy.InvalidDwordCount = vp.Int()
+			case "loss_of_dword_sync_count":
+				phy.LossOfDwordSyncCount = vp.Int()
+			case "maximum_linkrate":
+				phy.MaximumLinkrate = parseLinkrate(value)
+			case "maximum_linkrate_hw":
+				phy.MaximumLinkrateHW = parseLinkrate(value)
+			case "minimum_linkrate":
+				phy.MinimumLinkrate = parseLinkrate(value)
+			case "minimum_linkrate_hw":
+				phy.MinimumLinkrateHW = parseLinkrate(value)
+			case "negotiated_linkrate":
+				phy.NegotiatedLinkrate = parseLinkrate(value)
+			case "phy_identifier":
+				phy.PhyIdentifier = value
+			case "phy_reset_problem_count":
+				phy.PhyResetProblemCount = vp.Int()
+			case "running_disparity_error_count":
+				phy.RunningDisparityErrorCount = vp.Int()
+			case "target_port_protocols":
+				phy.TargetPortProtocols = strings.Split(value, ", ")
+			}
+
+			if err := vp.Err(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &phy, nil
+}
+
+func parseLinkrate(value string) float64 {
+	f := strings.Split(value," ")[0]
+	gb, err := strconv.ParseFloat(f, 64)
+	if err != nil {
+		return 0
+	}
+	return gb
+}

--- a/sysfs/class_sas_phy_test.go
+++ b/sysfs/class_sas_phy_test.go
@@ -17,9 +17,8 @@
 package sysfs
 
 import (
-	"testing"
-
 	"github.com/google/go-cmp/cmp"
+	"testing"
 )
 
 func TestSASPhyClass(t *testing.T) {

--- a/sysfs/class_sas_phy_test.go
+++ b/sysfs/class_sas_phy_test.go
@@ -1,0 +1,206 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSASPhyClass(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.SASPhyClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := SASPhyClass{
+		"phy-11:0:2": {
+			Name:                       "phy-11:0:2",
+			SASAddress:                 "0x5000ccab0200947e",
+			DeviceType:                 "edge expander",
+			InitiatorPortProtocols:     []string{"smp"},
+			InvalidDwordCount:          18,
+			LossOfDwordSyncCount:       1,
+			MaximumLinkrate:            12,
+			MaximumLinkrateHW:          12,
+			MinimumLinkrate:            1.5,
+			MinimumLinkrateHW:          1.5,
+			NegotiatedLinkrate:         6,
+			PhyIdentifier:              "2",
+			RunningDisparityErrorCount: 18,
+			TargetPortProtocols:        []string{"smp"},
+		},
+		"phy-11:0:4": {
+			Name:                       "phy-11:0:4",
+			SASAddress:                 "0x5000ccab0200947e",
+			DeviceType:                 "edge expander",
+			InitiatorPortProtocols:     []string{"smp"},
+			InvalidDwordCount:          1,
+			MaximumLinkrate:            12,
+			MaximumLinkrateHW:          12,
+			MinimumLinkrate:            1.5,
+			MinimumLinkrateHW:          1.5,
+			NegotiatedLinkrate:         12,
+			PhyIdentifier:              "4",
+			RunningDisparityErrorCount: 1,
+			TargetPortProtocols:        []string{"smp"},
+		},
+		"phy-11:0:6": {
+			Name:                       "phy-11:0:6",
+			SASAddress:                 "0x5000ccab0200947e",
+			DeviceType:                 "edge expander",
+			InitiatorPortProtocols:     []string{"smp"},
+			InvalidDwordCount:          19,
+			LossOfDwordSyncCount:       1,
+			MaximumLinkrate:            12,
+			MaximumLinkrateHW:          12,
+			MinimumLinkrate:            1.5,
+			MinimumLinkrateHW:          1.5,
+			NegotiatedLinkrate:         6,
+			PhyIdentifier:              "6",
+			RunningDisparityErrorCount: 20,
+			TargetPortProtocols:        []string{"smp"},
+		},
+		"phy-11:10": {
+			Name:                   "phy-11:10",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     12,
+			PhyIdentifier:          "10",
+			TargetPortProtocols:    []string{"none"},
+		},
+		"phy-11:11": {
+			Name:                   "phy-11:11",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     12,
+			PhyIdentifier:          "11",
+			TargetPortProtocols:    []string{"none"},
+		},
+		"phy-11:12": {
+			Name:                   "phy-11:12",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     6,
+			PhyIdentifier:          "12",
+			TargetPortProtocols:    []string{"none"},
+		},
+		"phy-11:13": {
+			Name:                   "phy-11:13",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     6,
+			PhyIdentifier:          "13",
+			TargetPortProtocols:    []string{"none"},
+		},
+		"phy-11:14": {
+			Name:                   "phy-11:14",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     6,
+			PhyIdentifier:          "14",
+			TargetPortProtocols:    []string{"none"},
+		},
+		"phy-11:15": {
+			Name:                   "phy-11:15",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     6,
+			PhyIdentifier:          "15",
+			TargetPortProtocols:    []string{"none"},
+		},
+		"phy-11:7": {
+			Name:                   "phy-11:7",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     12,
+			PhyIdentifier:          "7",
+			TargetPortProtocols:    []string{"none"},
+		},
+		"phy-11:8": {
+			Name:                   "phy-11:8",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     12,
+			PhyIdentifier:          "8",
+			TargetPortProtocols:    []string{"none"},
+		},
+		"phy-11:9": {
+			Name:                   "phy-11:9",
+			SASAddress:             "0x500062b2047b51c4",
+			DeviceType:             "end device",
+			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
+			MaximumLinkrate:        12,
+			MaximumLinkrateHW:      12,
+			MinimumLinkrate:        3,
+			MinimumLinkrateHW:      1.5,
+			NegotiatedLinkrate:     12,
+			PhyIdentifier:          "9",
+			TargetPortProtocols:    []string{"none"},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASPhy class (-want +got):\n%s", diff)
+	}
+}

--- a/sysfs/class_sas_phy_test.go
+++ b/sysfs/class_sas_phy_test.go
@@ -216,3 +216,27 @@ func TestSASPhyClass(t *testing.T) {
 		t.Fatalf("unexpected SASPhy class (-want +got):\n%s", diff)
 	}
 }
+
+func TestSASPhyGetByName(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pc, err := fs.SASPhyClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "phy-11:9"
+	got := pc.GetByName("phy-11:9").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASPhy class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := pc.GetByName("phy-12:0")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByName response: got %v want nil", got2)
+	}
+}

--- a/sysfs/class_sas_phy_test.go
+++ b/sysfs/class_sas_phy_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSASPhyClass(t *testing.T) {
@@ -36,6 +37,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:0:2": {
 			Name:                       "phy-11:0:2",
 			SASAddress:                 "0x5000ccab0200947e",
+			SASPort:                    "port-11:0:0",
 			DeviceType:                 "edge expander",
 			InitiatorPortProtocols:     []string{"smp"},
 			InvalidDwordCount:          18,
@@ -52,6 +54,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:0:4": {
 			Name:                       "phy-11:0:4",
 			SASAddress:                 "0x5000ccab0200947e",
+			SASPort:                    "port-11:0:1",
 			DeviceType:                 "edge expander",
 			InitiatorPortProtocols:     []string{"smp"},
 			InvalidDwordCount:          1,
@@ -67,6 +70,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:0:6": {
 			Name:                       "phy-11:0:6",
 			SASAddress:                 "0x5000ccab0200947e",
+			SASPort:                    "port-11:0:2",
 			DeviceType:                 "edge expander",
 			InitiatorPortProtocols:     []string{"smp"},
 			InvalidDwordCount:          19,
@@ -83,6 +87,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:10": {
 			Name:                   "phy-11:10",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:0",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,
@@ -96,6 +101,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:11": {
 			Name:                   "phy-11:11",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:0",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,
@@ -109,6 +115,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:12": {
 			Name:                   "phy-11:12",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:1",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,
@@ -122,6 +129,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:13": {
 			Name:                   "phy-11:13",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:1",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,
@@ -135,6 +143,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:14": {
 			Name:                   "phy-11:14",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:1",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,
@@ -148,6 +157,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:15": {
 			Name:                   "phy-11:15",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:1",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,
@@ -161,6 +171,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:7": {
 			Name:                   "phy-11:7",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:2",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,
@@ -174,6 +185,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:8": {
 			Name:                   "phy-11:8",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:0",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,
@@ -187,6 +199,7 @@ func TestSASPhyClass(t *testing.T) {
 		"phy-11:9": {
 			Name:                   "phy-11:9",
 			SASAddress:             "0x500062b2047b51c4",
+			SASPort:                "port-11:0",
 			DeviceType:             "end device",
 			InitiatorPortProtocols: []string{"smp", "stp", "ssp"},
 			MaximumLinkrate:        12,

--- a/sysfs/class_sas_port.go
+++ b/sysfs/class_sas_port.go
@@ -32,6 +32,8 @@ type SASPort struct {
 
 type SASPortClass map[string]SASPort
 
+var sasExpanderDeviceRegexp = regexp.MustCompile(`^expander-[0-9:]+$`)
+
 // SASPortClass parses ports in /sys/class/sas_port.
 //
 // A SAS port in this context is a collection of SAS PHYs operating
@@ -76,14 +78,11 @@ func (fs FS) parseSASPort(name string) (*SASPort, error) {
 		return nil, err
 	}
 
-	phyDevice := regexp.MustCompile(`^phy-[0-9:]+$`)
-	expanderDevice := regexp.MustCompile(`^expander-[0-9:]+$`)
-
 	for _, d := range dirs {
-		if phyDevice.Match([]byte(d.Name())) {
+		if sasPhyDeviceRegexp.Match([]byte(d.Name())) {
 			port.SASPhys = append(port.SASPhys, d.Name())
 		}
-		if expanderDevice.Match([]byte(d.Name())) {
+		if sasExpanderDeviceRegexp.Match([]byte(d.Name())) {
 			port.Expanders = append(port.Expanders, d.Name())
 		}
 	}

--- a/sysfs/class_sas_port.go
+++ b/sysfs/class_sas_port.go
@@ -25,14 +25,24 @@ import (
 const sasPortClassPath = "class/sas_port"
 
 type SASPort struct {
-	Name       string   // /sys/class/sas_device/<Name>
-	SASPhys    []string // /sys/class/sas_device/<Name>/device/phy-*
-	Expanders  []string // /sys/class/sas_port/<Name>/device/expander-*
+	Name      string   // /sys/class/sas_device/<Name>
+	SASPhys   []string // /sys/class/sas_device/<Name>/device/phy-*
+	Expanders []string // /sys/class/sas_port/<Name>/device/expander-*
 }
 
 type SASPortClass map[string]SASPort
 
 // SASPortClass parses ports in /sys/class/sas_port.
+//
+// A SAS port in this context is a collection of SAS PHYs operating
+// together.  For example, it's common to have 8-lane SAS cards that
+// have 2 external connectors, each of which carries 4 SAS lanes over
+// a SFF-8088 or SFF-8644 connector.  While it's possible to split
+// those 4 lanes into 4 different cables wired directly into
+// individual drives, it's more common to connect them all to a SAS
+// expander.  This gives you 4x the bandwidth between the expander and
+// the SAS host, and is represented by a sas-port object which
+// contains 4 sas-phy objects.
 func (fs FS) SASPortClass() (SASPortClass, error) {
 	path := fs.sys.Path(sasPortClassPath)
 

--- a/sysfs/class_sas_port.go
+++ b/sysfs/class_sas_port.go
@@ -31,7 +31,7 @@ type SASPort struct {
 	EndDevices []string // /sys/class/sas_port/<Name>/device/end_device-*
 }
 
-type SASPortClass map[string]SASPort
+type SASPortClass map[string]*SASPort
 
 var (
 	sasExpanderDeviceRegexp = regexp.MustCompile(`^expander-[0-9:]+$`)
@@ -65,7 +65,7 @@ func (fs FS) SASPortClass() (SASPortClass, error) {
 			return nil, err
 		}
 
-		spc[port.Name] = *port
+		spc[port.Name] = port
 	}
 
 	return spc, nil
@@ -95,4 +95,45 @@ func (fs FS) parseSASPort(name string) (*SASPort, error) {
 	}
 
 	return &port, nil
+}
+
+// GetByName returns the SASPort with the provided name.
+func (spc *SASPortClass) GetByName(name string) *SASPort {
+	return (*spc)[name]
+}
+
+// GetByPhy finds the SASPort that contains the provided PHY name.
+func (spc *SASPortClass) GetByPhy(name string) *SASPort {
+	for _, d := range *spc {
+		for _, p := range d.SASPhys {
+			if p == name {
+				return d
+			}
+		}
+	}
+	return nil
+}
+
+// GetByExpander finds the SASPort that contains the provided SAS expander name.
+func (spc *SASPortClass) GetByExpander(name string) *SASPort {
+	for _, d := range *spc {
+		for _, e := range d.Expanders {
+			if e == name {
+				return d
+			}
+		}
+	}
+	return nil
+}
+
+// GetByEndDevice finds the SASPort that contains the provided SAS end device name.
+func (spc *SASPortClass) GetByEndDevice(name string) *SASPort {
+	for _, d := range *spc {
+		for _, e := range d.EndDevices {
+			if e == name {
+				return d
+			}
+		}
+	}
+	return nil
 }

--- a/sysfs/class_sas_port.go
+++ b/sysfs/class_sas_port.go
@@ -1,0 +1,82 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+)
+
+const sasPortClassPath = "class/sas_port"
+
+type SASPort struct {
+	Name       string   // /sys/class/sas_device/<Name>
+	SASPhys    []string // /sys/class/sas_device/<Name>/device/phy-*
+	Expanders  []string // /sys/class/sas_port/<Name>/device/expander-*
+}
+
+type SASPortClass map[string]SASPort
+
+// SASPortClass parses ports in /sys/class/sas_port.
+func (fs FS) SASPortClass() (SASPortClass, error) {
+	path := fs.sys.Path(sasPortClassPath)
+
+	dirs, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	spc := make(SASPortClass, len(dirs))
+
+	for _, d := range dirs {
+		port, err := fs.parseSASPort(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		spc[port.Name] = *port
+	}
+
+	return spc, nil
+}
+
+// Parse a single sas_port.
+func (fs FS) parseSASPort(name string) (*SASPort, error) {
+	port := SASPort{Name: name}
+
+	portpath := fs.sys.Path(filepath.Join(sasPortClassPath, name, "device"))
+
+	dirs, err := ioutil.ReadDir(portpath)
+	if err != nil {
+		return nil, err
+	}
+
+	phyDevice := regexp.MustCompile(`^phy-[0-9:]+$`)
+	expanderDevice := regexp.MustCompile(`^expander-[0-9:]+$`)
+
+	for _, d := range dirs {
+		if phyDevice.Match([]byte(d.Name())) {
+			port.SASPhys = append(port.SASPhys, d.Name())
+		}
+		if expanderDevice.Match([]byte(d.Name())) {
+			port.Expanders = append(port.Expanders, d.Name())
+		}
+	}
+
+	return &port, nil
+}

--- a/sysfs/class_sas_port_test.go
+++ b/sysfs/class_sas_port_test.go
@@ -17,9 +17,8 @@
 package sysfs
 
 import (
-	"testing"
-
 	"github.com/google/go-cmp/cmp"
+	"testing"
 )
 
 func TestSASPortClass(t *testing.T) {

--- a/sysfs/class_sas_port_test.go
+++ b/sysfs/class_sas_port_test.go
@@ -65,3 +65,99 @@ func TestSASPortClass(t *testing.T) {
 		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
 	}
 }
+
+func TestSASPortGetByName(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dc, err := fs.SASPortClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "port-11:0:0"
+	got := dc.GetByName("port-11:0:0").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASPort name (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := dc.GetByName("port-15")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByName response: got %v want nil", got2)
+	}
+}
+
+func TestSASPortGetByPhy(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dc, err := fs.SASPortClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "port-11:0:2"
+	got := dc.GetByPhy("phy-11:0:6").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASPort class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := dc.GetByPhy("phy-12:0")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByPhy response: got %v want nil", got2)
+	}
+}
+
+func TestSASPortGetByExpander(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dc, err := fs.SASPortClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "port-11:0"
+	got := dc.GetByExpander("expander-11:0").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASPort class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := dc.GetByExpander("expander-12:0")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByPhy response: got %v want nil", got2)
+	}
+}
+
+func TestSASPortGetByEndDevice(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dc, err := fs.SASPortClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "port-11:0:2"
+	got := dc.GetByEndDevice("end_device-11:0:2").Name
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASPort class (-want +got):\n%s", diff)
+	}
+
+	// Doesn't exist.
+	got2 := dc.GetByEndDevice("end_device-12:0")
+	if got2 != nil {
+		t.Fatalf("unexpected GetByPhy response: got %v want nil", got2)
+	}
+}

--- a/sysfs/class_sas_port_test.go
+++ b/sysfs/class_sas_port_test.go
@@ -1,0 +1,55 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSASPortClass(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.SASPortClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := SASPortClass{
+		"port-11:0": {
+			Name:      "port-11:0",
+			SASPhys:   []string{"phy-11:10", "phy-11:11", "phy-11:8", "phy-11:9"},
+			Expanders: []string{"expander-11:0"},
+		},
+		"port-11:0:0": {Name: "port-11:0:0", SASPhys: []string{"phy-11:0:2"}},
+		"port-11:0:1": {Name: "port-11:0:1", SASPhys: []string{"phy-11:0:4"}},
+		"port-11:0:2": {Name: "port-11:0:2", SASPhys: []string{"phy-11:0:6"}},
+		"port-11:1": {
+			Name:      "port-11:1",
+			SASPhys:   []string{"phy-11:12", "phy-11:13", "phy-11:14", "phy-11:15"},
+			Expanders: []string{"expander-11:1"},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected SASDevice class (-want +got):\n%s", diff)
+	}
+}

--- a/sysfs/class_sas_port_test.go
+++ b/sysfs/class_sas_port_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSASPortClass(t *testing.T) {
@@ -38,9 +39,21 @@ func TestSASPortClass(t *testing.T) {
 			SASPhys:   []string{"phy-11:10", "phy-11:11", "phy-11:8", "phy-11:9"},
 			Expanders: []string{"expander-11:0"},
 		},
-		"port-11:0:0": {Name: "port-11:0:0", SASPhys: []string{"phy-11:0:2"}},
-		"port-11:0:1": {Name: "port-11:0:1", SASPhys: []string{"phy-11:0:4"}},
-		"port-11:0:2": {Name: "port-11:0:2", SASPhys: []string{"phy-11:0:6"}},
+		"port-11:0:0": {
+			Name:       "port-11:0:0",
+			SASPhys:    []string{"phy-11:0:2"},
+			EndDevices: []string{"end_device-11:0:0"},
+		},
+		"port-11:0:1": {
+			Name:       "port-11:0:1",
+			SASPhys:    []string{"phy-11:0:4"},
+			EndDevices: []string{"end_device-11:0:1"},
+		},
+		"port-11:0:2": {
+			Name:       "port-11:0:2",
+			SASPhys:    []string{"phy-11:0:6"},
+			EndDevices: []string{"end_device-11:0:2"},
+		},
 		"port-11:1": {
 			Name:      "port-11:1",
 			SASPhys:   []string{"phy-11:12", "phy-11:13", "phy-11:14", "phy-11:15"},


### PR DESCRIPTION
This adds support for several SAS classes from `/sys/class`:

  * `sas_host`
  * `sas_device`
  * `sas_end_device`
  * `sas_expander`
  * `sas_phy`
  * `sas_port`

These are for issue #452, which is needed for https://github.com/prometheus/node_exporter/issues/2386.  Once that is complete, it'll be possible to track SAS communication errors on each individual SAS link in a system, and then map those links to specific block devices.

Use case: I recently discovered that I had a bad SAS cable in my system and was seeing weird, intermittent disk timeouts and errors which caused ZFS problems.  Being able to track SAS issues for each node should make detecting and debugging this sort of problem much easier.