### PR TITLE
Use SysReadFile for thermals and skip failed zones

### DIFF
--- a/internal/util/sysreadfile.go
+++ b/internal/util/sysreadfile.go
@@ -20,6 +20,8 @@ package util
 import (
 	"bytes"
 	"os"
+	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -47,4 +49,22 @@ func SysReadFile(file string) (string, error) {
 	}
 
 	return string(bytes.TrimSpace(b[:n])), nil
+}
+
+// SysReadUintFromFile reads a file using SysReadFile and attempts to parse a uint64 from it.
+func SysReadUintFromFile(path string) (uint64, error) {
+	data, err := SysReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+}
+
+// SysReadIntFromFile reads a file using SysReadFile and attempts to parse a int64 from it.
+func SysReadIntFromFile(path string) (int64, error) {
+	data, err := SysReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
 }

--- a/sysfs/class_thermal.go
+++ b/sysfs/class_thermal.go
@@ -51,7 +51,7 @@ func (fs FS) ClassThermalZoneStats() ([]ClassThermalZoneStats, error) {
 	for _, zone := range zones {
 		zoneStats, err := parseClassThermalZone(zone)
 		if err != nil {
-			if errors.Is(err, syscall.ENODATA) || errors.As(err, new(*fsp.PathError)) {
+			if errors.Is(err, syscall.ENODATA) || errors.As(err, new(*fsp.PathError)) || errors.Is(err, syscall.EAGAIN) {
 				continue
 			}
 			return nil, err
@@ -72,7 +72,7 @@ func parseClassThermalZone(zone string) (ClassThermalZoneStats, error) {
 	if err != nil {
 		return ClassThermalZoneStats{}, err
 	}
-	zoneTemp, err := util.ReadIntFromFile(filepath.Join(zone, "temp"))
+	zoneTemp, err := util.SysReadIntFromFile(filepath.Join(zone, "temp"))
 	if err != nil {
 		return ClassThermalZoneStats{}, err
 	}
@@ -85,7 +85,7 @@ func parseClassThermalZone(zone string) (ClassThermalZoneStats, error) {
 	zoneMode := util.ParseBool(mode)
 
 	var zonePassive *uint64
-	passive, err := util.ReadUintFromFile(filepath.Join(zone, "passive"))
+	passive, err := util.SysReadUintFromFile(filepath.Join(zone, "passive"))
 	if os.IsNotExist(err) || os.IsPermission(err) {
 		zonePassive = nil
 	} else if err != nil {


### PR DESCRIPTION
Switches all calls in the thermal zones processing to use SysReadFile so
that unavailable zones won't stall forever waiting for them to become
available. Also continues processing in the case that one zone fails
with EAGAIN, as is the case for temporarily unavailable zones.

Addresses #698
