### PR TITLE
Fix softnet CPU Index

### DIFF
--- a/net_softnet.go
+++ b/net_softnet.go
@@ -76,6 +76,7 @@ func parseSoftnet(r io.Reader) ([]SoftnetStat, error) {
 	s := bufio.NewScanner(r)
 
 	var stats []SoftnetStat
+	cpuIndex := 0
 	for s.Scan() {
 		columns := strings.Fields(s.Text())
 		width := len(columns)
@@ -127,9 +128,13 @@ func parseSoftnet(r io.Reader) ([]SoftnetStat, error) {
 
 			softnetStat.SoftnetBacklogLen = us[0]
 			softnetStat.Index = us[1]
+		} else {
+			// For older kernels, create the Index based on the scan line number.
+			softnetStat.Index = uint32(cpuIndex)
 		}
 		softnetStat.Width = width
 		stats = append(stats, softnetStat)
+		cpuIndex++
 	}
 
 	return stats, nil

--- a/net_softnet_test.go
+++ b/net_softnet_test.go
@@ -55,6 +55,7 @@ func TestNetSoftnet(t *testing.T) {
 			CPUCollision:   0x00000004,
 			ReceivedRps:    0x00000003,
 			FlowLimitCount: 0x00000002,
+			Index:          0x00000002,
 			Width:          11,
 		},
 		{
@@ -62,6 +63,7 @@ func TestNetSoftnet(t *testing.T) {
 			Dropped:      0x00000000,
 			TimeSqueezed: 0x0109a4,
 			CPUCollision: 0x00020e76,
+			Index:        0x00000003,
 			Width:        9,
 		},
 		{
@@ -70,6 +72,7 @@ func TestNetSoftnet(t *testing.T) {
 			TimeSqueezed: 0x00000011,
 			CPUCollision: 0x00000020,
 			ReceivedRps:  0x00000010,
+			Index:        0x00000004,
 			Width:        10,
 		},
 	}


### PR DESCRIPTION
When parsing older kernel versoins, we assume the CPU is indexed based on the parsed line, rather than an explicit index column.