### PR TITLE
fs: Statfs_t{} doesn't have a Type field on NetBSD, OpenBSD, or Solaris

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -14,8 +14,6 @@
 package procfs
 
 import (
-	"syscall"
-
 	"github.com/prometheus/procfs/internal/fs"
 )
 
@@ -49,16 +47,4 @@ func NewFS(mountPoint string) (FS, error) {
 	}
 
 	return FS{fs, real}, nil
-}
-
-// isRealProc determines whether supplied mountpoint is really a proc filesystem.
-func isRealProc(mountPoint string) (bool, error) {
-	stat := syscall.Statfs_t{}
-	err := syscall.Statfs(mountPoint, &stat)
-	if err != nil {
-		return false, err
-	}
-
-	// 0x9fa0 is PROC_SUPER_MAGIC: https://elixir.bootlin.com/linux/v6.1/source/include/uapi/linux/magic.h#L87
-	return stat.Type == 0x9fa0, nil
 }

--- a/fs_statfs_notype.go
+++ b/fs_statfs_notype.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build netbsd || openbsd || solaris
+// +build netbsd openbsd solaris
+
+package procfs
+
+// isRealProc returns true on architectures that don't have a Type argument
+// in their Statfs_t struct
+func isRealProc(mountPoint string) (bool, error) {
+	return true, nil
+}

--- a/fs_statfs_type.go
+++ b/fs_statfs_type.go
@@ -1,0 +1,33 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !netbsd && !openbsd && !solaris
+// +build !netbsd,!openbsd,!solaris
+
+package procfs
+
+import (
+	"syscall"
+)
+
+// isRealProc determines whether supplied mountpoint is really a proc filesystem.
+func isRealProc(mountPoint string) (bool, error) {
+	stat := syscall.Statfs_t{}
+	err := syscall.Statfs(mountPoint, &stat)
+	if err != nil {
+		return false, err
+	}
+
+	// 0x9fa0 is PROC_SUPER_MAGIC: https://elixir.bootlin.com/linux/v6.1/source/include/uapi/linux/magic.h#L87
+	return stat.Type == 0x9fa0, nil
+}


### PR DESCRIPTION
Other projects that import procfs, like node_exporter, apparently build for OSs that don't have Statfs_t.Type.

Leads to errors like (for node_exporter):

```
/go/bin/promu --config .promu.yml build --prefix .build/openbsd-amd64 
 >   node_exporter
# github.com/prometheus/procfs
/go/pkg/mod/github.com/prometheus/procfs@v0.9.1-0.20230517120836-7acd99d0499a/fs.go:63:14: stat.Type undefined (type syscall.Statfs_t has no field or method Type)
!! command failed: build -o .build/openbsd-amd64/node_exporter -ldflags -X github.com/prometheus/common/version.Version=1.5.0 -X github.com/prometheus/common/version.Revision=849b6076b81bf64249b4f75e0c3134d25a1da9a3 -X github.com/prometheus/common/version.Branch=pull/2669 -X github.com/prometheus/common/version.BuildUser=root@d9577d73a62f -X github.com/prometheus/common/version.BuildDate=20230517-20:49:53  -extldflags '-static' -a -tags 'netgo osusergo static_build' github.com/prometheus/node_exporter: exit status 1
```