### PR TITLE
Replace deprecation ioutil fucntions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Many of the files are changing continuously and the data being read can in some 
 reads in the same file.  Also, most of the files are relatively small (less than a few KBs), and system calls
 to the `stat` function will often return the wrong size.  Therefore, for most files it's recommended to read the 
 full file in a single operation using an internal utility function called `util.ReadFileNoStat`.
-This function is similar to `ioutil.ReadFile`, but it avoids the system call to `stat` to get the current size of
+This function is similar to `os.ReadFile`, but it avoids the system call to `stat` to get the current size of
 the file.
 
 Note that parsing the file's contents can still be performed one line at a time.  This is done by first reading 
@@ -113,7 +113,7 @@ the full file, and then using a scanner on the `[]byte` or `string` containing t
 ```
 
 The `/sys` filesystem contains many very small files which contain only a single numeric or text value.  These files
-can be read using an internal function called `util.SysReadFile` which is similar to `ioutil.ReadFile` but does
+can be read using an internal function called `util.SysReadFile` which is similar to `os.ReadFile` but does
 not bother to check the size of the file before reading.
 ```
     data, err := util.SysReadFile("/sys/class/power_supply/BAT0/capacity")

--- a/arp.go
+++ b/arp.go
@@ -15,8 +15,8 @@ package procfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -53,7 +53,7 @@ type ARPEntry struct {
 // GatherARPEntries retrieves all the ARP entries, parse the relevant columns,
 // and then return a slice of ARPEntry's.
 func (fs FS) GatherARPEntries() ([]ARPEntry, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("net/arp"))
+	data, err := os.ReadFile(fs.proc.Path("net/arp"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading arp %q: %w", fs.proc.Path("net/arp"), err)
 	}

--- a/bcache/get.go
+++ b/bcache/get.go
@@ -16,7 +16,6 @@ package bcache
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -204,7 +203,7 @@ func (p *parser) readValue(fileName string) uint64 {
 		return 0
 	}
 	path := path.Join(p.currentDir, fileName)
-	byt, err := ioutil.ReadFile(path)
+	byt, err := os.ReadFile(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			p.err = fmt.Errorf("failed to read: %s", path)

--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -293,7 +292,7 @@ func (fs FS) ProcDiskstats() ([]Diskstats, error) {
 
 // SysBlockDevices lists the device names from /sys/block/<dev>.
 func (fs FS) SysBlockDevices() ([]string, error) {
-	deviceDirs, err := ioutil.ReadDir(fs.sys.Path(sysBlockPath))
+	deviceDirs, err := os.ReadDir(fs.sys.Path(sysBlockPath))
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +308,7 @@ func (fs FS) SysBlockDevices() ([]string, error) {
 // and 11 if they are not available.
 func (fs FS) SysBlockDeviceStat(device string) (IOStats, int, error) {
 	stat := IOStats{}
-	bytes, err := ioutil.ReadFile(fs.sys.Path(sysBlockPath, device, "stat"))
+	bytes, err := os.ReadFile(fs.sys.Path(sysBlockPath, device, "stat"))
 	if err != nil {
 		return stat, 0, err
 	}

--- a/btrfs/get.go
+++ b/btrfs/get.go
@@ -14,7 +14,6 @@
 package btrfs
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -122,7 +121,7 @@ func (r *reader) readValue(n string) (v uint64) {
 
 // listFiles returns a list of files for a directory of the reader.
 func (r *reader) listFiles(p string) []string {
-	files, err := ioutil.ReadDir(path.Join(r.path, p))
+	files, err := os.ReadDir(path.Join(r.path, p))
 	if err != nil {
 		r.err = err
 		return nil
@@ -164,7 +163,7 @@ func (r *reader) readAllocationStats(d string) (a *AllocationStats) {
 
 // readLayouts reads all Btrfs layout statistics for the current path.
 func (r *reader) readLayouts() map[string]*LayoutUsage {
-	files, err := ioutil.ReadDir(r.path)
+	files, err := os.ReadDir(r.path)
 	if err != nil {
 		r.err = err
 		return nil

--- a/internal/util/parse.go
+++ b/internal/util/parse.go
@@ -14,7 +14,7 @@
 package util
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -66,7 +66,7 @@ func ParsePInt64s(ss []string) ([]*int64, error) {
 
 // ReadUintFromFile reads a file and attempts to parse a uint64 from it.
 func ReadUintFromFile(path string) (uint64, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}
@@ -75,7 +75,7 @@ func ReadUintFromFile(path string) (uint64, error) {
 
 // ReadIntFromFile reads a file and attempts to parse a int64 from it.
 func ReadIntFromFile(path string) (int64, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/util/readfile.go
+++ b/internal/util/readfile.go
@@ -15,12 +15,11 @@ package util
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
-// ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.
-// This is similar to ioutil.ReadFile but without the call to os.Stat, because
+// ReadFileNoStat uses io.ReadAll to read contents of entire file.
+// This is similar to os.ReadFile but without the call to os.Stat, because
 // many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
 // Reads a max file size of 512kB.  For files larger than this, a scanner
 // should be used.
@@ -34,5 +33,5 @@ func ReadFileNoStat(filename string) ([]byte, error) {
 	defer f.Close()
 
 	reader := io.LimitReader(f, maxBufferSize)
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }

--- a/internal/util/sysreadfile.go
+++ b/internal/util/sysreadfile.go
@@ -22,7 +22,7 @@ import (
 	"syscall"
 )
 
-// SysReadFile is a simplified ioutil.ReadFile that invokes syscall.Read directly.
+// SysReadFile is a simplified os.ReadFile that invokes syscall.Read directly.
 // https://github.com/prometheus/node_exporter/pull/728/files
 //
 // Note that this function will not read files larger than 128 bytes.
@@ -34,7 +34,7 @@ func SysReadFile(file string) (string, error) {
 	defer f.Close()
 
 	// On some machines, hwmon drivers are broken and return EAGAIN.  This causes
-	// Go's ioutil.ReadFile implementation to poll forever.
+	// Go's os.ReadFile implementation to poll forever.
 	//
 	// Since we either want to read data or bail immediately, do the simplest
 	// possible read using syscall directly.

--- a/ipvs.go
+++ b/ipvs.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -84,7 +83,7 @@ func parseIPVSStats(r io.Reader) (IPVSStats, error) {
 		stats       IPVSStats
 	)
 
-	statContent, err := ioutil.ReadAll(r)
+	statContent, err := io.ReadAll(r)
 	if err != nil {
 		return IPVSStats{}, err
 	}

--- a/iscsi/get.go
+++ b/iscsi/get.go
@@ -17,7 +17,6 @@ package iscsi
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -60,7 +59,7 @@ func GetStats(iqnPath string) (*Stats, error) {
 
 // isPathEnable checks if the file "enable" contain enable message.
 func isPathEnable(path string) (bool, error) {
-	enableReadout, err := ioutil.ReadFile(filepath.Join(path, "enable"))
+	enableReadout, err := os.ReadFile(filepath.Join(path, "enable"))
 	if err != nil {
 		return false, fmt.Errorf("iscsi: isPathEnable ReadFile error %w", err)
 	}
@@ -74,7 +73,7 @@ func isPathEnable(path string) (bool, error) {
 func getLunLinkTarget(lunPath string) (lunObject LUN, err error) {
 	lunObject.Name = filepath.Base(lunPath)
 	lunObject.LunPath = lunPath
-	files, err := ioutil.ReadDir(lunPath)
+	files, err := os.ReadDir(lunPath)
 	if err != nil {
 		return lunObject, fmt.Errorf("getLunLinkTarget: ReadDir path %q: %w", lunPath, err)
 	}
@@ -144,7 +143,7 @@ func (fs FS) GetFileioUdev(fileioNumber string, objectName string) (*FILEIO, err
 	if _, err := os.Stat(udevPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("iscsi: GetFileioUdev: fileio_%s is missing file name", fileio.Fnumber)
 	}
-	filename, err := ioutil.ReadFile(udevPath)
+	filename, err := os.ReadFile(udevPath)
 	if err != nil {
 		return nil, fmt.Errorf("iscsi: GetFileioUdev: Cannot read filename from udev link %q", udevPath)
 	}
@@ -166,7 +165,7 @@ func (fs FS) GetIblockUdev(iblockNumber string, objectName string) (*IBLOCK, err
 	if _, err := os.Stat(udevPath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("iscsi: GetIBlockUdev: iblock_%s is missing file name", iblock.Bnumber)
 	}
-	filename, err := ioutil.ReadFile(udevPath)
+	filename, err := os.ReadFile(udevPath)
 	if err != nil {
 		return nil, fmt.Errorf("iscsi: GetIBlockUdev: Cannot read iblock from udev link %q", udevPath)
 	}
@@ -193,7 +192,7 @@ func (fs FS) GetRBDMatch(rbdNumber string, poolImage string) (*RBD, error) {
 		if _, err := os.Stat(systemPoolPath); os.IsNotExist(err) {
 			continue
 		}
-		bSystemPool, err := ioutil.ReadFile(systemPoolPath)
+		bSystemPool, err := os.ReadFile(systemPoolPath)
 		if err != nil {
 			continue
 		} else {
@@ -204,7 +203,7 @@ func (fs FS) GetRBDMatch(rbdNumber string, poolImage string) (*RBD, error) {
 		if _, err := os.Stat(systemImagePath); os.IsNotExist(err) {
 			continue
 		}
-		bSystemImage, err := ioutil.ReadFile(systemImagePath)
+		bSystemImage, err := os.ReadFile(systemImagePath)
 		if err != nil {
 			continue
 		} else {

--- a/mdstat.go
+++ b/mdstat.go
@@ -15,7 +15,7 @@ package procfs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -64,7 +64,7 @@ type MDStat struct {
 // structs containing the relevant info.  More information available here:
 // https://raid.wiki.kernel.org/index.php/Mdstat
 func (fs FS) MDStat() ([]MDStat, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("mdstat"))
+	data, err := os.ReadFile(fs.proc.Path("mdstat"))
 	if err != nil {
 		return nil, err
 	}

--- a/proc.go
+++ b/proc.go
@@ -16,7 +16,7 @@ package procfs
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -142,7 +142,7 @@ func (p Proc) Wchan() (string, error) {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return "", err
 	}
@@ -311,7 +311,7 @@ func (p Proc) FileDescriptorsInfo() (ProcFDInfos, error) {
 
 // Schedstat returns task scheduling information for the process.
 func (p Proc) Schedstat() (ProcSchedstat, error) {
-	contents, err := ioutil.ReadFile(p.path("schedstat"))
+	contents, err := os.ReadFile(p.path("schedstat"))
 	if err != nil {
 		return ProcSchedstat{}, err
 	}

--- a/sysfs/class_dmi.go
+++ b/sysfs/class_dmi.go
@@ -18,7 +18,6 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -56,14 +55,14 @@ type DMIClass struct {
 func (fs FS) DMIClass() (*DMIClass, error) {
 	path := fs.sys.Path(dmiClassPath)
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read directory %q: %w", path, err)
 	}
 
 	var dmi DMIClass
 	for _, f := range files {
-		if !f.Mode().IsRegular() {
+		if !f.Type().IsRegular() {
 			continue
 		}
 

--- a/sysfs/class_fibrechannel.go
+++ b/sysfs/class_fibrechannel.go
@@ -18,7 +18,6 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -66,7 +65,7 @@ type FibreChannelClass map[string]FibreChannelHost
 func (fs FS) FibreChannelClass() (FibreChannelClass, error) {
 	path := fs.sys.Path(fibrechannelClassPath)
 
-	dirs, err := ioutil.ReadDir(path)
+	dirs, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -148,13 +147,13 @@ func parseFibreChannelStatistics(hostPath string) (*FibreChannelCounters, error)
 	var counters FibreChannelCounters
 
 	path := filepath.Join(hostPath, "statistics")
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, f := range files {
-		if !f.Mode().IsRegular() || f.Name() == "reset_statistics" {
+		if !f.Type().IsRegular() || f.Name() == "reset_statistics" {
 			continue
 		}
 

--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -18,7 +18,6 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -102,7 +101,7 @@ type InfiniBandClass map[string]InfiniBandDevice
 func (fs FS) InfiniBandClass() (InfiniBandClass, error) {
 	path := fs.sys.Path(infinibandClassPath)
 
-	dirs, err := ioutil.ReadDir(path)
+	dirs, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +146,7 @@ func (fs FS) parseInfiniBandDevice(name string) (*InfiniBandDevice, error) {
 	}
 
 	portsPath := filepath.Join(path, "ports")
-	ports, err := ioutil.ReadDir(portsPath)
+	ports, err := os.ReadDir(portsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list InfiniBand ports at %q: %w", portsPath, err)
 	}
@@ -205,7 +204,7 @@ func (fs FS) parseInfiniBandPort(name string, port string) (*InfiniBandPort, err
 	ibp := InfiniBandPort{Name: name, Port: uint(portNumber)}
 
 	portPath := fs.sys.Path(infinibandClassPath, name, "ports", port)
-	content, err := ioutil.ReadFile(filepath.Join(portPath, "state"))
+	content, err := os.ReadFile(filepath.Join(portPath, "state"))
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +215,7 @@ func (fs FS) parseInfiniBandPort(name string, port string) (*InfiniBandPort, err
 	ibp.State = name
 	ibp.StateID = id
 
-	content, err = ioutil.ReadFile(filepath.Join(portPath, "phys_state"))
+	content, err = os.ReadFile(filepath.Join(portPath, "phys_state"))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +226,7 @@ func (fs FS) parseInfiniBandPort(name string, port string) (*InfiniBandPort, err
 	ibp.PhysState = name
 	ibp.PhysStateID = id
 
-	content, err = ioutil.ReadFile(filepath.Join(portPath, "rate"))
+	content, err = os.ReadFile(filepath.Join(portPath, "rate"))
 	if err != nil {
 		return nil, err
 	}
@@ -249,13 +248,13 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 	var counters InfiniBandCounters
 
 	path := filepath.Join(portPath, "counters")
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, f := range files {
-		if !f.Mode().IsRegular() {
+		if !f.Type().IsRegular() {
 			continue
 		}
 
@@ -344,13 +343,13 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 
 	// Parse legacy counters
 	path = filepath.Join(portPath, "counters_ext")
-	files, err = ioutil.ReadDir(path)
+	files, err = os.ReadDir(path)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 
 	for _, f := range files {
-		if !f.Mode().IsRegular() {
+		if !f.Type().IsRegular() {
 			continue
 		}
 

--- a/sysfs/class_nvme.go
+++ b/sysfs/class_nvme.go
@@ -18,7 +18,7 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/prometheus/procfs/internal/util"
@@ -44,7 +44,7 @@ type NVMeClass map[string]NVMeDevice
 func (fs FS) NVMeClass() (NVMeClass, error) {
 	path := fs.sys.Path(nvmeClassPath)
 
-	dirs, err := ioutil.ReadDir(path)
+	dirs, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list NVMe devices at %q: %w", path, err)
 	}

--- a/sysfs/class_power_supply.go
+++ b/sysfs/class_power_supply.go
@@ -18,7 +18,6 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -109,7 +108,7 @@ type PowerSupplyClass map[string]PowerSupply
 func (fs FS) PowerSupplyClass() (PowerSupplyClass, error) {
 	path := fs.sys.Path("class/power_supply")
 
-	dirs, err := ioutil.ReadDir(path)
+	dirs, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -129,14 +128,14 @@ func (fs FS) PowerSupplyClass() (PowerSupplyClass, error) {
 }
 
 func parsePowerSupply(path string) (*PowerSupply, error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
 
 	var ps PowerSupply
 	for _, f := range files {
-		if !f.Mode().IsRegular() {
+		if !f.Type().IsRegular() {
 			continue
 		}
 

--- a/sysfs/class_powercap.go
+++ b/sysfs/class_powercap.go
@@ -18,7 +18,7 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -40,7 +40,7 @@ type RaplZone struct {
 func GetRaplZones(fs FS) ([]RaplZone, error) {
 	raplDir := fs.sys.Path("class/powercap")
 
-	files, err := ioutil.ReadDir(raplDir)
+	files, err := os.ReadDir(raplDir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read class/powercap: %w", err)
 	}
@@ -53,7 +53,7 @@ func GetRaplZones(fs FS) ([]RaplZone, error) {
 	// Loop through directory files searching for file "name" from subdirs.
 	for _, f := range files {
 		nameFile := filepath.Join(raplDir, f.Name(), "/name")
-		nameBytes, err := ioutil.ReadFile(nameFile)
+		nameBytes, err := os.ReadFile(nameFile)
 		if err == nil {
 			// Add new rapl zone since name file was found.
 			name := strings.TrimSpace(string(nameBytes))

--- a/sysfs/class_scsitape.go
+++ b/sysfs/class_scsitape.go
@@ -18,7 +18,7 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -51,7 +51,7 @@ type SCSITapeClass map[string]SCSITape
 func (fs FS) SCSITapeClass() (SCSITapeClass, error) {
 	path := fs.sys.Path(scsiTapeClassPath)
 
-	dirs, err := ioutil.ReadDir(path)
+	dirs, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func parseSCSITapeStatistics(tapePath string) (*SCSITapeCounters, error) {
 	var counters SCSITapeCounters
 
 	path := filepath.Join(tapePath, "stats")
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -18,7 +18,6 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -68,13 +67,13 @@ func (fs FS) NetClassDevices() ([]string, error) {
 	var res []string
 	path := fs.sys.Path(netclassPath)
 
-	devices, err := ioutil.ReadDir(path)
+	devices, err := os.ReadDir(path)
 	if err != nil {
 		return res, fmt.Errorf("cannot access dir %q: %w", path, err)
 	}
 
 	for _, deviceDir := range devices {
-		if deviceDir.Mode().IsRegular() {
+		if deviceDir.Type().IsRegular() {
 			continue
 		}
 		res = append(res, deviceDir.Name())
@@ -122,13 +121,13 @@ func (fs FS) NetClass() (NetClass, error) {
 func parseNetClassIface(devicePath string) (*NetClassIface, error) {
 	interfaceClass := NetClassIface{}
 
-	files, err := ioutil.ReadDir(devicePath)
+	files, err := os.ReadDir(devicePath)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, f := range files {
-		if !f.Mode().IsRegular() {
+		if !f.Type().IsRegular() {
 			continue
 		}
 		name := filepath.Join(devicePath, f.Name())

--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -18,7 +18,6 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -243,7 +242,7 @@ func parseCpufreqCpuinfo(cpuPath string) (*SystemCPUCpufreqStats, error) {
 }
 
 func (fs FS) IsolatedCPUs() ([]uint16, error) {
-	isolcpus, err := ioutil.ReadFile(fs.sys.Path("devices/system/cpu/isolated"))
+	isolcpus, err := os.ReadFile(fs.sys.Path("devices/system/cpu/isolated"))
 	if err != nil {
 		return nil, err
 	}

--- a/sysfs/vulnerability.go
+++ b/sysfs/vulnerability.go
@@ -18,7 +18,7 @@ package sysfs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -40,7 +40,7 @@ func (fs FS) CPUVulnerabilities() ([]Vulnerability, error) {
 	for _, match := range matches {
 		name := filepath.Base(match)
 
-		value, err := ioutil.ReadFile(match)
+		value, err := os.ReadFile(match)
 		if err != nil {
 			return nil, err
 		}

--- a/vm.go
+++ b/vm.go
@@ -18,7 +18,6 @@ package procfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,7 +87,7 @@ func (fs FS) VM() (*VM, error) {
 		return nil, fmt.Errorf("%s is not a directory", path)
 	}
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/zoneinfo.go
+++ b/zoneinfo.go
@@ -19,7 +19,7 @@ package procfs
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -73,7 +73,7 @@ var nodeZoneRE = regexp.MustCompile(`(\d+), zone\s+(\w+)`)
 // structs containing the relevant info.  More information available here:
 // https://www.kernel.org/doc/Documentation/sysctl/vm.txt
 func (fs FS) Zoneinfo() ([]Zoneinfo, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("zoneinfo"))
+	data, err := os.ReadFile(fs.proc.Path("zoneinfo"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading zoneinfo %q: %w", fs.proc.Path("zoneinfo"), err)
 	}


### PR DESCRIPTION
Go 1.16 deprecated several `io/ioutil` functions.
* `ioutil.ReadFile` -> `os.ReadFile`
* `ioutil.ReadAll` -> `io.ReadAll`
* `ioutil.ReadDir` -> `os.ReadDir`

Signed-off-by: SuperQ <superq@gmail.com>