### PR TITLE
Fix build tags for isRealProc function

### DIFF
--- a/fs_statfs_notype.go
+++ b/fs_statfs_notype.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build netbsd || openbsd || solaris || windows || nostatfs
-// +build netbsd openbsd solaris windows nostatfs
+//go:build !freebsd && !linux
+// +build !freebsd,!linux
 
 package procfs
 

--- a/fs_statfs_type.go
+++ b/fs_statfs_type.go
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !netbsd && !openbsd && !solaris && !windows && !nostatfs
-// +build !netbsd,!openbsd,!solaris,!windows,!nostatfs
+//go:build freebsd || linux
+// +build freebsd linux
 
 package procfs
 


### PR DESCRIPTION
Only aix, darwin, dragonfly freebsd and linux GOOS have a Type member in their syscall.Statfs_t struct. However, since the isRealProc compares that Type to a magic number (PROC_SUPER_MAGIC, 0x9fa0) which is only relevant to Linux (and possibly FreeBSD with Linux compatibility), adjust build tags accordingly.

This drops the previous nostatfs build tag workaround, since the "tamago" GOOS for which it was originally added won't match the updated build tags.

Fixes: #554.