### PR TITLE
fs: syscall.Statfs_t object doesn't have a Type field on Windows

### DIFF
--- a/fs_statfs_notype.go
+++ b/fs_statfs_notype.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build netbsd || openbsd || solaris
-// +build netbsd openbsd solaris
+//go:build netbsd || openbsd || solaris || windows
+// +build netbsd openbsd solaris windows
 
 package procfs
 

--- a/fs_statfs_type.go
+++ b/fs_statfs_type.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !netbsd && !openbsd && !solaris
-// +build !netbsd,!openbsd,!solaris
+//go:build !netbsd && !openbsd && !solaris && !windows
+// +build !netbsd,!openbsd,!solaris,!windows
 
 package procfs
 


### PR DESCRIPTION
## fs: syscall.Statfs_t object doesn't have a Type field on Windows

Fixes build for `GOOS=windows` (https://github.com/prometheus/procfs/issues/527)

This PR extends the solution from https://github.com/prometheus/procfs/pull/523 to include windows in the list of OSes for which the `syscall.Statfs_t` object does not have a `Type` field

## Testing:

### Before:

```
✔ ~/go/src/github.com/adrianosela/procfs [master|✔]
11:22 $ GOOS=windows GOARCH=amd64 go build
# github.com/prometheus/procfs
./fs_statfs_type.go:25:18: undefined: syscall.Statfs_t
./fs_statfs_type.go:26:17: undefined: syscall.Statfs
```

### After:

```
✔ ~/go/src/github.com/adrianosela/procfs [master|✔]
11:24 $ GOOS=windows GOARCH=amd64 go build
✔ ~/go/src/github.com/adrianosela/procfs [master|✔]
```
