### PR TITLE
class_infiniband: continue on syscall EINVAL

### DIFF
--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/prometheus/procfs/internal/util"
 )
@@ -319,7 +320,7 @@ func parseInfiniBandCounters(portPath string) (*InfiniBandCounters, error) {
 		name := filepath.Join(path, f.Name())
 		value, err := util.SysReadFile(name)
 		if err != nil {
-			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || errors.Is(err, os.ErrInvalid) {
+			if os.IsNotExist(err) || os.IsPermission(err) || err.Error() == "operation not supported" || errors.Is(err, os.ErrInvalid) || errors.Is(err, syscall.EINVAL) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %q: %w", name, err)


### PR DESCRIPTION
Addresses https://github.com/prometheus/procfs/issues/704, in a very naive way.

In some very bleeding-edge configurations, syscalls against some IB counters will return `invalid argument`. This bubbles back to callers (e.g. node_exporter) in a very bad way -- e.g. all IB metrics collection failing when a single or group of IB ports returns this.

Suspect this has always been an error case and possible to experience (the syscall code path in procfs has been in place for ages), but it's the first time we're seeing it in a very new hardware deployment.

