### PR TITLE
Fix parsing NSpids field in /proc/{PID}/status

### DIFF
--- a/proc_status.go
+++ b/proc_status.go
@@ -146,7 +146,11 @@ func (s *ProcStatus) fillStatus(k string, vString string, vUint uint64, vUintByt
 			}
 		}
 	case "NSpid":
-		s.NSpids = calcNSPidsList(vString)
+		nspids, err := calcNSPidsList(vString)
+		if err != nil {
+			return err
+		}
+		s.NSpids = nspids
 	case "VmPeak":
 		s.VmPeak = vUintBytes
 	case "VmSize":
@@ -222,17 +226,17 @@ func calcCpusAllowedList(cpuString string) []uint64 {
 	return g
 }
 
-func calcNSPidsList(nspidsString string) []uint64 {
-	s := strings.Split(nspidsString, " ")
+func calcNSPidsList(nspidsString string) ([]uint64, error) {
+	s := strings.Split(nspidsString, "\t")
 	var nspids []uint64
 
 	for _, nspid := range s {
-		nspid, _ := strconv.ParseUint(nspid, 10, 64)
-		if nspid == 0 {
-			continue
+		nspid, err := strconv.ParseUint(nspid, 10, 64)
+		if err != nil {
+			return nil, err
 		}
 		nspids = append(nspids, nspid)
 	}
 
-	return nspids
+	return nspids, nil
 }

--- a/proc_status_test.go
+++ b/proc_status_test.go
@@ -139,3 +139,19 @@ func TestCpusAllowedList(t *testing.T) {
 		t.Errorf("want CpusAllowedList %v, have %v", want, have)
 	}
 }
+
+func TestNsPids(t *testing.T) {
+	p, err := getProcFixtures(t).Proc(26235)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := p.NewStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, have := []uint64{26235, 1}, s.NSpids; !reflect.DeepEqual(want, have) {
+		t.Errorf("want NsPids %v, have %v", want, have)
+	}
+}

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -818,10 +818,10 @@ Uid:	0	0	0	0
 Gid:	0	0	0	0
 FDSize: 64
 Groups:
-NStgid: 26235   1
-NSpid:  26235   1
-NSpgid: 26235   1
-NSsid:  26235   1
+NStgid: 26235	1
+NSpid:  26235	1
+NSpgid: 26235	1
+NSsid:  26235	1
 VmPeak:   758200 kB
 VmSize:   758200 kB
 VmLck:         0 kB


### PR DESCRIPTION
The NSpids field uses a tab (\t) to separate the list of PIDs. The procfs parser should split on \t, rather than space. This was not caught because the test fixtures themselves used the space character.

The patch updates the parser, the fixtures, and adds an explicit test for NSpids.