### PR TITLE
Do not collect InfiniBand counters for Broadcom RoCE NICs

### DIFF
--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -279,8 +279,8 @@ func (fs FS) parseInfiniBandPort(name string, port string) (*InfiniBandPort, err
 		return nil, fmt.Errorf("could not parse rate file in %q: %w", portPath, err)
 	}
 
-	// Intel irdma module does not expose /sys/class/infiniband/<device>/ports/<port-num>/counters
-	if !strings.HasPrefix(ibp.Name, "irdma") {
+	// Intel irdma and Broadcom RoCE does not expose /sys/class/infiniband/<device>/ports/<port-num>/counters
+	if !strings.HasPrefix(ibp.Name, "irdma") && !strings.HasPrefix(ibp.Name, "bnxt_re") {
 		counters, err := parseInfiniBandCounters(portPath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Broadcom RoCE NICs (bnxt_re#) does not have the counter metrics exposed in `/sys/class/infiniband/<device>/ports/<port-num>/counter`.

```shell
$ strace -e trace=open,openat node_exporter --log.level=debug
...
1270794 openat(AT_FDCWD, "/sys/class/infiniband/bnxt_re0/ports/1/counters", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
...

$ ls /sys/class/infiniband/bnxt_re0/ports/1/counters
ls: cannot access '/sys/class/infiniband/bnxt_re0/ports/1/counters': No such file or directory
```

This will cause Node Exporter to never collect any InfiniBand metrics since it always return with error ENOENT