### PR TITLE
Bug Fix: SystemCPUfreq fails when any core is offline

### DIFF
--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -165,7 +165,7 @@ func TestIsolatedParsingCPU(t *testing.T) {
 	}
 	for _, params := range testParams {
 		t.Run("blabla", func(t *testing.T) {
-			res, err := parseIsolatedCPUs(params.in)
+			res, err := parseCPURange(params.in)
 			if !reflect.DeepEqual(res, params.res) {
 				t.Fatalf("should have %v result: got %v", params.res, res)
 			}
@@ -191,5 +191,26 @@ func TestIsolatedCPUs(t *testing.T) {
 	}
 	if err != nil {
 		t.Errorf("Error not correct: want %v, have %v", nil, err)
+	}
+}
+
+func TestBinSearch(t *testing.T) {
+	var testParams = []struct {
+		elem  uint16
+		elems []uint16
+		res   bool
+	}{
+		{3, []uint16{1, 3, 5, 7, 9}, true},
+		{4, []uint16{1, 3, 5, 7, 9}, false},
+		{2, []uint16{}, false},
+	}
+
+	for _, param := range testParams {
+		res := binSearch(param.elem, &param.elems)
+
+		if res != param.res {
+			t.Fatalf("Result not correct: want %v, have %v", param.res, res)
+		}
+
 	}
 }

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -12721,6 +12721,11 @@ Lines: 1
 1,2-7,9
 Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/offline
+Lines: 1
+2,12-15
+Mode: 664
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/devices/system/node
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
SystemCpufreq function does not check if a core is online before collecting metrics. In the case when a core is offline it fails and does not collect a couple of metrics.

Refer https://github.com/prometheus/node_exporter/issues/2577 for more details