### PR TITLE
meminfo: Fix ZswappedBytes

### DIFF
--- a/meminfo.go
+++ b/meminfo.go
@@ -307,7 +307,7 @@ func parseMemInfo(r io.Reader) (*Meminfo, error) {
 			m.ZswapBytes = &valBytes
 		case "Zswapped:":
 			m.Zswapped = &val
-			m.ZswapBytes = &valBytes
+			m.ZswappedBytes = &valBytes
 		case "Dirty:":
 			m.Dirty = &val
 			m.DirtyBytes = &valBytes

--- a/meminfo_test.go
+++ b/meminfo_test.go
@@ -14,12 +14,13 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMeminfo(t *testing.T) {
-	expected := Meminfo{
+	want := Meminfo{
 		MemTotal:          newuint64(15666184),
 		MemFree:           newuint64(440324),
 		Buffers:           newuint64(1020128),
@@ -35,6 +36,8 @@ func TestMeminfo(t *testing.T) {
 		Mlocked:           newuint64(0),
 		SwapTotal:         newuint64(0),
 		SwapFree:          newuint64(0),
+		Zswap:             newuint64(22414),
+		Zswapped:          newuint64(10502),
 		Dirty:             newuint64(768),
 		Writeback:         newuint64(0),
 		AnonPages:         newuint64(266216),
@@ -79,6 +82,8 @@ func TestMeminfo(t *testing.T) {
 		MlockedBytes:           newuint64(0),
 		SwapTotalBytes:         newuint64(0),
 		SwapFreeBytes:          newuint64(0),
+		ZswapBytes:             newuint64(22951936),
+		ZswappedBytes:          newuint64(10754048),
 		DirtyBytes:             newuint64(786432),
 		WritebackBytes:         newuint64(0),
 		AnonPagesBytes:         newuint64(272605184),
@@ -105,14 +110,12 @@ func TestMeminfo(t *testing.T) {
 		DirectMap2MBytes:       newuint64(16424894464),
 	}
 
-	have, err := getProcFixtures(t).Meminfo()
+	got, err := getProcFixtures(t).Meminfo()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(have, expected) {
-		t.Logf("have: %+v", have)
-		t.Logf("expected: %+v", expected)
-		t.Errorf("structs are not equal")
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected meminfo entry (-want +got):\n%s", diff)
 	}
 }

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -2513,7 +2513,7 @@ unused devices: <none>
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/meminfo
-Lines: 43
+Lines: 45
 MemTotal:       15666184 kB
 MemFree:          440324 kB
 Buffers:         1020128 kB
@@ -2529,6 +2529,8 @@ Unevictable:           0 kB
 Mlocked:               0 kB
 SwapTotal:             0 kB
 SwapFree:              0 kB
+Zswap:             22414 kB
+Zswapped:          10502 kB
 Dirty:               768 kB
 Writeback:             0 kB
 AnonPages:        266216 kB


### PR DESCRIPTION
Fix assignment of ZswappedBytes parsing.
* Add tests.
* Migrate `meminfo_test.go` to `cmp` package.

Fixes: https://github.com/prometheus/procfs/issues/758