### PR TITLE
Cleanup various linting issues

### DIFF
--- a/btrfs/get.go
+++ b/btrfs/get.go
@@ -207,7 +207,7 @@ func (r *reader) calcRatio(p string) float64 {
 
 // readDeviceInfo returns the information for all devices associated with this filesystem.
 func (r *reader) readDeviceInfo(d string) map[string]*Device {
-	devs := r.listFiles("devices")
+	devs := r.listFiles(d)
 	info := make(map[string]*Device, len(devs))
 	for _, n := range devs {
 		info[n] = &Device{

--- a/fs.go
+++ b/fs.go
@@ -20,8 +20,8 @@ import (
 // FS represents the pseudo-filesystem sys, which provides an interface to
 // kernel data structures.
 type FS struct {
-	proc fs.FS
-	real bool
+	proc   fs.FS
+	isReal bool
 }
 
 // DefaultMountPoint is the common mount point of the proc filesystem.
@@ -41,10 +41,10 @@ func NewFS(mountPoint string) (FS, error) {
 		return FS{}, err
 	}
 
-	real, err := isRealProc(mountPoint)
+	isReal, err := isRealProc(mountPoint)
 	if err != nil {
 		return FS{}, err
 	}
 
-	return FS{fs, real}, nil
+	return FS{fs, isReal}, nil
 }

--- a/iscsi/get.go
+++ b/iscsi/get.go
@@ -195,9 +195,8 @@ func (fs FS) GetRBDMatch(rbdNumber string, poolImage string) (*RBD, error) {
 		bSystemPool, err := os.ReadFile(systemPoolPath)
 		if err != nil {
 			continue
-		} else {
-			systemPool = strings.TrimSpace(string(bSystemPool))
 		}
+		systemPool = strings.TrimSpace(string(bSystemPool))
 
 		systemImagePath := filepath.Join(systemRbdPath, "name")
 		if _, err := os.Stat(systemImagePath); os.IsNotExist(err) {
@@ -206,9 +205,8 @@ func (fs FS) GetRBDMatch(rbdNumber string, poolImage string) (*RBD, error) {
 		bSystemImage, err := os.ReadFile(systemImagePath)
 		if err != nil {
 			continue
-		} else {
-			systemImage = strings.TrimSpace(string(bSystemImage))
 		}
+		systemImage = strings.TrimSpace(string(bSystemImage))
 
 		if strings.Compare(strconv.FormatInt(int64(systemRbdNumber), 10), rbdNumber) == 0 &&
 			matchPoolImage(systemPool, systemImage, poolImage) {

--- a/proc.go
+++ b/proc.go
@@ -244,7 +244,7 @@ func (p Proc) FileDescriptorTargets() ([]string, error) {
 // a process.
 func (p Proc) FileDescriptorsLen() (int, error) {
 	// Use fast path if available (Linux v6.2): https://github.com/torvalds/linux/commit/f1f1f2569901
-	if p.fs.real {
+	if p.fs.isReal {
 		stat, err := os.Stat(p.path("fd"))
 		if err != nil {
 			return 0, err

--- a/proc_psi.go
+++ b/proc_psi.go
@@ -64,11 +64,11 @@ func (fs FS) PSIStatsForResource(resource string) (PSIStats, error) {
 		return PSIStats{}, fmt.Errorf("%s: psi_stats: unavailable for %q: %w", ErrFileRead, resource, err)
 	}
 
-	return parsePSIStats(resource, bytes.NewReader(data))
+	return parsePSIStats(bytes.NewReader(data))
 }
 
 // parsePSIStats parses the specified file for pressure stall information.
-func parsePSIStats(resource string, r io.Reader) (PSIStats, error) {
+func parsePSIStats(r io.Reader) (PSIStats, error) {
 	psiStats := PSIStats{}
 
 	scanner := bufio.NewScanner(r)

--- a/proc_psi_test.go
+++ b/proc_psi_test.go
@@ -111,7 +111,7 @@ func TestPSIStats(t *testing.T) {
 func TestParsePSIStats(t *testing.T) {
 	t.Run("unknown measurement type", func(t *testing.T) {
 		raw := "nonsense haha test=fake"
-		_, err := parsePSIStats("fake", strings.NewReader(raw))
+		_, err := parsePSIStats(strings.NewReader(raw))
 		if err != nil {
 			t.Error("unknown measurement type must be ignored")
 		}
@@ -121,7 +121,7 @@ func TestParsePSIStats(t *testing.T) {
 		t.Run("some", func(t *testing.T) {
 			raw := `some avg10=0.10 avg60=2.00 avg300=3.85 total=oops
 full avg10=0.20 avg60=3.00 avg300=teddy total=25`
-			stats, err := parsePSIStats("fake", strings.NewReader(raw))
+			stats, err := parsePSIStats(strings.NewReader(raw))
 			if err == nil {
 				t.Error("a malformed line must result in a parse error")
 			}
@@ -133,7 +133,7 @@ full avg10=0.20 avg60=3.00 avg300=teddy total=25`
 		t.Run("full", func(t *testing.T) {
 			raw := `some avg10=0.10 avg60=2.00 avg300=3.85 total=1
 full avg10=0.20 avg60=3.00 avg300=test total=25`
-			stats, err := parsePSIStats("fake", strings.NewReader(raw))
+			stats, err := parsePSIStats(strings.NewReader(raw))
 			t.Log(err)
 			t.Log(stats)
 			if err == nil {

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -135,12 +135,12 @@ func (s *ProcSMapsRollup) parseLine(line string) error {
 	}
 	vBytes := vKBytes * 1024
 
-	s.addValue(k, v, vKBytes, vBytes)
+	s.addValue(k, vBytes)
 
 	return nil
 }
 
-func (s *ProcSMapsRollup) addValue(k string, vString string, vUint uint64, vUintBytes uint64) {
+func (s *ProcSMapsRollup) addValue(k string, vUintBytes uint64) {
 	switch k {
 	case "Rss":
 		s.Rss += vUintBytes

--- a/sysfs/class_sas_device.go
+++ b/sysfs/class_sas_device.go
@@ -163,9 +163,8 @@ func (fs FS) blockSASDeviceBlockDevices(name string) ([]string, error) {
 				if err != nil {
 					if os.IsNotExist(err) {
 						continue
-					} else {
-						return nil, err
 					}
+					return nil, err
 				}
 
 				for _, blockdevice := range blocks {

--- a/sysfs/class_sas_phy.go
+++ b/sysfs/class_sas_phy.go
@@ -99,9 +99,8 @@ func (fs FS) parseSASPhy(name string) (*SASPhy, error) {
 			if err != nil {
 				if os.IsPermission(err) {
 					continue
-				} else {
-					return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 				}
+				return nil, fmt.Errorf("failed to read file %q: %w", name, err)
 			}
 
 			vp := util.NewValueParser(value)

--- a/thread.go
+++ b/thread.go
@@ -55,7 +55,7 @@ func (fs FS) AllThreads(pid int) (Procs, error) {
 			continue
 		}
 
-		t = append(t, Proc{PID: int(tid), fs: FS{fsi.FS(taskPath), fs.real}})
+		t = append(t, Proc{PID: int(tid), fs: FS{fsi.FS(taskPath), fs.isReal}})
 	}
 
 	return t, nil
@@ -67,12 +67,12 @@ func (fs FS) Thread(pid, tid int) (Proc, error) {
 	if _, err := os.Stat(taskPath); err != nil {
 		return Proc{}, err
 	}
-	return Proc{PID: tid, fs: FS{fsi.FS(taskPath), fs.real}}, nil
+	return Proc{PID: tid, fs: FS{fsi.FS(taskPath), fs.isReal}}, nil
 }
 
 // Thread returns a process for a given TID of Proc.
 func (proc Proc) Thread(tid int) (Proc, error) {
-	tfs := FS{fsi.FS(proc.path("task")), proc.fs.real}
+	tfs := FS{fsi.FS(proc.path("task")), proc.fs.isReal}
 	if _, err := os.Stat(tfs.proc.Path(strconv.Itoa(tid))); err != nil {
 		return Proc{}, err
 	}


### PR DESCRIPTION
Fix up minor issues found by newer golangci-lint.
* Remove unused params.
* Fix unused-parameter issues.
* Fix redefines-builtin-id issues.