### PR TITLE
golint: redundant type from array, slice, or map composite literal

### DIFF
--- a/net_tcp_test.go
+++ b/net_tcp_test.go
@@ -30,7 +30,7 @@ func Test_newNetTCP(t *testing.T) {
 			name: "tcp file found, no error should come up",
 			file: "testdata/fixtures/proc/net/tcp",
 			want: []*netIPSocketLine{
-				&netIPSocketLine{
+				{
 					Sl:        0,
 					LocalAddr: net.IP{10, 0, 0, 5},
 					LocalPort: 22,
@@ -42,7 +42,7 @@ func Test_newNetTCP(t *testing.T) {
 					UID:       0,
 					Inode:     2740,
 				},
-				&netIPSocketLine{
+				{
 					Sl:        1,
 					LocalAddr: net.IP{0, 0, 0, 0},
 					LocalPort: 22,
@@ -54,7 +54,7 @@ func Test_newNetTCP(t *testing.T) {
 					UID:       0,
 					Inode:     2740,
 				},
-				&netIPSocketLine{
+				{
 					Sl:        2,
 					LocalAddr: net.IP{0, 0, 0, 0},
 					LocalPort: 22,
@@ -73,7 +73,7 @@ func Test_newNetTCP(t *testing.T) {
 			name: "tcp6 file found, no error should come up",
 			file: "testdata/fixtures/proc/net/tcp6",
 			want: []*netIPSocketLine{
-				&netIPSocketLine{
+				{
 					Sl:        1315,
 					LocalAddr: net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 					LocalPort: 5355,
@@ -85,7 +85,7 @@ func Test_newNetTCP(t *testing.T) {
 					UID:       981,
 					Inode:     21040,
 				},
-				&netIPSocketLine{
+				{
 					Sl:        6073,
 					LocalAddr: net.IP{254, 128, 0, 0, 0, 0, 0, 0, 86, 225, 173, 255, 254, 124, 102, 9},
 					LocalPort: 51073,


### PR DESCRIPTION
golint: redundant type from array, slice, or map composite literal