### PR TITLE
Fix CPUVulnerabilities() reporting from sysfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ ensure the `fixtures` directory is up to date by removing the existing directory
 extracting the ttar file using `make fixtures/.unpacked` or just `make test`.
 
 ```bash
-rm -rf fixtures
+rm -rf testdata/fixtures
 make test
 ```
 
 Next, make the required changes to the extracted files in the `fixtures` directory.  When
 the changes are complete, run `make update_fixtures` to create a new `fixtures.ttar` file
 based on the updated `fixtures` directory.  And finally, verify the changes using
-`git diff fixtures.ttar`.
+`git diff testdata/fixtures.ttar`.

--- a/sysfs/vulnerability.go
+++ b/sysfs/vulnerability.go
@@ -81,29 +81,24 @@ func parseVulnerability(name, rawContent string) (*Vulnerability, error) {
 	v := &Vulnerability{CodeName: name}
 	rawContent = strings.TrimSpace(rawContent)
 	rawContentLower := strings.ToLower(rawContent)
-
-	if strings.HasPrefix(rawContentLower, notAffected) {
+	switch {
+	case strings.HasPrefix(rawContentLower, notAffected):
 		v.State = VulnerabilityStateNotAffected
-		return v, nil
-	}
-
-	if strings.HasPrefix(rawContentLower, vulnerable) {
+	case strings.HasPrefix(rawContentLower, vulnerable):
 		v.State = VulnerabilityStateVulnerable
 		m := strings.Fields(rawContent)
 		if len(m) > 1 {
 			v.Mitigation = strings.Join(m[1:], " ")
 		}
-		return v, nil
-	}
-
-	if strings.HasPrefix(rawContentLower, mitigation) {
+	case strings.HasPrefix(rawContentLower, mitigation):
 		v.State = VulnerabilityStateMitigation
 		m := strings.Fields(rawContent)
 		if len(m) > 1 {
 			v.Mitigation = strings.Join(m[1:], " ")
 		}
-		return v, nil
-	}
+	default:
+		return nil, fmt.Errorf("unknown vulnerability state for %s: %s", name, rawContent)
 
-	return nil, fmt.Errorf("unknown vulnerability state for %s: %s", name, rawContent)
+	}
+	return v, nil
 }

--- a/sysfs/vulnerability.go
+++ b/sysfs/vulnerability.go
@@ -36,6 +36,8 @@ const (
 )
 
 var (
+	// VulnerabilityHumanEncoding allows mapping the vulnerability state (encoded as an int) onto a human friendly
+	// string. It can be used by consumers of this library to expose to the user the state of the vulnerability.
 	VulnerabilityHumanEncoding = map[int]string{
 		VulnerabilityStateNotAffected: notAffected,
 		VulnerabilityStateVulnerable:  vulnerable,

--- a/sysfs/vulnerability.go
+++ b/sysfs/vulnerability.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	notAffected = "Not Affected"
+	notAffected = "Not affected"
 	vulnerable  = "Vulnerable"
 	mitigation  = "Mitigation"
 )

--- a/sysfs/vulnerability.go
+++ b/sysfs/vulnerability.go
@@ -24,33 +24,33 @@ import (
 )
 
 const (
-	notAffected = "Not affected"
+	notAffected = "Not affected" // based on: https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
 	vulnerable  = "Vulnerable"
 	mitigation  = "Mitigation"
 )
 
 // CPUVulnerabilities retrieves a map of vulnerability names to their mitigations.
-func (fs FS) CPUVulnerabilities() ([]Vulnerability, error) {
-	matches, err := filepath.Glob(fs.sys.Path("devices/system/cpu/vulnerabilities/*"))
+func (fs FS) CPUVulnerabilities() (map[string]*Vulnerability, error) {
+	matchingFilepaths, err := filepath.Glob(fs.sys.Path("devices/system/cpu/vulnerabilities/*"))
 	if err != nil {
 		return nil, err
 	}
 
-	vulnerabilities := make([]Vulnerability, 0, len(matches))
-	for _, match := range matches {
-		name := filepath.Base(match)
+	vulnerabilities := make(map[string]*Vulnerability, len(matchingFilepaths))
+	for _, path := range matchingFilepaths {
+		filename := filepath.Base(path)
 
-		value, err := os.ReadFile(match)
+		rawContent, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
 
-		v, err := parseVulnerability(name, string(value))
+		v, err := parseVulnerability(filename, string(rawContent))
 		if err != nil {
 			return nil, err
 		}
 
-		vulnerabilities = append(vulnerabilities, v)
+		vulnerabilities[filename] = v
 	}
 
 	return vulnerabilities, nil
@@ -63,8 +63,8 @@ type Vulnerability struct {
 	Mitigation string
 }
 
-func parseVulnerability(name, value string) (Vulnerability, error) {
-	v := Vulnerability{CodeName: name}
+func parseVulnerability(name, value string) (*Vulnerability, error) {
+	v := &Vulnerability{CodeName: name}
 	value = strings.TrimSpace(value)
 	if value == notAffected {
 		v.State = notAffected
@@ -83,5 +83,5 @@ func parseVulnerability(name, value string) (Vulnerability, error) {
 		return v, nil
 	}
 
-	return v, fmt.Errorf("unknown vulnerability state for %s: %s", name, value)
+	return nil, fmt.Errorf("unknown vulnerability state for %s: %s", name, value)
 }

--- a/sysfs/vulnerability.go
+++ b/sysfs/vulnerability.go
@@ -29,6 +29,20 @@ const (
 	mitigation  = "Mitigation"
 )
 
+const (
+	VulnerabilityStateNotAffected = iota
+	VulnerabilityStateVulnerable
+	VulnerabilityStateMitigation
+)
+
+var (
+	VulnerabilityHumanEncoding = map[int]string{
+		VulnerabilityStateNotAffected: notAffected,
+		VulnerabilityStateVulnerable:  vulnerable,
+		VulnerabilityStateMitigation:  mitigation,
+	}
+)
+
 // CPUVulnerabilities retrieves a map of vulnerability names to their mitigations.
 func (fs FS) CPUVulnerabilities() (map[string]*Vulnerability, error) {
 	matchingFilepaths, err := filepath.Glob(fs.sys.Path("devices/system/cpu/vulnerabilities/*"))
@@ -59,29 +73,29 @@ func (fs FS) CPUVulnerabilities() (map[string]*Vulnerability, error) {
 // Vulnerability represents a single vulnerability extracted from /sys/devices/system/cpu/vulnerabilities/.
 type Vulnerability struct {
 	CodeName   string
-	State      string
+	State      int
 	Mitigation string
 }
 
-func parseVulnerability(name, value string) (*Vulnerability, error) {
+func parseVulnerability(name, rawContent string) (*Vulnerability, error) {
 	v := &Vulnerability{CodeName: name}
-	value = strings.TrimSpace(value)
-	if value == notAffected {
-		v.State = notAffected
+	rawContent = strings.TrimSpace(rawContent)
+	if rawContent == notAffected {
+		v.State = VulnerabilityStateNotAffected
 		return v, nil
 	}
 
-	if strings.HasPrefix(value, vulnerable) {
-		v.State = vulnerable
-		v.Mitigation = strings.TrimPrefix(strings.TrimPrefix(value, vulnerable), ": ")
+	if strings.HasPrefix(rawContent, vulnerable) {
+		v.State = VulnerabilityStateVulnerable
+		v.Mitigation = strings.TrimPrefix(strings.TrimPrefix(rawContent, vulnerable), ": ")
 		return v, nil
 	}
 
-	if strings.HasPrefix(value, mitigation) {
-		v.State = mitigation
-		v.Mitigation = strings.TrimPrefix(strings.TrimPrefix(value, mitigation), ": ")
+	if strings.HasPrefix(rawContent, mitigation) {
+		v.State = VulnerabilityStateMitigation
+		v.Mitigation = strings.TrimPrefix(strings.TrimPrefix(rawContent, mitigation), ": ")
 		return v, nil
 	}
 
-	return nil, fmt.Errorf("unknown vulnerability state for %s: %s", name, value)
+	return nil, fmt.Errorf("unknown vulnerability state for %s: %s", name, rawContent)
 }

--- a/sysfs/vulnerability.go
+++ b/sysfs/vulnerability.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	notAffected = "Not affected" // based on: https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
-	vulnerable  = "Vulnerable"
-	mitigation  = "Mitigation"
+	notAffected = "not affected" // based on: https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
+	vulnerable  = "vulnerable"
+	mitigation  = "mitigation"
 )
 
 const (
@@ -80,20 +80,28 @@ type Vulnerability struct {
 func parseVulnerability(name, rawContent string) (*Vulnerability, error) {
 	v := &Vulnerability{CodeName: name}
 	rawContent = strings.TrimSpace(rawContent)
-	if rawContent == notAffected {
+	rawContentLower := strings.ToLower(rawContent)
+
+	if strings.HasPrefix(rawContentLower, notAffected) {
 		v.State = VulnerabilityStateNotAffected
 		return v, nil
 	}
 
-	if strings.HasPrefix(rawContent, vulnerable) {
+	if strings.HasPrefix(rawContentLower, vulnerable) {
 		v.State = VulnerabilityStateVulnerable
-		v.Mitigation = strings.TrimPrefix(strings.TrimPrefix(rawContent, vulnerable), ": ")
+		m := strings.Fields(rawContent)
+		if len(m) > 1 {
+			v.Mitigation = strings.Join(m[1:], " ")
+		}
 		return v, nil
 	}
 
-	if strings.HasPrefix(rawContent, mitigation) {
+	if strings.HasPrefix(rawContentLower, mitigation) {
 		v.State = VulnerabilityStateMitigation
-		v.Mitigation = strings.TrimPrefix(strings.TrimPrefix(rawContent, mitigation), ": ")
+		m := strings.Fields(rawContent)
+		if len(m) > 1 {
+			v.Mitigation = strings.Join(m[1:], " ")
+		}
 		return v, nil
 	}
 

--- a/sysfs/vulnerability_test.go
+++ b/sysfs/vulnerability_test.go
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
+// +build linux
+
 package sysfs
 
 import (

--- a/sysfs/vulnerability_test.go
+++ b/sysfs/vulnerability_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Prometheus Authors
+// Copyright 2023 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/sysfs/vulnerability_test.go
+++ b/sysfs/vulnerability_test.go
@@ -1,6 +1,7 @@
 package sysfs
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -8,32 +9,34 @@ import (
 func TestFS_CPUVulnerabilities(t *testing.T) {
 	sysFs, err := NewFS(sysTestFixtures)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal(fmt.Errorf("failed to get sysfs FS: %w", err))
+	}
+	got, err := sysFs.CPUVulnerabilities()
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to parse sysfs vulnerabilities files: %w", err))
 	}
 
 	tests := []struct {
-		name    string
-		want    []Vulnerability
-		wantErr bool
+		name              string
+		vulnerabilityName string
+		want              *Vulnerability
+		wantErr           bool
 	}{
-		{"TestFS_CPUVulnerabilities", []Vulnerability{
-			{CodeName: "itlb_multihit", State: "Not affected", Mitigation: ""},
-			{CodeName: "retbleed", State: "Mitigation", Mitigation: "untrained return thunk; SMT enabled with STIBP protection"},
-			{CodeName: "spec_store_bypass", State: "Mitigation", Mitigation: "Speculative Store Bypass disabled via prctl"},
-			{CodeName: "spectre_v1", State: "Mitigation", Mitigation: "usercopy/swapgs barriers and __user pointer sanitization"},
-			{CodeName: "spectre_v2", State: "Mitigation", Mitigation: "Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected"},
-			{CodeName: "tsx_async_abort", State: "Not affected", Mitigation: ""},
-		}, false},
+		{"Not affected", "itlb_multihit", &Vulnerability{CodeName: "itlb_multihit", State: notAffected, Mitigation: ""}, false},
+		{"Not affected with underscores", "tsx_async_abort", &Vulnerability{CodeName: "tsx_async_abort", State: notAffected, Mitigation: ""}, false},
+		{"Mitigation simple string", "spec_store_bypass", &Vulnerability{CodeName: "spec_store_bypass", State: mitigation, Mitigation: "Speculative Store Bypass disabled via prctl"}, false},
+		{"Mitigation special chars", "retbleed", &Vulnerability{CodeName: "retbleed", State: mitigation, Mitigation: "untrained return thunk; SMT enabled with STIBP protection"}, false},
+		{"Mitigation more special chars", "spectre_v1", &Vulnerability{CodeName: "spectre_v1", State: mitigation, Mitigation: "usercopy/swapgs barriers and __user pointer sanitization"}, false},
+		{"Mitigation with multiple subsections", "spectre_v2", &Vulnerability{CodeName: "spectre_v2", State: mitigation, Mitigation: "Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := sysFs.CPUVulnerabilities()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CPUVulnerabilities() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			gotVulnerability, ok := got[tt.vulnerabilityName]
+			if !ok && !tt.wantErr {
+				t.Errorf("CPUVulnerabilities() vulnerability %s not found", tt.vulnerabilityName)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CPUVulnerabilities() got = %v, want %v", got, tt.want)
+			if !reflect.DeepEqual(gotVulnerability, tt.want) {
+				t.Errorf("CPUVulnerabilities() gotVulnerability = %v, want %v", gotVulnerability, tt.want)
 			}
 		})
 	}

--- a/sysfs/vulnerability_test.go
+++ b/sysfs/vulnerability_test.go
@@ -22,12 +22,12 @@ func TestFS_CPUVulnerabilities(t *testing.T) {
 		want              *Vulnerability
 		wantErr           bool
 	}{
-		{"Not affected", "itlb_multihit", &Vulnerability{CodeName: "itlb_multihit", State: notAffected, Mitigation: ""}, false},
-		{"Not affected with underscores", "tsx_async_abort", &Vulnerability{CodeName: "tsx_async_abort", State: notAffected, Mitigation: ""}, false},
-		{"Mitigation simple string", "spec_store_bypass", &Vulnerability{CodeName: "spec_store_bypass", State: mitigation, Mitigation: "Speculative Store Bypass disabled via prctl"}, false},
-		{"Mitigation special chars", "retbleed", &Vulnerability{CodeName: "retbleed", State: mitigation, Mitigation: "untrained return thunk; SMT enabled with STIBP protection"}, false},
-		{"Mitigation more special chars", "spectre_v1", &Vulnerability{CodeName: "spectre_v1", State: mitigation, Mitigation: "usercopy/swapgs barriers and __user pointer sanitization"}, false},
-		{"Mitigation with multiple subsections", "spectre_v2", &Vulnerability{CodeName: "spectre_v2", State: mitigation, Mitigation: "Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected"}, false},
+		{"Not affected", "itlb_multihit", &Vulnerability{CodeName: "itlb_multihit", State: VulnerabilityStateNotAffected, Mitigation: ""}, false},
+		{"Not affected with underscores", "tsx_async_abort", &Vulnerability{CodeName: "tsx_async_abort", State: VulnerabilityStateNotAffected, Mitigation: ""}, false},
+		{"Mitigation simple string", "spec_store_bypass", &Vulnerability{CodeName: "spec_store_bypass", State: VulnerabilityStateMitigation, Mitigation: "Speculative Store Bypass disabled via prctl"}, false},
+		{"Mitigation special chars", "retbleed", &Vulnerability{CodeName: "retbleed", State: VulnerabilityStateMitigation, Mitigation: "untrained return thunk; SMT enabled with STIBP protection"}, false},
+		{"Mitigation more special chars", "spectre_v1", &Vulnerability{CodeName: "spectre_v1", State: VulnerabilityStateMitigation, Mitigation: "usercopy/swapgs barriers and __user pointer sanitization"}, false},
+		{"Mitigation with multiple subsections", "spectre_v2", &Vulnerability{CodeName: "spectre_v2", State: VulnerabilityStateMitigation, Mitigation: "Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sysfs/vulnerability_test.go
+++ b/sysfs/vulnerability_test.go
@@ -1,3 +1,16 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sysfs
 
 import (

--- a/sysfs/vulnerability_test.go
+++ b/sysfs/vulnerability_test.go
@@ -44,6 +44,8 @@ func TestFS_CPUVulnerabilities(t *testing.T) {
 		{"Mitigation special chars", "retbleed", &Vulnerability{CodeName: "retbleed", State: VulnerabilityStateMitigation, Mitigation: "untrained return thunk; SMT enabled with STIBP protection"}, false},
 		{"Mitigation more special chars", "spectre_v1", &Vulnerability{CodeName: "spectre_v1", State: VulnerabilityStateMitigation, Mitigation: "usercopy/swapgs barriers and __user pointer sanitization"}, false},
 		{"Mitigation with multiple subsections", "spectre_v2", &Vulnerability{CodeName: "spectre_v2", State: VulnerabilityStateMitigation, Mitigation: "Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected"}, false},
+		{"Vulnerable", "mds", &Vulnerability{CodeName: "mds", State: VulnerabilityStateVulnerable, Mitigation: ""}, false},
+		{"Vulnerable with mitigation available", "mmio_stale_data", &Vulnerability{CodeName: "mmio_stale_data", State: VulnerabilityStateVulnerable, Mitigation: "Clear CPU buffers attempted, no microcode"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sysfs/vulnerability_test.go
+++ b/sysfs/vulnerability_test.go
@@ -1,0 +1,40 @@
+package sysfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFS_CPUVulnerabilities(t *testing.T) {
+	sysFs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		want    []Vulnerability
+		wantErr bool
+	}{
+		{"TestFS_CPUVulnerabilities", []Vulnerability{
+			{CodeName: "itlb_multihit", State: "Not affected", Mitigation: ""},
+			{CodeName: "retbleed", State: "Mitigation", Mitigation: "untrained return thunk; SMT enabled with STIBP protection"},
+			{CodeName: "spec_store_bypass", State: "Mitigation", Mitigation: "Speculative Store Bypass disabled via prctl"},
+			{CodeName: "spectre_v1", State: "Mitigation", Mitigation: "usercopy/swapgs barriers and __user pointer sanitization"},
+			{CodeName: "spectre_v2", State: "Mitigation", Mitigation: "Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected"},
+			{CodeName: "tsx_async_abort", State: "Not affected", Mitigation: ""},
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sysFs.CPUVulnerabilities()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CPUVulnerabilities() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CPUVulnerabilities() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -13242,6 +13242,16 @@ Lines: 1
 Not affected
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/vulnerabilities/mds
+Lines: 1
+Vulnerable
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/vulnerabilities/mmio_stale_data
+Lines: 1
+Vulnerable: Clear CPU buffers attempted, no microcode
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/devices/system/cpu/vulnerabilities/retbleed
 Lines: 1
 Mitigation: untrained return thunk; SMT enabled with STIBP protection

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -13234,6 +13234,39 @@ Lines: 1
 2
 Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/devices/system/cpu/vulnerabilities
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/vulnerabilities/itlb_multihit
+Lines: 1
+Not affected
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/vulnerabilities/retbleed
+Lines: 1
+Mitigation: untrained return thunk; SMT enabled with STIBP protection
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/vulnerabilities/spec_store_bypass
+Lines: 1
+Mitigation: Speculative Store Bypass disabled via prctl
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/vulnerabilities/spectre_v1
+Lines: 1
+Mitigation: usercopy/swapgs barriers and __user pointer sanitization
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/vulnerabilities/spectre_v2
+Lines: 1
+Mitigation: Retpolines, IBPB: conditional, STIBP: always-on, RSB filling, PBRSB-eIBRS: Not affected
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/vulnerabilities/tsx_async_abort
+Lines: 1
+Not affected
+Mode: 444
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/devices/system/node
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
closes #531 

This PR contains a few changes (each in a separate commit):
- adds fixtures and tests for parsing cpu vulnerabilities from sysfs, fixes the typo in the vulnerability string
- switches to using a map of vulnerabilities instead of a slice (makes working with the result easier, e.g. when testing)
- switches to using encoding of the state
- adds license in the test file
- adds linux build flags
- adds test cases for vulnerable state, brings state string to lower cases (to try and make it case insensitive)