### PR TITLE
add SysBlockDeviceQueueStat

### DIFF
--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -442,6 +442,15 @@ func (fs FS) SysBlockDeviceQueueStats(device string) (BlockQueueStats, error) {
 	return stat, nil
 }
 
+// SysBlockDeviceQueueStat returns a single stat from /sys/block/xxx/queue where xxx is a device name and stat is a file.
+func (fs FS) SysBlockDeviceQueueStat(device string, file string) (string, error) {
+	stat, err := util.SysReadFile(fs.sys.Path(sysBlockPath, device, sysBlockQueue, file))
+	if err != nil {
+		return "", err
+	}
+	return stat, nil
+}
+
 func (fs FS) SysBlockDeviceMapperInfo(device string) (DeviceMapperInfo, error) {
 	info := DeviceMapperInfo{}
 	// Files with uint64 fields

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -152,6 +152,13 @@ func TestBlockDevice(t *testing.T) {
 	if !reflect.DeepEqual(blockQueueStat, blockQueueStatExpected) {
 		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", blockQueueStatExpected, blockQueueStat)
 	}
+	rotational, err := blockdevice.SysBlockDeviceQueueStat(devices[7], "rotational")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotational != "1" {
+		t.Errorf("Incorrect BlockQueueStat('rotational'), expected: \n%+v, got: \n%+v", 1, rotational)
+	}
 }
 
 func TestBlockDmInfo(t *testing.T) {


### PR DESCRIPTION
SysBlockDeviceQueueStat returns a single stat from `/sys/block/xxx/queue` where `xxx` is a device name and `stat` is a file. Allow fetching a single queue stat without parsing the entire queue sysfs structure.

See: https://github.com/prometheus/node_exporter/issues/3282#issuecomment-2755706786