### PR TITLE
Out of range panic fix

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -86,7 +86,9 @@ func parseCrypto(r io.Reader) ([]Crypto, error) {
 		if len(kv) != 2 {
 			return nil, fmt.Errorf("%w: Cannot parse line: %q", ErrFileParse, text)
 		}
-
+		if len(out) == 0 {
+			continue
+		}
 		k := strings.TrimSpace(kv[0])
 		v := strings.TrimSpace(kv[1])
 


### PR DESCRIPTION
The Svace static analyzer (https://www.ispras.ru/en/technologies/svace/) flagged this code as suspicious: it could lead to a panic (out of range) if len(out) == 0. It might happen if text would be e.g. "bla:bla"