### PR TITLE
Bug Fix: Slice out of bound in filterOfflineCpus

### DIFF
--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -35,7 +35,7 @@ func TestCPUTopology(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want, have := 2, len(cpus); want != have {
+	if want, have := 3, len(cpus); want != have {
 		t.Errorf("incorrect number of CPUs, have %v, want %v", want, have)
 	}
 	if want, have := "0", cpus[0].Number(); want != have {
@@ -72,7 +72,7 @@ func TestCPUThermalThrottle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want, have := 2, len(cpus); want != have {
+	if want, have := 3, len(cpus); want != have {
 		t.Errorf("incorrect number of CPUs, have %v, want %v", want, have)
 	}
 	cpu0Throttle, err := cpus[0].ThermalThrottle()

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -13152,6 +13152,9 @@ Lines: 1
 1,5
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/devices/system/cpu/cpu2
+Mode: 775
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/devices/system/cpu/cpufreq
 Mode: 775
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -13228,7 +13231,7 @@ Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/devices/system/cpu/offline
 Lines: 1
-2,12-15
+2
 Mode: 664
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/devices/system/node


### PR DESCRIPTION
Fix for #530

Created a new slice while filtering offline CPUs.