### PR TITLE
feat(blockdevice): added sysblockdevicesize method and test

### DIFF
--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -209,6 +209,8 @@ const (
 	sysBlockQueue       = "queue"
 	sysBlockDM          = "dm"
 	sysUnderlyingDev    = "slaves"
+	sysBlockSize        = "size"
+	sectorSize          = 512
 )
 
 // FS represents the pseudo-filesystems proc and sys, which provides an
@@ -473,4 +475,14 @@ func (fs FS) SysBlockDeviceUnderlyingDevices(device string) (UnderlyingDeviceInf
 	}
 	return UnderlyingDeviceInfo{DeviceNames: underlying}, nil
 
+}
+
+// SysBlockDeviceSize returns the size of the block device from /sys/block/<device>/size.
+// in bytes by multiplying the value by the Linux sector length of 512.
+func (fs FS) SysBlockDeviceSize(device string) (uint64, error) {
+	size, err := util.ReadUintFromFile(fs.sys.Path(sysBlockPath, device, sysBlockSize))
+	if err != nil {
+		return 0, err
+	}
+	return sectorSize * size, nil
 }

--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -21,7 +21,8 @@ import (
 	"os"
 	"strings"
 
-	filesystem "github.com/prometheus/procfs/internal/fs"
+	"github.com/prometheus/procfs"
+	"github.com/prometheus/procfs/internal/fs"
 	"github.com/prometheus/procfs/internal/util"
 )
 
@@ -215,30 +216,30 @@ const (
 // FS represents the pseudo-filesystems proc and sys, which provides an
 // interface to kernel data structures.
 type FS struct {
-	proc *filesystem.FS
-	sys  *filesystem.FS
+	proc *fs.FS
+	sys  *fs.FS
 }
 
 // NewDefaultFS returns a new blockdevice fs using the default mountPoints for proc and sys.
 // It will error if either of these mount points can't be read.
 func NewDefaultFS() (FS, error) {
-	return NewFS(filesystem.DefaultProcMountPoint, filesystem.DefaultSysMountPoint)
+	return NewFS(fs.DefaultProcMountPoint, fs.DefaultSysMountPoint)
 }
 
 // NewFS returns a new blockdevice fs using the given mountPoints for proc and sys.
 // It will error if either of these mount points can't be read.
 func NewFS(procMountPoint string, sysMountPoint string) (FS, error) {
 	if strings.TrimSpace(procMountPoint) == "" {
-		procMountPoint = filesystem.DefaultProcMountPoint
+		procMountPoint = fs.DefaultProcMountPoint
 	}
-	procfs, err := filesystem.NewFS(procMountPoint)
+	procfs, err := fs.NewFS(procMountPoint)
 	if err != nil {
 		return FS{}, err
 	}
 	if strings.TrimSpace(sysMountPoint) == "" {
-		sysMountPoint = filesystem.DefaultSysMountPoint
+		sysMountPoint = fs.DefaultSysMountPoint
 	}
-	sysfs, err := filesystem.NewFS(sysMountPoint)
+	sysfs, err := fs.NewFS(sysMountPoint)
 	if err != nil {
 		return FS{}, err
 	}
@@ -483,5 +484,5 @@ func (fs FS) SysBlockDeviceSize(device string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return filesystem.SectorSize * size, nil
+	return procfs.SectorSize * size, nil
 }

--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -21,8 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/prometheus/procfs/btrfs"
-	"github.com/prometheus/procfs/internal/fs"
+	filesystem "github.com/prometheus/procfs/internal/fs"
 	"github.com/prometheus/procfs/internal/util"
 )
 
@@ -216,30 +215,30 @@ const (
 // FS represents the pseudo-filesystems proc and sys, which provides an
 // interface to kernel data structures.
 type FS struct {
-	proc *fs.FS
-	sys  *fs.FS
+	proc *filesystem.FS
+	sys  *filesystem.FS
 }
 
 // NewDefaultFS returns a new blockdevice fs using the default mountPoints for proc and sys.
 // It will error if either of these mount points can't be read.
 func NewDefaultFS() (FS, error) {
-	return NewFS(fs.DefaultProcMountPoint, fs.DefaultSysMountPoint)
+	return NewFS(filesystem.DefaultProcMountPoint, filesystem.DefaultSysMountPoint)
 }
 
 // NewFS returns a new blockdevice fs using the given mountPoints for proc and sys.
 // It will error if either of these mount points can't be read.
 func NewFS(procMountPoint string, sysMountPoint string) (FS, error) {
 	if strings.TrimSpace(procMountPoint) == "" {
-		procMountPoint = fs.DefaultProcMountPoint
+		procMountPoint = filesystem.DefaultProcMountPoint
 	}
-	procfs, err := fs.NewFS(procMountPoint)
+	procfs, err := filesystem.NewFS(procMountPoint)
 	if err != nil {
 		return FS{}, err
 	}
 	if strings.TrimSpace(sysMountPoint) == "" {
-		sysMountPoint = fs.DefaultSysMountPoint
+		sysMountPoint = filesystem.DefaultSysMountPoint
 	}
-	sysfs, err := fs.NewFS(sysMountPoint)
+	sysfs, err := filesystem.NewFS(sysMountPoint)
 	if err != nil {
 		return FS{}, err
 	}
@@ -484,5 +483,5 @@ func (fs FS) SysBlockDeviceSize(device string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return btrfs.SectorSize * size, nil
+	return filesystem.SectorSize * size, nil
 }

--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/prometheus/procfs/btrfs"
 	"github.com/prometheus/procfs/internal/fs"
 	"github.com/prometheus/procfs/internal/util"
 )
@@ -210,7 +211,6 @@ const (
 	sysBlockDM          = "dm"
 	sysUnderlyingDev    = "slaves"
 	sysBlockSize        = "size"
-	sectorSize          = 512
 )
 
 // FS represents the pseudo-filesystems proc and sys, which provides an
@@ -484,5 +484,5 @@ func (fs FS) SysBlockDeviceSize(device string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return sectorSize * size, nil
+	return btrfs.SectorSize * size, nil
 }

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -219,3 +219,22 @@ func TestSysBlockDeviceUnderlyingDevices(t *testing.T) {
 		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", underlying0Expected, underlying0)
 	}
 }
+
+func TestSysBlockDeviceSize(t *testing.T) {
+	blockdevice, err := NewFS("testdata/fixtures/proc", "testdata/fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access blockdevice fs: %v", err)
+	}
+	devices, err := blockdevice.SysBlockDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+	size7, err := blockdevice.SysBlockDeviceSize(devices[7])
+	if err != nil {
+		t.Fatal(err)
+	}
+	size7Expected := uint64(3750748848)
+	if size7 != size7Expected {
+		t.Errorf("Incorrect BlockDeviceSize, expected: \n%+v, got: \n%+v", size7Expected, size7)
+	}
+}

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -233,7 +233,7 @@ func TestSysBlockDeviceSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	size7Expected := uint64(3750748848)
+	size7Expected := uint64(1920383410176)
 	if size7 != size7Expected {
 		t.Errorf("Incorrect BlockDeviceSize, expected: \n%+v, got: \n%+v", size7Expected, size7)
 	}

--- a/btrfs/get.go
+++ b/btrfs/get.go
@@ -26,11 +26,6 @@ import (
 	"github.com/prometheus/procfs/internal/util"
 )
 
-// SectorSize contains the Linux sector size.
-// > Linux always considers sectors to be 512 bytes long independently
-// > of the devices real block size.
-const SectorSize = 512
-
 // FS represents the pseudo-filesystem sys, which provides an interface to
 // kernel data structures.
 type FS struct {
@@ -213,7 +208,7 @@ func (r *reader) readDeviceInfo(d string) map[string]*Device {
 	info := make(map[string]*Device, len(devs))
 	for _, n := range devs {
 		info[n] = &Device{
-			Size: SectorSize * r.readValue("devices/"+n+"/size"),
+			Size: fs.SectorSize * r.readValue("devices/"+n+"/size"),
 		}
 	}
 

--- a/btrfs/get.go
+++ b/btrfs/get.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/prometheus/procfs"
 	"github.com/prometheus/procfs/internal/fs"
 	"github.com/prometheus/procfs/internal/util"
 )
@@ -208,7 +209,7 @@ func (r *reader) readDeviceInfo(d string) map[string]*Device {
 	info := make(map[string]*Device, len(devs))
 	for _, n := range devs {
 		info[n] = &Device{
-			Size: fs.SectorSize * r.readValue("devices/"+n+"/size"),
+			Size: procfs.SectorSize * r.readValue("devices/"+n+"/size"),
 		}
 	}
 

--- a/fs.go
+++ b/fs.go
@@ -24,8 +24,14 @@ type FS struct {
 	isReal bool
 }
 
-// DefaultMountPoint is the common mount point of the proc filesystem.
-const DefaultMountPoint = fs.DefaultProcMountPoint
+const (
+	// DefaultMountPoint is the common mount point of the proc filesystem.
+	DefaultMountPoint = fs.DefaultProcMountPoint
+
+	// SectorSize represents the size of a sector in bytes.
+	// It is specific to Linux block I/O operations.
+	SectorSize = 512
+)
 
 // NewDefaultFS returns a new proc FS mounted under the default proc mountPoint.
 // It will error if the mount point directory can't be read or is a file.

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -31,10 +31,6 @@ const (
 
 	// DefaultSelinuxMountPoint is the common mount point of the selinuxfs.
 	DefaultSelinuxMountPoint = "/sys/fs/selinux"
-
-	// SectorSize represents the size of a sector in bytes.
-	// It is specific to Linux block I/O operations.
-	SectorSize = 512
 )
 
 // FS represents a pseudo-filesystem, normally /proc or /sys, which provides an

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -31,6 +31,10 @@ const (
 
 	// DefaultSelinuxMountPoint is the common mount point of the selinuxfs.
 	DefaultSelinuxMountPoint = "/sys/fs/selinux"
+
+	// SectorSize represents the size of a sector in bytes.
+	// It is specific to Linux block I/O operations.
+	SectorSize = 512
 )
 
 // FS represents a pseudo-filesystem, normally /proc or /sys, which provides an

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -4335,6 +4335,11 @@ Lines: 1
 none
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/block/sda/size
+Lines: 1
+3750748848EOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/block/sda/stat
 Lines: 1
 9652963   396792 759304206   412943  8422549  6731723 286915323 13947418        0  5658367 19174573 1 2 3 12


### PR DESCRIPTION
In part to support https://github.com/prometheus/node_exporter/pull/3068, I have added a new method that retrieves the value of `/sys/block/<device>/size`