### PR TITLE
NetIPSocketSummary: Fix typo in godoc: UPD→UDP

### DIFF
--- a/net_ip_socket.go
+++ b/net_ip_socket.go
@@ -50,7 +50,7 @@ type (
 		// UsedSockets shows the total number of parsed lines representing the
 		// number of used sockets.
 		UsedSockets uint64
-		// Drops shows the total number of dropped packets of all UPD sockets.
+		// Drops shows the total number of dropped packets of all UDP sockets.
 		Drops *uint64
 	}
 


### PR DESCRIPTION
Change "UPD" to "UDP" in the godoc for the Drops field.

Follow-up to #538.