### PR TITLE
feat(mdstat): recognize reshape status

### DIFF
--- a/mdstat.go
+++ b/mdstat.go
@@ -123,13 +123,16 @@ func parseMDStat(mdStatData []byte) ([]MDStat, error) {
 		finish := float64(0)
 		pct := float64(0)
 		recovering := strings.Contains(lines[syncLineIdx], "recovery")
+		reshaping := strings.Contains(lines[syncLineIdx], "reshape")
 		resyncing := strings.Contains(lines[syncLineIdx], "resync")
 		checking := strings.Contains(lines[syncLineIdx], "check")
 
 		// Append recovery and resyncing state info.
-		if recovering || resyncing || checking {
+		if recovering || resyncing || checking || reshaping {
 			if recovering {
 				state = "recovering"
+			} else if reshaping {
+				state = "reshaping"
 			} else if checking {
 				state = "checking"
 			} else {

--- a/mdstat_test.go
+++ b/mdstat_test.go
@@ -283,6 +283,21 @@ func TestFS_MDStat(t *testing.T) {
 			BlocksSyncedFinishTime: 0.2,
 			BlocksSyncedSpeed:      114176,
 			Devices:                []string{"sda3", "sdb3"}},
+		"md42": {
+			Name:                   "md42",
+			ActivityState:          "reshaping",
+			DisksActive:            2,
+			DisksTotal:             3,
+			DisksFailed:            0,
+			DisksDown:              1,
+			DisksSpare:             1,
+			BlocksTotal:            1953381440,
+			BlocksSynced:           1096879076,
+			BlocksToBeSynced:       1953381440,
+			BlocksSyncedPct:        56.1,
+			BlocksSyncedFinishTime: 1868.1,
+			BlocksSyncedSpeed:      7640,
+			Devices:                []string{"sda1", "sdd1", "sde1"}},
 	}
 
 	if want, have := len(refs), len(mdStats); want != have {

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -2253,7 +2253,7 @@ Lines: 1
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/mdstat
-Lines: 60
+Lines: 65
 Personalities : [linear] [multipath] [raid0] [raid1] [raid6] [raid5] [raid4] [raid10]
 
 md3 : active raid6 sda1[8] sdh1[7] sdg1[6] sdf1[5] sde1[11] sdd1[3] sdc1[10] sdb1[9] sdd1[10](S) sdd2[11](S)
@@ -2312,6 +2312,11 @@ md120 : active linear sda1[1] sdb1[0]
 
 md101 : active (read-only) raid0 sdb[2] sdd[1] sdc[0]
       322560 blocks super 1.2 512k chunks
+
+md42 : active raid5 sda1[3](S) sdd1[0] sde1[1]
+      1953381440 blocks super 1.2 level 5, 64k chunk, algorithm 2 [3/2] [UU_]
+      [===========>.........]  reshape = 56.1% (1096879076/1953381440) finish=1868.1min speed=7640K/sec
+      bitmap: 4/15 pages [16KB], 65536KB chunk
 
 unused devices: <none>
 Mode: 644


### PR DESCRIPTION
This change will properly catch raids that are currently undergoing conversion (reshaping), i.e. from RAID1 to RAID5 as in my case.