### PR TITLE
add processor field for /proc/[pid]/stat

### DIFF
--- a/proc_stat.go
+++ b/proc_stat.go
@@ -102,6 +102,8 @@ type ProcStat struct {
 	RSS int
 	// Soft limit in bytes on the rss of the process.
 	RSSLimit uint64
+	// CPU number last executed on.
+	Processor uint
 	// Real-time scheduling priority, a number in the range 1 to 99 for processes
 	// scheduled under a real-time policy, or 0, for non-real-time processes.
 	RTPriority uint
@@ -184,7 +186,7 @@ func (p Proc) Stat() (ProcStat, error) {
 		&ignoreUint64,
 		&ignoreUint64,
 		&ignoreInt64,
-		&ignoreInt64,
+		&s.Processor,
 		&s.RTPriority,
 		&s.Policy,
 		&s.DelayAcctBlkIOTicks,

--- a/proc_stat_test.go
+++ b/proc_stat_test.go
@@ -68,6 +68,7 @@ func TestProcStat(t *testing.T) {
 		want uint
 		have uint
 	}{
+		{name: "processor", want: 0, have: s.Processor},
 		{name: "rt_priority", want: 0, have: s.RTPriority},
 		{name: "policy", want: 0, have: s.Policy},
 	} {


### PR DESCRIPTION
When analysing performance issue, it is useful to know process run on which cpu.


Signed-off-by: peter wang wangbo.red@gmail.com