### PR TITLE
style: returns procfs build-in error like other parsing methods

### DIFF
--- a/cpuinfo.go
+++ b/cpuinfo.go
@@ -386,7 +386,7 @@ func parseCPUInfoLoong(info []byte) ([]CPUInfo, error) {
 	// find the first "processor" line
 	firstLine := firstNonEmptyLine(scanner)
 	if !strings.HasPrefix(firstLine, "system type") || !strings.Contains(firstLine, ":") {
-		return nil, errors.New("invalid cpuinfo file: " + firstLine)
+		return nil, fmt.Errorf("%w: %q", ErrFileParse, firstLine)
 	}
 	field := strings.SplitN(firstLine, ": ", 2)
 	cpuinfo := []CPUInfo{}


### PR DESCRIPTION
For file parsing errors, procfs defines error ErrFileParse. Other architectures, such as x86 ,arm,mips, use ErrFileParse to return parsing errors. Loong should do this too.