### PR TITLE
Add read-only token permissions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,9 @@ on:
       - ".golangci.yml"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
Fixes prometheus/prometheus#12379.

This PR adds read-only token permissions to the golangci-lint.yml workflow to protect the project from supply-chain attacks. See the linked issue for details.