### PR TITLE
Enable oppportunistic fd counting fast path

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/prometheus/procfs/internal/fs"
 	"github.com/prometheus/procfs/internal/util"
 )
 
@@ -30,7 +29,7 @@ type Proc struct {
 	// The process ID.
 	PID int
 
-	fs fs.FS
+	fs FS
 }
 
 // Procs represents a list of Proc structs.
@@ -92,7 +91,7 @@ func (fs FS) Proc(pid int) (Proc, error) {
 	if _, err := os.Stat(fs.proc.Path(strconv.Itoa(pid))); err != nil {
 		return Proc{}, err
 	}
-	return Proc{PID: pid, fs: fs.proc}, nil
+	return Proc{PID: pid, fs: fs}, nil
 }
 
 // AllProcs returns a list of all currently available processes.
@@ -114,7 +113,7 @@ func (fs FS) AllProcs() (Procs, error) {
 		if err != nil {
 			continue
 		}
-		p = append(p, Proc{PID: int(pid), fs: fs.proc})
+		p = append(p, Proc{PID: int(pid), fs: fs})
 	}
 
 	return p, nil
@@ -238,14 +237,16 @@ func (p Proc) FileDescriptorTargets() ([]string, error) {
 // a process.
 func (p Proc) FileDescriptorsLen() (int, error) {
 	// Use fast path if available (Linux v6.2): https://github.com/torvalds/linux/commit/f1f1f2569901
-	stat, err := os.Stat(p.path("fd"))
-	if err != nil {
-		return 0, err
-	}
+	if p.fs.real {
+		stat, err := os.Stat(p.path("fd"))
+		if err != nil {
+			return 0, err
+		}
 
-	size := stat.Size()
-	if size > 0 {
-		return int(size), nil
+		size := stat.Size()
+		if size > 0 {
+			return int(size), nil
+		}
 	}
 
 	fds, err := p.fileDescriptors()
@@ -296,7 +297,7 @@ func (p Proc) fileDescriptors() ([]string, error) {
 }
 
 func (p Proc) path(pa ...string) string {
-	return p.fs.Path(append([]string{strconv.Itoa(p.PID)}, pa...)...)
+	return p.fs.proc.Path(append([]string{strconv.Itoa(p.PID)}, pa...)...)
 }
 
 // FileDescriptorsInfo retrieves information about all file descriptors of

--- a/proc_stat.go
+++ b/proc_stat.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/prometheus/procfs/internal/fs"
 	"github.com/prometheus/procfs/internal/util"
 )
 
@@ -112,7 +111,7 @@ type ProcStat struct {
 	// Aggregated block I/O delays, measured in clock ticks (centiseconds).
 	DelayAcctBlkIOTicks uint64
 
-	proc fs.FS
+	proc FS
 }
 
 // NewStat returns the current status information of the process.
@@ -210,8 +209,7 @@ func (s ProcStat) ResidentMemory() int {
 
 // StartTime returns the unix timestamp of the process in seconds.
 func (s ProcStat) StartTime() (float64, error) {
-	fs := FS{proc: s.proc}
-	stat, err := fs.Stat()
+	stat, err := s.proc.Stat()
 	if err != nil {
 		return 0, err
 	}

--- a/thread.go
+++ b/thread.go
@@ -54,7 +54,8 @@ func (fs FS) AllThreads(pid int) (Procs, error) {
 		if err != nil {
 			continue
 		}
-		t = append(t, Proc{PID: int(tid), fs: fsi.FS(taskPath)})
+
+		t = append(t, Proc{PID: int(tid), fs: FS{fsi.FS(taskPath), fs.real}})
 	}
 
 	return t, nil
@@ -66,13 +67,13 @@ func (fs FS) Thread(pid, tid int) (Proc, error) {
 	if _, err := os.Stat(taskPath); err != nil {
 		return Proc{}, err
 	}
-	return Proc{PID: tid, fs: fsi.FS(taskPath)}, nil
+	return Proc{PID: tid, fs: FS{fsi.FS(taskPath), fs.real}}, nil
 }
 
 // Thread returns a process for a given TID of Proc.
 func (proc Proc) Thread(tid int) (Proc, error) {
-	tfs := fsi.FS(proc.path("task"))
-	if _, err := os.Stat(tfs.Path(strconv.Itoa(tid))); err != nil {
+	tfs := FS{fsi.FS(proc.path("task")), proc.fs.real}
+	if _, err := os.Stat(tfs.proc.Path(strconv.Itoa(tid))); err != nil {
 		return Proc{}, err
 	}
 	return Proc{PID: tid, fs: tfs}, nil

--- a/thread_test.go
+++ b/thread_test.go
@@ -37,7 +37,7 @@ func TestAllThreads(t *testing.T) {
 			t.Errorf("want TID %d, have %d", wantTID, haveTID)
 		}
 		wantFS := fixFS.proc.Path(strconv.Itoa(testPID), "task")
-		haveFS := string(threads[i].fs)
+		haveFS := string(threads[i].fs.proc)
 		if wantFS != haveFS {
 			t.Errorf("want fs %q, have %q", wantFS, haveFS)
 		}


### PR DESCRIPTION
Existing slow path takes ~725ms of CPU time on my laptopto count 1 million open files. Compare this to just 0.25ms for the baseline, when no extra files are open by a Go program:

```
Open files reported: 7
 Gathered metrics in 0.26ms
Open files reported: 1000007
 Gathered metrics in 724.50ms
```

Adding fastpath from Linux v6.2 makes it fast:

```
Open files reported: 6
 Gathered metrics in 0.29ms
Open files reported: 1000006
 Gathered metrics in 0.31ms
```

This is before taking in account any lock contention effects in the kernel if you try to count files from multiple threads concurrently, which makes the slow path even slower, burning a lot more CPU in the process. See:

* https://github.com/torvalds/linux/commit/f1f1f2569901

<details>
  <summary>The code I used</summary>

```go
package main

import (
	"fmt"
	"os"
	"time"

	"github.com/prometheus/client_golang/prometheus"
)

func main() {
	run()

	openLotsOfFiles(1000000)

	run()
}

func run() {
	s := time.Now()

	metrics, err := prometheus.DefaultGatherer.Gather()
	if err != nil {
		panic(err)
	}

	for _, metric := range metrics {
		if metric.GetName() == "process_open_fds" {
			fmt.Printf("Open files reported: %.0f\n", *metric.Metric[0].Gauge.Value)
		}
	}

	fmt.Printf(" Gathered metrics in %.2fms\n", float64(time.Since(s).Microseconds())/1000)
}

func openLotsOfFiles(lots int) []*os.File {
	files := make([]*os.File, lots)

	for i := 0; i < lots; i++ {
		file, err := os.Open("/etc/hosts")
		if err != nil {
			panic(err)
		}

		files[i] = file
	}

	return files
}
```

```
go build -o /tmp/lol .
```

```
for i in $(seq 1 5); do GOMAXPROCS=1 /tmp/lol; done
```

</details>