### PR TITLE
Custom build tag "nostatfs" disables statfs

### DIFF
--- a/fs_statfs_notype.go
+++ b/fs_statfs_notype.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build netbsd || openbsd || solaris || windows
-// +build netbsd openbsd solaris windows
+//go:build netbsd || openbsd || solaris || windows || nostatfs
+// +build netbsd openbsd solaris windows nostatfs
 
 package procfs
 

--- a/fs_statfs_type.go
+++ b/fs_statfs_type.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !netbsd && !openbsd && !solaris && !windows
-// +build !netbsd,!openbsd,!solaris,!windows
+//go:build !netbsd && !openbsd && !solaris && !windows && !nostatfs
+// +build !netbsd,!openbsd,!solaris,!windows,!nostatfs
 
 package procfs
 


### PR DESCRIPTION
This allows users to specify the "nostatfs" build tag to disable this feature if needed.

In our case, we are using Tamago (https://github.com/usbarmory/tamago), which does not support syscall.Statfs. Without this change attempting to build returns 'undefined: syscall.Statfs' and 'undefined: syscall.Statfs_t'. With this change, we can build successfully build our tamago executables provided that "nostatfs" is added to the build tags.

This option seems preferable to adding "tamago" as a build tag here, and will scale to other use cases too.
