### PR TITLE
Parse StartCode, EndCode, and StartStack in `Proc.Stat()`

### DIFF
--- a/proc_stat.go
+++ b/proc_stat.go
@@ -101,6 +101,12 @@ type ProcStat struct {
 	RSS int
 	// Soft limit in bytes on the rss of the process.
 	RSSLimit uint64
+	// The address above which program text can run.
+	StartCode uint64
+	// The address below which program text can run.
+	EndCode uint64
+	// The address of the start (i.e., bottom) of the stack.
+	StartStack uint64
 	// CPU number last executed on.
 	Processor uint
 	// Real-time scheduling priority, a number in the range 1 to 99 for processes
@@ -177,9 +183,9 @@ func (p Proc) Stat() (ProcStat, error) {
 		&s.VSize,
 		&s.RSS,
 		&s.RSSLimit,
-		&ignoreUint64,
-		&ignoreUint64,
-		&ignoreUint64,
+		&s.StartCode,
+		&s.EndCode,
+		&s.StartStack,
 		&ignoreUint64,
 		&ignoreUint64,
 		&ignoreUint64,

--- a/proc_stat_test.go
+++ b/proc_stat_test.go
@@ -55,6 +55,9 @@ func TestProcStat(t *testing.T) {
 		have uint64
 	}{
 		{name: "RSS Limit", want: 18446744073709551615, have: s.RSSLimit},
+		{name: "Start Code", want: 4194304, have: s.StartCode},
+		{name: "End Code", want: 6294284, have: s.EndCode},
+		{name: "Start Stack", want: 140736914091744, have: s.StartStack},
 		{name: "delayacct_blkio_ticks", want: 31, have: s.DelayAcctBlkIOTicks},
 	} {
 		if test.want != test.have {


### PR DESCRIPTION
Add the following fields to the `ProcStat` type and read them from `/proc/<pid>/stat` in `Proc.Stat()`:
- StartCode
- EndCode
- StartStack

See fields 26, 27, and 28 in https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html.

It enables categorizing regions from `/proc/<pid>/maps` depending on their address (ie. actual code vs something else, eg. memory mapped file).