### PR TITLE
Update Go versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-    - image: cimg/go:1.21
+    - image: cimg/go:1.22
     steps:
     - checkout
     - run: make check_license
@@ -46,8 +46,8 @@ workflows:
         matrix:
           parameters:
             go_version:
-            - "1.20"
             - "1.21"
+            - "1.22"
     - test:
         name: test-windows
         os: windows
@@ -55,5 +55,5 @@ workflows:
         matrix:
           parameters:
             go_version:
-            - "1.20"
             - "1.21"
+            - "1.22"

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/prometheus/procfs
 
-go 1.20
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.6.0
-	golang.org/x/sync v0.6.0
-	golang.org/x/sys v0.18.0
+	golang.org/x/sync v0.7.0
+	golang.org/x/sys v0.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
-golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
* Update minimum Go to 1.21.
* Update testing to include Go 1.22.
* Update Go modules.

Signed-off-by: SuperQ <superq@gmail.com>