### PR TITLE
Refactor netstat parsing

### DIFF
--- a/netstat.go
+++ b/netstat.go
@@ -15,7 +15,6 @@ package procfs
 
 import (
 	"bufio"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -38,13 +37,7 @@ func (fs FS) NetStat() ([]NetStat, error) {
 	var netStatsTotal []NetStat
 
 	for _, filePath := range statFiles {
-		file, err := os.Open(filePath)
-		if err != nil {
-			return nil, err
-		}
-		defer file.Close()
-
-		procNetstat, err := parseNetstat(file)
+		procNetstat, err := parseNetstat(filePath)
 		if err != nil {
 			return nil, err
 		}
@@ -57,14 +50,17 @@ func (fs FS) NetStat() ([]NetStat, error) {
 
 // parseNetstat parses the metrics from `/proc/net/stat/` file
 // and returns a NetStat structure.
-func parseNetstat(r io.Reader) (NetStat, error) {
-	var (
-		scanner = bufio.NewScanner(r)
-		netStat = NetStat{
-			Stats: make(map[string][]uint64),
-		}
-	)
+func parseNetstat(filePath string) (NetStat, error) {
+	netStat := NetStat{
+		Stats: make(map[string][]uint64),
+	}
+	file, err := os.Open(filePath)
+	if err != nil {
+		return netStat, err
+	}
+	defer file.Close()
 
+	scanner := bufio.NewScanner(file)
 	scanner.Scan()
 
 	// First string is always a header for stats


### PR DESCRIPTION
Move the file hadling into the parseNetstat() function to only open one file at a time. This eliminates keeping all files open until all are read.