### PR TITLE
Implement mdraid sysfs parsing

### DIFF
--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -73,7 +73,7 @@ func TestBlockDevice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedNumOfDevices := 2
+	expectedNumOfDevices := 8
 	if len(devices) != expectedNumOfDevices {
 		t.Fatalf(failMsgFormat, "Incorrect number of devices", expectedNumOfDevices, len(devices))
 	}
@@ -93,18 +93,18 @@ func TestBlockDevice(t *testing.T) {
 	if device0stats.WeightedIOTicks != 6088971 {
 		t.Errorf(failMsgFormat, "Incorrect time in queue", 6088971, device0stats.WeightedIOTicks)
 	}
-	device1stats, count, err := blockdevice.SysBlockDeviceStat(devices[1])
+	device7stats, count, err := blockdevice.SysBlockDeviceStat(devices[7])
 	if count != 15 {
 		t.Errorf(failMsgFormat, "Incorrect number of stats read", 15, count)
 	}
 	if err != nil {
 		t.Fatal(err)
 	}
-	if device1stats.WriteSectors != 286915323 {
-		t.Errorf(failMsgFormat, "Incorrect write merges", 286915323, device1stats.WriteSectors)
+	if device7stats.WriteSectors != 286915323 {
+		t.Errorf(failMsgFormat, "Incorrect write merges", 286915323, device7stats.WriteSectors)
 	}
-	if device1stats.DiscardTicks != 12 {
-		t.Errorf(failMsgFormat, "Incorrect discard ticks", 12, device1stats.DiscardTicks)
+	if device7stats.DiscardTicks != 12 {
+		t.Errorf(failMsgFormat, "Incorrect discard ticks", 12, device7stats.DiscardTicks)
 	}
 	blockQueueStatExpected := BlockQueueStats{
 		AddRandom:            1,
@@ -145,7 +145,7 @@ func TestBlockDevice(t *testing.T) {
 		WriteZeroesMaxBytes:  0,
 	}
 
-	blockQueueStat, err := blockdevice.SysBlockDeviceQueueStats(devices[1])
+	blockQueueStat, err := blockdevice.SysBlockDeviceQueueStats(devices[7])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sysfs/mdraid.go
+++ b/sysfs/mdraid.go
@@ -1,0 +1,160 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// Mdraid holds info parsed from relevant files in the /sys/block/md*/md directory.
+type Mdraid struct {
+	Device          string            // Kernel device name of array.
+	Level           string            // mdraid level.
+	ArrayState      string            // State of the array.
+	MetadataVersion string            // mdraid metadata version.
+	Disks           uint64            // Number of devices in a fully functional array.
+	Components      []MdraidComponent // mdraid component devices.
+	UUID            string            // UUID of the array.
+
+	// The following item is only valid for raid0, 4, 5, 6 and 10.
+	ChunkSize uint64 // Chunk size
+
+	// The following items are only valid for raid1, 4, 5, 6 and 10.
+	DegradedDisks uint64  // Number of degraded disks in the array.
+	SyncAction    string  // Current sync action.
+	SyncCompleted float64 // Fraction (0-1) representing the completion status of current sync operation.
+}
+
+type MdraidComponent struct {
+	Device string // Kernel device name.
+	State  string // Current state of device.
+}
+
+// Mdraids gathers information and statistics about mdraid devices present. Based on upstream
+// kernel documentation https://docs.kernel.org/admin-guide/md.html.
+func (fs FS) Mdraids() ([]Mdraid, error) {
+	matches, err := filepath.Glob(fs.sys.Path("block/md*/md"))
+	if err != nil {
+		return nil, err
+	}
+
+	mdraids := make([]Mdraid, 0)
+
+	for _, m := range matches {
+		md := Mdraid{Device: filepath.Base(filepath.Dir(m))}
+		path := fs.sys.Path("block", md.Device, "md")
+
+		if val, err := util.SysReadFile(filepath.Join(path, "level")); err == nil {
+			md.Level = val
+		} else {
+			return mdraids, err
+		}
+
+		// Array state can be one of: clear, inactive, readonly, read-auto, clean, active,
+		// write-pending, active-idle.
+		if val, err := util.SysReadFile(filepath.Join(path, "array_state")); err == nil {
+			md.ArrayState = val
+		} else {
+			return mdraids, err
+		}
+
+		if val, err := util.SysReadFile(filepath.Join(path, "metadata_version")); err == nil {
+			md.MetadataVersion = val
+		} else {
+			return mdraids, err
+		}
+
+		if val, err := util.ReadUintFromFile(filepath.Join(path, "raid_disks")); err == nil {
+			md.Disks = val
+		} else {
+			return mdraids, err
+		}
+
+		if val, err := util.SysReadFile(filepath.Join(path, "uuid")); err == nil {
+			md.UUID = val
+		} else {
+			return mdraids, err
+		}
+
+		if devs, err := filepath.Glob(filepath.Join(path, "dev-*")); err == nil {
+			for _, dev := range devs {
+				comp := MdraidComponent{Device: strings.TrimPrefix(filepath.Base(dev), "dev-")}
+
+				// Component state can be a comma-separated list of: faulty, in_sync, writemostly,
+				// blocked, spare, write_error, want_replacement, replacement.
+				if val, err := util.SysReadFile(filepath.Join(dev, "state")); err == nil {
+					comp.State = val
+				} else {
+					return mdraids, err
+				}
+
+				md.Components = append(md.Components, comp)
+			}
+		} else {
+			return mdraids, err
+		}
+
+		switch md.Level {
+		case "raid0", "raid4", "raid5", "raid6", "raid10":
+			if val, err := util.ReadUintFromFile(filepath.Join(path, "chunk_size")); err == nil {
+				md.ChunkSize = val
+			} else {
+				return mdraids, err
+			}
+		}
+
+		switch md.Level {
+		case "raid1", "raid4", "raid5", "raid6", "raid10":
+			if val, err := util.ReadUintFromFile(filepath.Join(path, "degraded")); err == nil {
+				md.DegradedDisks = val
+			} else {
+				return mdraids, err
+			}
+
+			// Array sync action can be one of: resync, recover, idle, check, repair.
+			if val, err := util.SysReadFile(filepath.Join(path, "sync_action")); err == nil {
+				md.SyncAction = val
+			} else {
+				return mdraids, err
+			}
+
+			if val, err := util.SysReadFile(filepath.Join(path, "sync_completed")); err == nil {
+				if val != "none" {
+					var a, b uint64
+
+					// File contains two values representing the fraction of number of completed
+					// sectors divided by number of total sectors to process.
+					if _, err := fmt.Sscanf(val, "%d / %d", &a, &b); err == nil {
+						md.SyncCompleted = float64(a) / float64(b)
+					} else {
+						return mdraids, err
+					}
+				}
+			} else {
+				return mdraids, err
+			}
+		}
+
+		mdraids = append(mdraids, md)
+	}
+
+	return mdraids, nil
+}

--- a/sysfs/mdraid_test.go
+++ b/sysfs/mdraid_test.go
@@ -1,0 +1,134 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package sysfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMdraidStats(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.Mdraids()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []Mdraid{
+		{
+			Device:          "md0",
+			Level:           "raid0",
+			ArrayState:      "clean",
+			MetadataVersion: "1.2",
+			Disks:           2,
+			Components: []MdraidComponent{
+				{Device: "sdg", State: "in_sync"},
+				{Device: "sdh", State: "in_sync"},
+			},
+			UUID:      "155f29ff-1716-4107-b362-52307ef86cac",
+			ChunkSize: 524288,
+		},
+		{
+			Device:          "md1",
+			Level:           "raid1",
+			ArrayState:      "clean",
+			MetadataVersion: "1.2",
+			Disks:           2,
+			Components: []MdraidComponent{
+				{Device: "sdi", State: "in_sync"},
+				{Device: "sdj", State: "in_sync"},
+			},
+			UUID:       "0fbf5f2c-add2-43c2-bd78-a4be3ab709ef",
+			SyncAction: "idle",
+		},
+		{
+			Device:          "md10",
+			Level:           "raid10",
+			ArrayState:      "clean",
+			MetadataVersion: "1.2",
+			Disks:           4,
+			Components: []MdraidComponent{
+				{Device: "sdu", State: "in_sync"},
+				{Device: "sdv", State: "in_sync"},
+				{Device: "sdw", State: "in_sync"},
+				{Device: "sdx", State: "in_sync"},
+			},
+			UUID:       "0c15f7e7-b159-4b1f-a5cd-a79b5c04b6f5",
+			ChunkSize:  524288,
+			SyncAction: "idle",
+		},
+		{
+			Device:          "md4",
+			Level:           "raid4",
+			ArrayState:      "clean",
+			MetadataVersion: "1.2",
+			Disks:           3,
+			Components: []MdraidComponent{
+				{Device: "sdk", State: "in_sync"},
+				{Device: "sdl", State: "in_sync"},
+				{Device: "sdm", State: "in_sync"},
+			},
+			UUID:       "67f415d5-2c0c-4b69-8e0d-7e20ef553457",
+			ChunkSize:  524288,
+			SyncAction: "idle",
+		},
+		{
+			Device:          "md5",
+			Level:           "raid5",
+			ArrayState:      "clean",
+			MetadataVersion: "1.2",
+			Disks:           3,
+			Components: []MdraidComponent{
+				{Device: "sdaa", State: "spare"},
+				{Device: "sdn", State: "in_sync"},
+				{Device: "sdo", State: "in_sync"},
+				{Device: "sdp", State: "faulty"},
+			},
+			UUID:          "7615b98d-f2ba-4d99-bee8-6202d8e130b9",
+			ChunkSize:     524288,
+			DegradedDisks: 1,
+			SyncAction:    "idle",
+		},
+		{
+			Device:          "md6",
+			Level:           "raid6",
+			ArrayState:      "active",
+			MetadataVersion: "1.2",
+			Disks:           4,
+			Components: []MdraidComponent{
+				{Device: "sdq", State: "in_sync"},
+				{Device: "sdr", State: "in_sync"},
+				{Device: "sds", State: "in_sync"},
+				{Device: "sdt", State: "spare"},
+			},
+			UUID:          "5f529b25-6efd-46e4-99a2-31f6f597be6b",
+			ChunkSize:     524288,
+			DegradedDisks: 1,
+			SyncAction:    "recover",
+			SyncCompleted: 0.7500458659491194,
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected Mdraid (-want +got):\n%s", diff)
+	}
+}

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -3587,6 +3587,503 @@ Lines: 1
 6447303        0 710266738  1529043   953216        0 31201176  4557464        0   796160  6088971
 Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md0
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md0/md
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/array_state
+Lines: 1
+clean
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/chunk_size
+Lines: 1
+524288
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md0/md/dev-sdg
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/dev-sdg/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md0/md/dev-sdh
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/dev-sdh/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/level
+Lines: 1
+raid0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/metadata_version
+Lines: 1
+1.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/raid_disks
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/rd0
+SymlinkTo: dev-sdg
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/rd1
+SymlinkTo: dev-sdh
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md0/md/uuid
+Lines: 1
+155f29ff-1716-4107-b362-52307ef86cac
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md1
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md1/md
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/array_state
+Lines: 1
+clean
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/chunk_size
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/degraded
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md1/md/dev-sdi
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/dev-sdi/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md1/md/dev-sdj
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/dev-sdj/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/level
+Lines: 1
+raid1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/metadata_version
+Lines: 1
+1.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/raid_disks
+Lines: 1
+2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/rd0
+SymlinkTo: dev-sdi
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/rd1
+SymlinkTo: dev-sdj
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/sync_action
+Lines: 1
+idle
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/sync_completed
+Lines: 1
+none
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md1/md/uuid
+Lines: 1
+0fbf5f2c-add2-43c2-bd78-a4be3ab709ef
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md10
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md10/md
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/array_state
+Lines: 1
+clean
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/chunk_size
+Lines: 1
+524288
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/degraded
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md10/md/dev-sdu
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/dev-sdu/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md10/md/dev-sdv
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/dev-sdv/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md10/md/dev-sdw
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/dev-sdw/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md10/md/dev-sdx
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/dev-sdx/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/level
+Lines: 1
+raid10
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/metadata_version
+Lines: 1
+1.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/raid_disks
+Lines: 1
+4
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/rd0
+SymlinkTo: dev-sdu
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/rd1
+SymlinkTo: dev-sdv
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/rd2
+SymlinkTo: dev-sdw
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/rd3
+SymlinkTo: dev-sdx
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/sync_action
+Lines: 1
+idle
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/sync_completed
+Lines: 1
+none
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md10/md/uuid
+Lines: 1
+0c15f7e7-b159-4b1f-a5cd-a79b5c04b6f5
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md4
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md4/md
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/array_state
+Lines: 1
+clean
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/chunk_size
+Lines: 1
+524288
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/degraded
+Lines: 1
+0
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md4/md/dev-sdk
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/dev-sdk/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md4/md/dev-sdl
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/dev-sdl/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md4/md/dev-sdm
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/dev-sdm/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/level
+Lines: 1
+raid4
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/metadata_version
+Lines: 1
+1.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/raid_disks
+Lines: 1
+3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/rd0
+SymlinkTo: dev-sdk
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/rd1
+SymlinkTo: dev-sdl
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/rd2
+SymlinkTo: dev-sdm
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/sync_action
+Lines: 1
+idle
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/sync_completed
+Lines: 1
+none
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md4/md/uuid
+Lines: 1
+67f415d5-2c0c-4b69-8e0d-7e20ef553457
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md5
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md5/md
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/array_state
+Lines: 1
+clean
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/chunk_size
+Lines: 1
+524288
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/degraded
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md5/md/dev-sdaa
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/dev-sdaa/state
+Lines: 1
+spare
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md5/md/dev-sdn
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/dev-sdn/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md5/md/dev-sdo
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/dev-sdo/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md5/md/dev-sdp
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/dev-sdp/state
+Lines: 1
+faulty
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/level
+Lines: 1
+raid5
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/metadata_version
+Lines: 1
+1.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/raid_disks
+Lines: 1
+3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/rd0
+SymlinkTo: dev-sdn
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/rd1
+SymlinkTo: dev-sdo
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/rd2
+SymlinkTo: dev-sdp
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/sync_action
+Lines: 1
+idle
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/sync_completed
+Lines: 1
+none
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md5/md/uuid
+Lines: 1
+7615b98d-f2ba-4d99-bee8-6202d8e130b9
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md6
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md6/md
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/array_state
+Lines: 1
+active
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/chunk_size
+Lines: 1
+524288
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/degraded
+Lines: 1
+1
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md6/md/dev-sdq
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/dev-sdq/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md6/md/dev-sdr
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/dev-sdr/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md6/md/dev-sds
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/dev-sds/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/block/md6/md/dev-sdt
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/dev-sdt/state
+Lines: 1
+spare
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/level
+Lines: 1
+raid6
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/metadata_version
+Lines: 1
+1.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/raid_disks
+Lines: 1
+4
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/rd0
+SymlinkTo: dev-sdq
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/rd1
+SymlinkTo: dev-sdr
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/rd2
+SymlinkTo: dev-sds
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/rd3
+SymlinkTo: dev-sdt
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/sync_action
+Lines: 1
+recover
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/sync_completed
+Lines: 1
+1569888 / 2093056
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/md6/md/uuid
+Lines: 1
+5f529b25-6efd-46e4-99a2-31f6f597be6b
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/block/sda
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Modernised method of fetching mdraid statistics via machine-readable sysfs entries, instead of parsing human-readable `/proc/mdstat`.

This would go a long way towards addressing https://github.com/prometheus/node_exporter/issues/1085, as well as superseding / obsoleting various other pending PRs (#329) that attempt to squeeze a bit more info out of `/proc/mdstat` and issues, e.g., https://github.com/prometheus/node_exporter/issues/1874

The mdraid sysfs entries contain significantly more detailed information that what is presented in the simplified and human-readable `/proc/mdstat`.

I'd like to get a few more eyeballs on this code, and have it alongside the existing /proc/mdstat parser initially, with a view to perhaps making the `MDStat` function a wrapper around the new sysfs parser eventually (or refactor node_exporter to use the new function directly). Existing `MDStat` members ActivityState, DisksDown, DisksFailed, DisksSpare, DisksTotal, DisksActive can be derived / counted / calculated from information exposed by the new `Mdraid` struct.

_Some_ of the `MDStat` struct information is not exposed directly by `/sys/block/md*/md`, however it is obtainable via other means. For example:
- BlocksTotal - this is technically redundant, since it is just the md block device size in KiB. This should be implemented generically for _all_ block device types, i.e., by exposing `/sys/block/*/size` (measured in 512-byte sectors - yes, even on 4K sector drives).
- BlocksSynced - sysfs will only expose this _whilst an array is resyncing / recovering_ (or checking). Otherwise, it is to be assumed that all blocks are in sync.

Other `MDStat` struct members which are **not** currently used by node_exporter:
- BlocksSyncedPct - superseded by SyncCompleted, which is a fraction (0-1) representing the completion status of current sync operation.
- BlocksSyncedSpeed - no equivalent in sysfs, however this could be calculated in promql with the `rate()` function.
- BlocksSyncedFinishTime - no equivalent in sysfs, however this could be calculated in promql by dividing the remaining blocks to sync by the sync speed.

@SuperQ I would greatly appreciate your review / input on this.