### PR TITLE
chore: clean up golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,16 +19,12 @@ linters:
     misspell:
       locale: US
   exclusions:
-    generated: lax
     presets:
       - comments
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    warn-unused: true
 formatters:
   enable:
     - gofmt
@@ -37,9 +33,3 @@ formatters:
     goimports:
       local-prefixes:
         - github.com/prometheus/procfs
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$


### PR DESCRIPTION
#### Description

chore: clean up golangci-lint configuration