### PR TITLE
nvme: Add ControllerID output

### DIFF
--- a/sysfs/class_nvme.go
+++ b/sysfs/class_nvme.go
@@ -33,6 +33,7 @@ type NVMeDevice struct {
 	Model            string // /sys/class/nvme/<Name>/model
 	State            string // /sys/class/nvme/<Name>/state
 	FirmwareRevision string // /sys/class/nvme/<Name>/firmware_rev
+	ControllerID     string // /sys/class/nvme/<Name>/cntlid
 }
 
 // NVMeClass is a collection of every NVMe device in /sys/class/nvme.
@@ -67,7 +68,7 @@ func (fs FS) parseNVMeDevice(name string) (*NVMeDevice, error) {
 	path := fs.sys.Path(nvmeClassPath, name)
 	device := NVMeDevice{Name: name}
 
-	for _, f := range [...]string{"firmware_rev", "model", "serial", "state"} {
+	for _, f := range [...]string{"firmware_rev", "model", "serial", "state", "cntlid"} {
 		name := filepath.Join(path, f)
 		value, err := util.SysReadFile(name)
 		if err != nil {
@@ -83,6 +84,8 @@ func (fs FS) parseNVMeDevice(name string) (*NVMeDevice, error) {
 			device.Serial = value
 		case "state":
 			device.State = value
+		case "cntlid":
+			device.ControllerID = value
 		}
 	}
 

--- a/sysfs/class_nvme_test.go
+++ b/sysfs/class_nvme_test.go
@@ -40,6 +40,7 @@ func TestNVMeClass(t *testing.T) {
 			Model:            "Samsung SSD 970 PRO 512GB",
 			Serial:           "S680HF8N190894I",
 			State:            "live",
+			ControllerID:     "1997",
 		},
 	}
 

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -6412,6 +6412,11 @@ Mode: 755
 Directory: fixtures/sys/class/nvme/nvme0
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/nvme/nvme0/cntlid
+Lines: 1
+1997
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/class/nvme/nvme0/firmware_rev
 Lines: 1
 1B2QEXP7


### PR DESCRIPTION
exposing the ControllerID along with the existing parameters