### PR TITLE
sysfs/class_sas_phy: Continue on EINVAL in parseSASPhy

### DIFF
--- a/sysfs/class_sas_phy.go
+++ b/sysfs/class_sas_phy.go
@@ -17,11 +17,13 @@
 package sysfs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/prometheus/procfs/internal/util"
 )
@@ -97,7 +99,7 @@ func (fs FS) parseSASPhy(name string) (*SASPhy, error) {
 		if fileinfo.Mode().IsRegular() {
 			value, err := util.SysReadFile(name)
 			if err != nil {
-				if os.IsPermission(err) {
+				if os.IsPermission(err) || errors.Is(err, syscall.EINVAL) {
 					continue
 				}
 				return nil, fmt.Errorf("failed to read file %q: %w", name, err)


### PR DESCRIPTION
For the mpt3sas driver, it returns EINVAL when reading error counters such as invalid_dword_count from PHYs that do not return data in [mpt3sas_transport](https://elixir.bootlin.com/linux/v6.16.8/source/drivers/scsi/mpt3sas/mpt3sas_transport.c#L1321-L1374). Better to continue on EINVAL than error out in that case.