### PR TITLE
Return support for Go 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ workflows:
         matrix:
           parameters:
             go_version:
+            - "1.20"
             - "1.21"
             - "1.22"
     - test:
@@ -55,5 +56,6 @@ workflows:
         matrix:
           parameters:
             go_version:
+            - "1.20"
             - "1.21"
             - "1.22"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/procfs
 
-go 1.21
+go 1.20
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Support the last three releases to match the versions supported by prometheus client_golang.