### PR TITLE
Build CPUInfo on Darwin

### DIFF
--- a/cpuinfo.go
+++ b/cpuinfo.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux
-// +build linux
-
 package procfs
 
 import (

--- a/cpuinfo_darwin.go
+++ b/cpuinfo_darwin.go
@@ -1,0 +1,19 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+// +build darwin
+
+package procfs
+
+var parseCPUInfo = parseCPUInfoDummy


### PR DESCRIPTION
`cpuinfo.go` is currently only built on Linux and it breaks Darwin builds for no apparent reason. 
I understand that there's no procfs on Darwin but it should still be possible to use macOS for development of projects that use this package.

This change allows it to be built on Darwin with a dummy `parseCPUInfo` implementation.

Please let me know if I need to change this solution in any way. Thanks!