### PR TITLE
Use errors.Is() for invalid argument

### DIFF
--- a/sysfs/class_fibrechannel.go
+++ b/sysfs/class_fibrechannel.go
@@ -17,6 +17,7 @@
 package sysfs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -161,7 +162,7 @@ func parseFibreChannelStatistics(hostPath string) (*FibreChannelCounters, error)
 		value, err := util.SysReadFile(name)
 		if err != nil {
 			// there are some write-only files in this directory; we can safely skip over them
-			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || errors.Is(err, os.ErrInvalid) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %w", name, err)

--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -17,6 +17,7 @@
 package sysfs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -261,7 +262,7 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || errors.Is(err, os.ErrInvalid) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %w", name, err)
@@ -356,7 +357,7 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || errors.Is(err, os.ErrInvalid) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %w", name, err)

--- a/sysfs/class_power_supply.go
+++ b/sysfs/class_power_supply.go
@@ -17,6 +17,7 @@
 package sysfs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -142,7 +143,7 @@ func parsePowerSupply(path string) (*PowerSupply, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || errors.Is(err, os.ErrInvalid) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %w", name, err)

--- a/sysfs/net_class.go
+++ b/sysfs/net_class.go
@@ -17,6 +17,7 @@
 package sysfs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -133,7 +134,7 @@ func parseNetClassIface(devicePath string) (*NetClassIface, error) {
 		name := filepath.Join(devicePath, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || err.Error() == "invalid argument" {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || errors.Is(err, os.ErrInvalid) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %w", name, err)


### PR DESCRIPTION
Switch to using Go errors.Is() to check for the "invalid argument" error.

Signed-off-by: SuperQ <superq@gmail.com>