### PR TITLE
Separate NetStat parsing logic

### DIFF
--- a/proc_netstat.go
+++ b/proc_netstat.go
@@ -174,14 +174,14 @@ func (p Proc) Netstat() (ProcNetstat, error) {
 	if err != nil {
 		return ProcNetstat{PID: p.PID}, err
 	}
-	procNetstat, err := parseNetstat(bytes.NewReader(data), filename)
+	procNetstat, err := parseProcNetstat(bytes.NewReader(data), filename)
 	procNetstat.PID = p.PID
 	return procNetstat, err
 }
 
-// parseNetstat parses the metrics from proc/<pid>/net/netstat file
+// parseProcNetstat parses the metrics from proc/<pid>/net/netstat file
 // and returns a ProcNetstat structure.
-func parseNetstat(r io.Reader, fileName string) (ProcNetstat, error) {
+func parseProcNetstat(r io.Reader, fileName string) (ProcNetstat, error) {
 	var (
 		scanner     = bufio.NewScanner(r)
 		procNetstat = ProcNetstat{}


### PR DESCRIPTION
As procfs already did use `parseX(io.Reader)` functions for other filesystem formats, this was missing in `netstat` parsing. It should not do both _reading_ and _parsing_ stuff in the same function. Anyone who want to just access parser func using `go:linkname` directive, now it's possible. I had to copy-paste the actual parser logic since the function itself also _reads_ a file.

Signed-off-by: Furkan <furkan.turkal@trendyol.com>