### PR TITLE
chore: Use kernel-compliant types for `{U,G}IDs`

### DIFF
--- a/proc_status.go
+++ b/proc_status.go
@@ -15,6 +15,7 @@ package procfs
 
 import (
 	"bytes"
+	"math/bits"
 	"sort"
 	"strconv"
 	"strings"
@@ -76,9 +77,9 @@ type ProcStatus struct {
 	NonVoluntaryCtxtSwitches uint64
 
 	// UIDs of the process (Real, effective, saved set, and filesystem UIDs)
-	UIDs [4]string
+	UIDs [4]uint64
 	// GIDs of the process (Real, effective, saved set, and filesystem GIDs)
-	GIDs [4]string
+	GIDs [4]uint64
 
 	// CpusAllowedList: List of cpu cores processes are allowed to run on.
 	CpusAllowedList []uint64
@@ -113,22 +114,37 @@ func (p Proc) NewStatus() (ProcStatus, error) {
 		// convert kB to B
 		vBytes := vKBytes * 1024
 
-		s.fillStatus(k, v, vKBytes, vBytes)
+		err = s.fillStatus(k, v, vKBytes, vBytes)
+		if err != nil {
+			return ProcStatus{}, err
+		}
 	}
 
 	return s, nil
 }
 
-func (s *ProcStatus) fillStatus(k string, vString string, vUint uint64, vUintBytes uint64) {
+func (s *ProcStatus) fillStatus(k string, vString string, vUint uint64, vUintBytes uint64) error {
 	switch k {
 	case "Tgid":
 		s.TGID = int(vUint)
 	case "Name":
 		s.Name = vString
 	case "Uid":
-		copy(s.UIDs[:], strings.Split(vString, "\t"))
+		var err error
+		for i, v := range strings.Split(vString, "\t") {
+			s.UIDs[i], err = strconv.ParseUint(v, 10, bits.UintSize)
+			if err != nil {
+				return err
+			}
+		}
 	case "Gid":
-		copy(s.GIDs[:], strings.Split(vString, "\t"))
+		var err error
+		for i, v := range strings.Split(vString, "\t") {
+			s.GIDs[i], err = strconv.ParseUint(v, 10, bits.UintSize)
+			if err != nil {
+				return err
+			}
+		}
 	case "NSpid":
 		s.NSpids = calcNSPidsList(vString)
 	case "VmPeak":
@@ -173,6 +189,7 @@ func (s *ProcStatus) fillStatus(k string, vString string, vUint uint64, vUintByt
 		s.CpusAllowedList = calcCpusAllowedList(vString)
 	}
 
+	return nil
 }
 
 // TotalCtxtSwitches returns the total context switch.

--- a/proc_status_test.go
+++ b/proc_status_test.go
@@ -103,8 +103,8 @@ func TestProcStatusUIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want, have := [4]string{"1000", "1000", "1000", "0"}, s.UIDs; want != have {
-		t.Errorf("want uids %s, have %s", want, have)
+	if want, have := [4]uint64{1000, 1000, 1000, 0}, s.UIDs; want != have {
+		t.Errorf("want uids %v, have %v", want, have)
 	}
 }
 
@@ -119,8 +119,8 @@ func TestProcStatusGIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want, have := [4]string{"1001", "1001", "1001", "0"}, s.GIDs; want != have {
-		t.Errorf("want uids %s, have %s", want, have)
+	if want, have := [4]uint64{1001, 1001, 1001, 0}, s.GIDs; want != have {
+		t.Errorf("want gids %v, have %v", want, have)
 	}
 }
 

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -814,8 +814,8 @@ Ngid:   12345
 Pid:    26235
 PPid:   1234
 TracerPid:      0
-Uid:    0       0       0       0
-Gid:    0       0       0       0
+Uid:	0	0	0	0
+Gid:	0	0	0	0
 FDSize: 64
 Groups:
 NStgid: 26235   1


### PR DESCRIPTION
As defined in `uidgid_types.h`: https://github.com/torvalds/linux/blob/8e938e39866920ddc266898e6ae1fffc5c8f51aa/include/linux/uidgid_types.h#L8 (https://github.com/prometheus/procfs/issues/372#issuecomment-2015164486).

Fixes: #372