### PR TITLE
Bump max buffer size to 1024kb to handle larger mountinfo files

### DIFF
--- a/internal/util/readfile.go
+++ b/internal/util/readfile.go
@@ -21,10 +21,10 @@ import (
 // ReadFileNoStat uses io.ReadAll to read contents of entire file.
 // This is similar to os.ReadFile but without the call to os.Stat, because
 // many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
-// Reads a max file size of 512kB.  For files larger than this, a scanner
+// Reads a max file size of 1024kB.  For files larger than this, a scanner
 // should be used.
 func ReadFileNoStat(filename string) ([]byte, error) {
-	const maxBufferSize = 1024 * 512
+	const maxBufferSize = 1024 * 1024
 
 	f, err := os.Open(filename)
 	if err != nil {


### PR DESCRIPTION
Closes https://github.com/prometheus/procfs/issues/457