### PR TITLE
Update class_thermal.go to ignore only invalid thermal zones which raise fs.PathError

### DIFF
--- a/sysfs/class_thermal.go
+++ b/sysfs/class_thermal.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 
 	"github.com/prometheus/procfs/internal/util"
+	fsp "io/fs"
 )
 
 // ClassThermalZoneStats contains info from files in /sys/class/thermal/thermal_zone<zone>
@@ -49,7 +50,7 @@ func (fs FS) ClassThermalZoneStats() ([]ClassThermalZoneStats, error) {
 	for _, zone := range zones {
 		zoneStats, err := parseClassThermalZone(zone)
 		if err != nil {
-			if errors.Is(err, syscall.ENODATA) {
+			if errors.Is(err, syscall.ENODATA) || errors.As(err, new(*fsp.PathError)) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
Sum-up: ignore invalid thermal zones to avoid discharding of all thermal zone metric

Some thermal zones generates errors fs.PathError causing the lost of all metric data also for valid thermal zone.

Example of error log: ts=2024-04-10T14:23:57.064Z caller=collector.go:169 level=error msg="collector failed" name=thermal_zone duration_seconds=0.053034792 err="read /sys/class/thermal/thermal_zone24/temp: invalid argument"