### PR TITLE
Forbid print statements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@
 linters:
   enable:
   - errcheck
+  - forbidigo
   - godot
   - gofmt
   - goimports
@@ -15,6 +16,10 @@ linters:
   - unused
 
 linter-settings:
+  forbidigo:
+    forbid:
+      - p: ^fmt\.Print.*$
+        msg: Do not commit print statements.
   godot:
     capital: true
     exclude:

--- a/proc_smaps.go
+++ b/proc_smaps.go
@@ -19,7 +19,6 @@ package procfs
 import (
 	"bufio"
 	"errors"
-	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -117,7 +116,6 @@ func (p Proc) procSMapsRollupManual() (ProcSMapsRollup, error) {
 func (s *ProcSMapsRollup) parseLine(line string) error {
 	kv := strings.SplitN(line, ":", 2)
 	if len(kv) != 2 {
-		fmt.Println(line)
 		return errors.New("invalid net/dev line, missing colon")
 	}
 


### PR DESCRIPTION
Enable `forbidigo` to make sure print statements are not used in this library. This avoids injecting random log output into upstream user's log formatting.