### PR TITLE
Fix NODEV errors on Thinkpad when parsing battery status

### DIFF
--- a/sysfs/class_power_supply.go
+++ b/sysfs/class_power_supply.go
@@ -143,7 +143,7 @@ func parsePowerSupply(path string) (*PowerSupply, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || err.Error() == "operation not supported" || errors.Is(err, os.ErrInvalid) {
+			if os.IsNotExist(err) || err.Error() == "operation not supported" || err.Error() == "no such device" || errors.Is(err, os.ErrInvalid) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %w", name, err)


### PR DESCRIPTION
On thinkpads, reading `power_supply class charge_control_end_threshold` returns `no such device` error, which results in battery metrics not being exported.

Fixes: https://github.com/prometheus/node_exporter/issues/3019
