### PR TITLE
add avgRTT to nfs mountstats

### DIFF
--- a/mountstats.go
+++ b/mountstats.go
@@ -186,6 +186,8 @@ type NFSOperationStats struct {
 	CumulativeTotalResponseMilliseconds uint64
 	// Duration from when a request was enqueued to when it was completely handled.
 	CumulativeTotalRequestMilliseconds uint64
+	// The average time from the point the client sends RPC requests until it receives the response.
+	AverageRTTMilliseconds float64
 	// The count of operations that complete with tk_status < 0.  These statuses usually indicate error conditions.
 	Errors uint64
 }
@@ -534,7 +536,6 @@ func parseNFSOperationStats(s *bufio.Scanner) ([]NFSOperationStats, error) {
 
 			ns = append(ns, n)
 		}
-
 		opStats := NFSOperationStats{
 			Operation:                           strings.TrimSuffix(ss[0], ":"),
 			Requests:                            ns[0],
@@ -545,6 +546,9 @@ func parseNFSOperationStats(s *bufio.Scanner) ([]NFSOperationStats, error) {
 			CumulativeQueueMilliseconds:         ns[5],
 			CumulativeTotalResponseMilliseconds: ns[6],
 			CumulativeTotalRequestMilliseconds:  ns[7],
+		}
+		if ns[0] != 0 {
+			opStats.AverageRTTMilliseconds = float64(ns[6]) / float64(ns[0])
 		}
 
 		if len(ns) > 8 {

--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -339,6 +339,7 @@ func TestMountStats(t *testing.T) {
 								CumulativeQueueMilliseconds:         6,
 								CumulativeTotalResponseMilliseconds: 79386,
 								CumulativeTotalRequestMilliseconds:  79407,
+								AverageRTTMilliseconds:              61.16024653312789,
 							},
 							{
 								Operation: "WRITE",
@@ -352,6 +353,7 @@ func TestMountStats(t *testing.T) {
 								CumulativeQueueMilliseconds:         18446743919241604546,
 								CumulativeTotalResponseMilliseconds: 1667369447,
 								CumulativeTotalRequestMilliseconds:  1953587717,
+								AverageRTTMilliseconds:              0.5695744656983355,
 							},
 						},
 						Transport: NFSTransportStats{


### PR DESCRIPTION
Hi Team,
I'm sending this PR to add avgRTT to nfs mount stats. https://github.com/prometheus/node_exporter/issues/2550

I followed the same approach as linux kernel to calculate `avgRTT`. https://git.linux-nfs.org/?p=bfields/nfs-utils.git;a=blob;f=tools/nfs-iostat/nfs-iostat.py;h=1df74ba822b59f68c556530e6bf825a1e57f611d;hb=HEAD#l342

Let me know your feedback.

cc : @discordianfish 

Thanks!