### PR TITLE
Add Disk IO stats and ext4 FS stats

### DIFF
--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -1,0 +1,103 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package btrfs provides access to statistics exposed by ext4 filesystems.
+package ext4
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/prometheus/procfs/internal/fs"
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const (
+	sysFSPath     = "fs"
+	sysFSExt4Path = "ext4"
+)
+
+// Stats contains statistics for a single Btrfs filesystem.
+// See Linux fs/btrfs/sysfs.c for more information.
+type Stats struct {
+	Name string
+
+	Errors   uint64
+	Warnings uint64
+	Messages uint64
+}
+
+// FS represents the pseudo-filesystems proc and sys, which provides an
+// interface to kernel data structures.
+type FS struct {
+	proc *fs.FS
+	sys  *fs.FS
+}
+
+// NewDefaultFS returns a new blockdevice fs using the default mountPoints for proc and sys.
+// It will error if either of these mount points can't be read.
+func NewDefaultFS() (FS, error) {
+	return NewFS(fs.DefaultProcMountPoint, fs.DefaultSysMountPoint)
+}
+
+// NewFS returns a new XFS handle using the given proc and sys mountPoints. It will error
+// if either of the mounts point can't be read.
+func NewFS(procMountPoint string, sysMountPoint string) (FS, error) {
+	if strings.TrimSpace(procMountPoint) == "" {
+		procMountPoint = fs.DefaultProcMountPoint
+	}
+	procfs, err := fs.NewFS(procMountPoint)
+	if err != nil {
+		return FS{}, err
+	}
+	if strings.TrimSpace(sysMountPoint) == "" {
+		sysMountPoint = fs.DefaultSysMountPoint
+	}
+	sysfs, err := fs.NewFS(sysMountPoint)
+	if err != nil {
+		return FS{}, err
+	}
+	return FS{&procfs, &sysfs}, nil
+}
+
+// ProcStat returns stats for the filesystem.
+func (fs FS) ProcStat() ([]*Stats, error) {
+	matches, err := filepath.Glob(fs.sys.Path("fs/ext4/*"))
+	if err != nil {
+		return nil, err
+	}
+
+	stats := make([]*Stats, 0, len(matches))
+	for _, m := range matches {
+		s := &Stats{}
+
+		// "*" used in glob above indicates the name of the filesystem.
+		name := filepath.Base(m)
+		s.Name = name
+		for file, p := range map[string]*uint64{
+			"errors_count":  &s.Errors,
+			"warning_count": &s.Warnings,
+			"msg_count":     &s.Messages,
+		} {
+			var val uint64
+			val, err = util.ReadUintFromFile(fs.sys.Path(sysFSPath, sysFSExt4Path, name, file))
+			if err == nil {
+				*p = val
+			}
+		}
+
+		stats = append(stats, s)
+	}
+
+	return stats, nil
+}

--- a/internal/util/parse.go
+++ b/internal/util/parse.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"errors"
 	"os"
 	"strconv"
 	"strings"
@@ -109,4 +110,17 @@ func ParseBool(b string) *bool {
 		return nil
 	}
 	return &truth
+}
+
+// ReadHexFromFile reads a file and attempts to parse a uint64 from a hexadecimal format 0xXX.
+func ReadHexFromFile(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	hexString := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(hexString, "0x") {
+		return 0, errors.New("invalid format: hex string does not start with '0x'")
+	}
+	return strconv.ParseUint(hexString[2:], 16, 64)
 }


### PR DESCRIPTION
Related to: https://github.com/prometheus/node_exporter/issues/3005

Node exporter PR: https://github.com/prometheus/node_exporter/pull/3047

Adds function to return disk stats from:
- `/sys/block/<disk>/device/ioerr_cnt`: number of SCSI commands that completed with an error
- `/sys/block/<disk>/device/iodone_cnt`: number of completed or rejected SCSI commands

Add function to return stats for ext4 filesystem
- `/sys/fs/ext4/<partition>/errors_count`: number of ext4 errors ([commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=52c198c6820f68b6fbe1d83f76e34a82bf736024))
- `/sys/fs/ext4/<partition>/warning_count`: number of ext4 warning log messages ([commit](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1cf006ed19a887c22e085189c8b4a3cbf60d2246))
- `/sys/fs/ext4/<partition>/msg_count`: number of other ext4 log messages