### PR TITLE
fix: Avoid trimming characters incorrectly from ProcStatus

### DIFF
--- a/proc_status.go
+++ b/proc_status.go
@@ -96,10 +96,10 @@ func (p Proc) NewStatus() (ProcStatus, error) {
 		kv := strings.SplitN(line, ":", 2)
 
 		// removes spaces
-		k := string(strings.TrimSpace(kv[0]))
-		v := string(strings.TrimSpace(kv[1]))
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
 		// removes "kB"
-		v = string(bytes.Trim([]byte(v), " kB"))
+		v = strings.TrimSuffix(v, " kB")
 
 		// value to int when possible
 		// we can skip error check here, 'cause vKBytes is not used when value is a string

--- a/proc_status_test.go
+++ b/proc_status_test.go
@@ -76,6 +76,20 @@ func TestProcStatusName(t *testing.T) {
 	}
 }
 
+func TestProcStatusNameTrim(t *testing.T) {
+	p, err := getProcFixtures(t).Proc(26235)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := p.NewStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "kube-proxy", s.Name; want != have {
+		t.Errorf("want name %s, have %s", want, have)
+	}
+}
+
 func TestProcStatusUIDs(t *testing.T) {
 	p, err := getProcFixtures(t).Proc(26231)
 	if err != nil {

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -748,6 +748,64 @@ Lines: 4
 40000000-40015000 r-xp 00000000 03:01 61874 /lib/ld-2.3.2.so
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/proc/26235
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/26235/status
+Lines: 51
+Name:   kube-proxy
+Umask:  0022
+State:  S (sleeping)
+Tgid:   26235
+Ngid:   12345
+Pid:    26235
+PPid:   1234
+TracerPid:      0
+Uid:    0       0       0       0
+Gid:    0       0       0       0
+FDSize: 64
+Groups:
+NStgid: 26235   1
+NSpid:  26235   1
+NSpgid: 26235   1
+NSsid:  26235   1
+VmPeak:   758200 kB
+VmSize:   758200 kB
+VmLck:         0 kB
+VmPin:         0 kB
+VmHWM:     61776 kB
+VmRSS:     42652 kB
+RssAnon:           24852 kB
+RssFile:           17800 kB
+RssShmem:              0 kB
+VmData:   117136 kB
+VmStk:       132 kB
+VmExe:     21568 kB
+VmLib:         4 kB
+VmPTE:       264 kB
+VmSwap:        0 kB
+HugetlbPages:          0 kB
+Threads:        51
+SigQ:   9/511324
+SigPnd: 0000000000000000
+ShdPnd: 0000000000000000
+SigBlk: 0000000000000000
+SigIgn: 0000000000000000
+SigCgt: fffffffc7fc1feff
+CapInh: 0000003fffffffff
+CapPrm: 0000003fffffffff
+CapEff: 0000003fffffffff
+CapBnd: 0000003fffffffff
+CapAmb: 0000000000000000
+Seccomp:	0
+Cpus_allowed:	ff
+Cpus_allowed_list:	0-7
+Mems_allowed:	00000000,00000001
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	4742839
+nonvoluntary_ctxt_switches:	1727500
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/proc/584
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Hello, thank you for the wonderful library!

We found some issues in parsing ProcStatus, in particular those whose `Name` starts with a `k`. For a simple repro (I copied out the existing code from https://github.com/prometheus/procfs/blob/bf361025088d9df7a76662269f07facf20f8711e/proc_status.go):

```go
package main

import (
	"bytes"
	"fmt"
	"strconv"
	"strings"

	"github.com/prometheus/procfs"
)

const (
	pid  = 6187
	data = `Name:   kube-proxy`
)

func main() {
	s := procfs.ProcStatus{PID: pid}

	lines := strings.Split(data, "\n")
	for _, line := range lines {
		if !bytes.Contains([]byte(line), []byte(":")) {
			continue
		}

		kv := strings.SplitN(line, ":", 2)

		// removes spaces
		k := string(strings.TrimSpace(kv[0]))
		v := string(strings.TrimSpace(kv[1]))
		// removes "kB"
		v = string(bytes.Trim([]byte(v), " kB"))

		// value to int when possible
		// we can skip error check here, 'cause vKBytes is not used when value is a string
		vKBytes, _ := strconv.ParseUint(v, 10, 64)
		// convert kB to B
		vBytes := vKBytes * 1024

		fillStatus(&s, k, v, vKBytes, vBytes)
	}

	fmt.Printf("%v\n", s.Name)
}
```

The output is as follows:

```
ube-proxy
```

The reason is because `bytes.Trim` takes in a cutSet, not a suffix that should be trimmed. As such, this PR modifies `bytes.Trim` to `strings.TrimSuffix`.