### PR TITLE
Add support for for /proc/net/tls_data kTLS stats

### DIFF
--- a/net_tls_stat.go
+++ b/net_tls_stat.go
@@ -1,0 +1,119 @@
+// Copyright 2023 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// TLSStat struct represents data in /proc/net/tls_stat.
+// See https://docs.kernel.org/networking/tls.html#statistics
+type TLSStat struct {
+	// number of TX sessions currently installed where host handles cryptography
+	TLSCurrTxSw int
+	// number of RX sessions currently installed where host handles cryptography
+	TLSCurrRxSw int
+	// number of TX sessions currently installed where NIC handles cryptography
+	TLSCurrTxDevice int
+	// number of RX sessions currently installed where NIC handles cryptography
+	TLSCurrRxDevice int
+	//number of TX sessions opened with host cryptography
+	TLSTxSw int
+	//number of RX sessions opened with host cryptography
+	TLSRxSw int
+	// number of TX sessions opened with NIC cryptography
+	TLSTxDevice int
+	// number of RX sessions opened with NIC cryptography
+	TLSRxDevice int
+	// record decryption failed (e.g. due to incorrect authentication tag)
+	TLSDecryptError int
+	//  number of RX resyncs sent to NICs handling cryptography
+	TLSRxDeviceResync int
+	// number of RX records which had to be re-decrypted due to TLS_RX_EXPECT_NO_PAD mis-prediction. Note that this counter will also increment for non-data records.
+	TLSDecryptRetry int
+	// number of data RX records which had to be re-decrypted due to TLS_RX_EXPECT_NO_PAD mis-prediction.
+	TLSRxNoPadViolation int
+}
+
+// NewTLSStat reads the tls_stat statistics.
+func NewTLSStat() (TLSStat, error) {
+	fs, err := NewFS(DefaultMountPoint)
+	if err != nil {
+		return TLSStat{}, err
+	}
+
+	return fs.NewTLSStat()
+}
+
+// NewTLSStat reads the tls_stat statistics.
+func (fs FS) NewTLSStat() (TLSStat, error) {
+	file, err := os.Open(fs.proc.Path("net/tls_stat"))
+	if err != nil {
+		return TLSStat{}, err
+	}
+	defer file.Close()
+
+	var (
+		tlsstat = TLSStat{}
+		s       = bufio.NewScanner(file)
+	)
+
+	for s.Scan() {
+		fields := strings.Fields(s.Text())
+
+		if len(fields) != 2 {
+			return TLSStat{}, fmt.Errorf("%w: %q line %q", ErrFileParse, file.Name(), s.Text())
+		}
+
+		name := fields[0]
+		value, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return TLSStat{}, err
+		}
+
+		switch name {
+		case "TlsCurrTxSw":
+			tlsstat.TLSCurrTxSw = value
+		case "TlsCurrRxSw":
+			tlsstat.TLSCurrRxSw = value
+		case "TlsCurrTxDevice":
+			tlsstat.TLSCurrTxDevice = value
+		case "TlsCurrRxDevice":
+			tlsstat.TLSCurrRxDevice = value
+		case "TlsTxSw":
+			tlsstat.TLSTxSw = value
+		case "TlsRxSw":
+			tlsstat.TLSRxSw = value
+		case "TlsTxDevice":
+			tlsstat.TLSTxDevice = value
+		case "TlsRxDevice":
+			tlsstat.TLSRxDevice = value
+		case "TlsDecryptError":
+			tlsstat.TLSDecryptError = value
+		case "TlsRxDeviceResync":
+			tlsstat.TLSRxDeviceResync = value
+		case "TlsDecryptRetry":
+			tlsstat.TLSDecryptRetry = value
+		case "TlsRxNoPadViolation":
+			tlsstat.TLSRxNoPadViolation = value
+		}
+
+	}
+
+	return tlsstat, s.Err()
+}

--- a/net_tls_stat_test.go
+++ b/net_tls_stat_test.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Prometheus Team
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"testing"
+)
+
+func TestTLSStat(t *testing.T) {
+	tlsStats, err := getProcFixtures(t).NewTLSStat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		want int
+		got  int
+	}{
+		{name: "TLSCurrTxSw", want: 5, got: tlsStats.TLSCurrTxSw},
+		{name: "TLSCurrRxSw", want: 5, got: tlsStats.TLSCurrRxSw},
+		{name: "TLSCurrTxDevice", want: 0, got: tlsStats.TLSCurrTxDevice},
+		{name: "TLSCurrRxDevice", want: 0, got: tlsStats.TLSCurrRxDevice},
+		{name: "TLSTxSw", want: 8711, got: tlsStats.TLSTxSw},
+		{name: "TLSTxSw", want: 8711, got: tlsStats.TLSRxSw},
+		{name: "TLSTxDevice", want: 0, got: tlsStats.TLSTxDevice},
+		{name: "TLSRxDevice", want: 0, got: tlsStats.TLSRxDevice},
+		{name: "TLSDecryptError", want: 13, got: tlsStats.TLSDecryptError},
+		{name: "TLSRxDeviceResync", want: 0, got: tlsStats.TLSRxDeviceResync},
+		{name: "TLSDecryptRetry", want: 0, got: tlsStats.TLSDecryptRetry},
+		{name: "TLSRxNoPadViolation", want: 0, got: tlsStats.TLSRxNoPadViolation},
+	} {
+		if test.want != test.got {
+			t.Errorf("Want %s %d, have %d", test.name, test.want, test.got)
+		}
+	}
+}

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -2527,6 +2527,22 @@ Lines: 3
  6073: 000080FE00000000FFADE15609667CFE:C781 00000000000000000000000000000000:0000 07 00000000:00000000 00:00000000 00000000  1000        0 11337031 2 00000000b9256fdd 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/net/tls_stat
+Lines: 12
+TlsCurrTxSw                     	5
+TlsCurrRxSw                     	5
+TlsCurrTxDevice                 	0
+TlsCurrRxDevice                 	0
+TlsTxSw                         	8711
+TlsRxSw                         	8711
+TlsTxDevice                     	0
+TlsRxDevice                     	0
+TlsDecryptError                 	13
+TlsRxDeviceResync               	0
+TlsDecryptRetry                 	0
+TlsRxNoPadViolation             	0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/net/udp
 Lines: 4
   sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode


### PR DESCRIPTION
Since Linux kernel 4.17 (I believe) there is support to move some TLS operations to kernel space, enabling things like TLS `sendfile` to improve performance. Statistics for this feature is exposed under `/proc/net/tls_stats`. This PR adds support to read these statistics. It is very much based on the support for `/proc/net/xfrm_stats` in `net_xfrm.go` as they both share the same format.

For more info on Linux kTLS see https://docs.kernel.org/networking/tls.html.