### PR TITLE
Revert "add avgRTT to nfs mountstats"

### DIFF
--- a/mountstats.go
+++ b/mountstats.go
@@ -194,8 +194,6 @@ type NFSOperationStats struct {
 	CumulativeTotalResponseMilliseconds uint64
 	// Duration from when a request was enqueued to when it was completely handled.
 	CumulativeTotalRequestMilliseconds uint64
-	// The average time from the point the client sends RPC requests until it receives the response.
-	AverageRTTMilliseconds float64
 	// The count of operations that complete with tk_status < 0.  These statuses usually indicate error conditions.
 	Errors uint64
 }
@@ -571,6 +569,7 @@ func parseNFSOperationStats(s *bufio.Scanner) ([]NFSOperationStats, error) {
 
 			ns = append(ns, n)
 		}
+
 		opStats := NFSOperationStats{
 			Operation:                           strings.TrimSuffix(ss[0], ":"),
 			Requests:                            ns[0],
@@ -581,9 +580,6 @@ func parseNFSOperationStats(s *bufio.Scanner) ([]NFSOperationStats, error) {
 			CumulativeQueueMilliseconds:         ns[5],
 			CumulativeTotalResponseMilliseconds: ns[6],
 			CumulativeTotalRequestMilliseconds:  ns[7],
-		}
-		if ns[0] != 0 {
-			opStats.AverageRTTMilliseconds = float64(ns[6]) / float64(ns[0])
 		}
 
 		if len(ns) > 8 {

--- a/mountstats_test.go
+++ b/mountstats_test.go
@@ -339,7 +339,6 @@ func TestMountStats(t *testing.T) {
 								CumulativeQueueMilliseconds:         6,
 								CumulativeTotalResponseMilliseconds: 79386,
 								CumulativeTotalRequestMilliseconds:  79407,
-								AverageRTTMilliseconds:              61.16024653312789,
 							},
 							{
 								Operation: "WRITE",
@@ -353,7 +352,6 @@ func TestMountStats(t *testing.T) {
 								CumulativeQueueMilliseconds:         18446743919241604546,
 								CumulativeTotalResponseMilliseconds: 1667369447,
 								CumulativeTotalRequestMilliseconds:  1953587717,
-								AverageRTTMilliseconds:              0.5695744656983355,
 							},
 						},
 						Transport: NFSTransportStats{


### PR DESCRIPTION
Reverts prometheus/procfs#487

This is an artificiality computed value from existing values. The goal of this library is to provide simple raw access to values, rather than pre-compute data.