### PR TITLE
chore: Migrate tests to cmp package

### DIFF
--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -16,8 +16,9 @@ package blockdevice
 import (
 	"errors"
 	"os"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 const (
@@ -150,8 +151,8 @@ func TestBlockDevice(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(blockQueueStat, blockQueueStatExpected) {
-		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", blockQueueStatExpected, blockQueueStat)
+	if diff := cmp.Diff(blockQueueStat, blockQueueStatExpected); diff != "" {
+		t.Fatalf("unexpected BlockQueueStat (-want +got):\n%s", diff)
 	}
 }
 
@@ -176,8 +177,8 @@ func TestBlockDmInfo(t *testing.T) {
 		UseBlkMQ:                  0,
 		UUID:                      "LVM-3zSHSR5Nbf4j7g6auAAefWY2CMaX01theZYEvQyecVsm2WtX3iY5q51qq5dWWOq7",
 	}
-	if !reflect.DeepEqual(dm0Info, dm0InfoExpected) {
-		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", dm0InfoExpected, dm0Info)
+	if diff := cmp.Diff(dm0Info, dm0InfoExpected); diff != "" {
+		t.Fatalf("unexpected BlockQueueStat (-want +got):\n%s", diff)
 	}
 
 	dm1Info, err := blockdevice.SysBlockDeviceMapperInfo(devices[1])
@@ -195,8 +196,8 @@ func TestBlockDmInfo(t *testing.T) {
 		t.Fatal("SysBlockDeviceMapperInfo on sda was supposed to fail.")
 	}
 	dm1InfoExpected := DeviceMapperInfo{}
-	if !reflect.DeepEqual(dm1Info, dm1InfoExpected) {
-		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", dm0InfoExpected, dm0Info)
+	if diff := cmp.Diff(dm1Info, dm1InfoExpected); diff != "" {
+		t.Fatalf("unexpected BlockQueueStat (-want +got):\n%s", diff)
 	}
 }
 
@@ -217,8 +218,8 @@ func TestSysBlockDeviceUnderlyingDevices(t *testing.T) {
 	underlying0Expected := UnderlyingDeviceInfo{
 		DeviceNames: []string{"sda"},
 	}
-	if !reflect.DeepEqual(underlying0, underlying0Expected) {
-		t.Errorf("Incorrect BlockQueueStat, expected: \n%+v, got: \n%+v", underlying0Expected, underlying0)
+	if diff := cmp.Diff(underlying0, underlying0Expected); diff != "" {
+		t.Fatalf("unexpected BlockQueueStat (-want +got):\n%s", diff)
 	}
 }
 

--- a/fscache_test.go
+++ b/fscache_test.go
@@ -14,8 +14,9 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFscacheinfo(t *testing.T) {
@@ -128,9 +129,7 @@ func TestFscacheinfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(have, expected) {
-		t.Logf("have: %+v", have)
-		t.Logf("expected: %+v", expected)
-		t.Errorf("structs are not equal")
+	if diff := cmp.Diff(have, expected); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/iscsi/get_test.go
+++ b/iscsi/get_test.go
@@ -14,8 +14,9 @@
 package iscsi_test
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/prometheus/procfs/iscsi"
 )
@@ -140,8 +141,8 @@ func TestGetStats(t *testing.T) {
 
 	for i, stat := range sysfsStat {
 		want, have := tests[i].stat, stat
-		if !reflect.DeepEqual(want, have) {
-			t.Errorf("unexpected iSCSI stats:\nwant:\n%v\nhave:\n%v", want, have)
+		if diff := cmp.Diff(want, have); diff != "" {
+			t.Fatalf("unexpected iSCSI stats (-want +got):\n%s", diff)
 		} else {
 			readMB, writeMB, iops, err := iscsi.ReadWriteOPS(stat.RootPath+"/"+stat.Name,
 				stat.Tpgt[0].Name, stat.Tpgt[0].Luns[0].Name)
@@ -150,14 +151,14 @@ func TestGetStats(t *testing.T) {
 					stat.Name, stat.Tpgt[0].Name, stat.Tpgt[0].Luns[0].Name)
 				t.Errorf("%v", err)
 			}
-			if !reflect.DeepEqual(readTests[i].read, readMB) {
-				t.Errorf("unexpected iSCSI read data :\nwant:\n%v\nhave:\n%v", readTests[i].read, readMB)
+			if diff := cmp.Diff(readTests[i].read, readMB); diff != "" {
+				t.Fatalf("unexpected iSCSI read data (-want +got):\n%s", diff)
 			}
-			if !reflect.DeepEqual(readTests[i].write, writeMB) {
-				t.Errorf("unexpected iSCSI write data :\nwant:\n%v\nhave:\n%v", readTests[i].write, writeMB)
+			if diff := cmp.Diff(readTests[i].write, writeMB); diff != "" {
+				t.Fatalf("unexpected iSCSI write data (-want +got):\n%s", diff)
 			}
-			if !reflect.DeepEqual(readTests[i].iops, iops) {
-				t.Errorf("unexpected iSCSI iops data :\nwant:\n%v\nhave:\n%v", readTests[i].iops, iops)
+			if diff := cmp.Diff(readTests[i].iops, iops); diff != "" {
+				t.Fatalf("unexpected iSCSI iops data (-want +got):\n%s", diff)
 			}
 			switch stat.Tpgt[0].Luns[0].Backstore {
 			case "rd_mcp":
@@ -168,8 +169,8 @@ func TestGetStats(t *testing.T) {
 				// Name ObjectName
 				wantRdmcp := &iscsi.RDMCP{"rd_mcp_" + stat.Tpgt[0].Luns[0].TypeNumber, stat.Tpgt[0].Luns[0].ObjectName}
 
-				if !reflect.DeepEqual(wantRdmcp, haveRdmcp) {
-					t.Errorf("unexpected rdmcp data :\nwant:\n%v\nhave:\n%v", wantRdmcp, haveRdmcp)
+				if diff := cmp.Diff(wantRdmcp, haveRdmcp); diff != "" {
+					t.Fatalf("unexpected rdmcp data (-want +got):\n%s", diff)
 				}
 			case "iblock":
 				haveIblock, err := sysconfigfs.GetIblockUdev("0", "block_lio_rbd1")
@@ -178,8 +179,8 @@ func TestGetStats(t *testing.T) {
 				}
 				// Name Bnumber ObjectName Iblock
 				wantIblock := &iscsi.IBLOCK{"iblock_" + stat.Tpgt[0].Luns[0].TypeNumber, stat.Tpgt[0].Luns[0].TypeNumber, stat.Tpgt[0].Luns[0].ObjectName, "/dev/rbd1"}
-				if !reflect.DeepEqual(wantIblock, haveIblock) {
-					t.Errorf("unexpected iblock data :\nwant:\n%v\nhave:\n%v", wantIblock, haveIblock)
+				if diff := cmp.Diff(wantIblock, haveIblock); diff != "" {
+					t.Fatalf("unexpected iblock data (-want +got):\n%s", diff)
 				}
 			case "fileio":
 				haveFileIO, err := sysconfigfs.GetFileioUdev("1", "file_lio_1G")
@@ -188,8 +189,8 @@ func TestGetStats(t *testing.T) {
 				}
 				// Name, Fnumber, ObjectName, Filename
 				wantFileIO := &iscsi.FILEIO{"fileio_" + stat.Tpgt[0].Luns[0].TypeNumber, stat.Tpgt[0].Luns[0].TypeNumber, "file_lio_1G", "/home/iscsi/file_back_1G"}
-				if !reflect.DeepEqual(wantFileIO, haveFileIO) {
-					t.Errorf("unexpected fileio data :\nwant:\n%v\nhave:\n%v", wantFileIO, haveFileIO)
+				if diff := cmp.Diff(wantFileIO, haveFileIO); diff != "" {
+					t.Fatalf("unexpected fileio data (-want +got):\n%s", diff)
 				}
 			case "rbd":
 				haveRBD, err := sysconfigfs.GetRBDMatch("0", "iscsi-images-demo")
@@ -198,8 +199,8 @@ func TestGetStats(t *testing.T) {
 				}
 				// Name, Rnumber, Pool, Image
 				wantRBD := &iscsi.RBD{"rbd_" + stat.Tpgt[0].Luns[0].TypeNumber, stat.Tpgt[0].Luns[0].TypeNumber, "iscsi-images", "demo"}
-				if !reflect.DeepEqual(wantRBD, haveRBD) {
-					t.Errorf("unexpected fileio data :\nwant:\n%v\nhave:\n%v", wantRBD, haveRBD)
+				if diff := cmp.Diff(wantRBD, haveRBD); diff != "" {
+					t.Fatalf("unexpected fileio data (-want +got):\n%s", diff)
 				}
 			}
 		}

--- a/mountinfo_test.go
+++ b/mountinfo_test.go
@@ -13,7 +13,6 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -179,8 +178,8 @@ func TestMountInfo(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 
-		if want, have := test.mount, mount; !reflect.DeepEqual(want, have) {
-			t.Errorf("mounts:\nwant:\n%+v\nhave:\n%+v", want, have)
+		if diff := cmp.Diff(test.mount, mount); diff != "" {
+			t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/net_conntrackstat_test.go
+++ b/net_conntrackstat_test.go
@@ -15,8 +15,9 @@ package procfs
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseConntrackStat(t *testing.T) {
@@ -79,8 +80,8 @@ func TestParseConntrackStat(t *testing.T) {
 			SearchRestart: 4,
 		},
 	}
-	if !reflect.DeepEqual(want, have) {
-		t.Errorf("want %v, have %v", want, have)
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }
 
@@ -112,7 +113,7 @@ func TestParseOldConntrackStat(t *testing.T) {
 			SearchRestart: 0,
 		},
 	}
-	if !reflect.DeepEqual(want, have) {
-		t.Errorf("want %v, have %v", want, have)
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/net_ip_socket_test.go
+++ b/net_ip_socket_test.go
@@ -15,8 +15,9 @@ package procfs
 
 import (
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_parseNetIPSocketLine(t *testing.T) {
@@ -115,8 +116,8 @@ func Test_parseNetIPSocketLine(t *testing.T) {
 			if tt.want == nil && got != nil {
 				t.Errorf("parseNetIPSocketLine() = %v, want %v", got, tt.want)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseNetIPSocketLine() = %#v, want %#v", got, tt.want)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/net_route_test.go
+++ b/net_route_test.go
@@ -15,8 +15,9 @@ package procfs
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseNetRoute(t *testing.T) {
@@ -54,7 +55,7 @@ eno16780032      0000A8C0     00000000  0001   0       0    100     0000FFFF  0 
 			IRTT:        0,
 		},
 	}
-	if !reflect.DeepEqual(want, parsed) {
-		t.Errorf("want %v, parsed %v", want, parsed)
+	if diff := cmp.Diff(want, parsed); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/net_tcp_test.go
+++ b/net_tcp_test.go
@@ -15,8 +15,9 @@ package procfs
 
 import (
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_newNetTCP(t *testing.T) {
@@ -120,8 +121,8 @@ func Test_newNetTCP(t *testing.T) {
 				t.Errorf("newNetTCP() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("newNetTCP() = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -166,8 +167,8 @@ func Test_newNetTCPSummary(t *testing.T) {
 				t.Errorf("newNetTCPSummary() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("newNetTCPSummary() = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/net_udp_test.go
+++ b/net_udp_test.go
@@ -15,8 +15,9 @@ package procfs
 
 import (
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_newNetUDP(t *testing.T) {
@@ -125,8 +126,8 @@ func Test_newNetUDP(t *testing.T) {
 				t.Errorf("newNetUDP() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("newNetUDP() = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Fatalf("unexpected newNetUDP() (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -171,8 +172,8 @@ func Test_newNetUDPSummary(t *testing.T) {
 				t.Errorf("newNetUDPSummary() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("newNetUDPSummary() = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Fatalf("unexpected newNetUDPSummary() (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/net_wireless_test.go
+++ b/net_wireless_test.go
@@ -14,8 +14,9 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestWireless(t *testing.T) {
@@ -63,8 +64,8 @@ func TestWireless(t *testing.T) {
 	}
 
 	for i, iface := range got {
-		if !reflect.DeepEqual(iface, expected[i]) {
-			t.Errorf("unexpected interface got %+v, expected %+v", iface, expected[i])
+		if diff := cmp.Diff(iface, expected[i]); diff != "" {
+			t.Fatalf("unexpected interface (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/nfnetlink_queue.go
+++ b/nfnetlink_queue.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/nfnetlink_queue_test.go
+++ b/nfnetlink_queue_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -14,8 +14,9 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseNFNetLinkQueueLine(t *testing.T) {
@@ -67,8 +68,8 @@ func TestParseNFNetLinkQueueLine(t *testing.T) {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 		}
 
-		if want, have := test.nfNetLinkQueue, nfNetLinkQueue; !reflect.DeepEqual(want, have) {
-			t.Errorf("nfNetLinkQueue:\nwant:\n%+v\nhave:\n%+v", want, have)
+		if diff := cmp.Diff(test.nfNetLinkQueue, nfNetLinkQueue); diff != "" {
+			t.Fatalf("unexpected nfNetLinkQueue (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/nfs/parse_nfs_test.go
+++ b/nfs/parse_nfs_test.go
@@ -14,9 +14,10 @@
 package nfs_test
 
 import (
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/prometheus/procfs/nfs"
 )
@@ -297,8 +298,8 @@ proc4 61 1 0 0 0 0 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if want, have := tt.stats, stats; !reflect.DeepEqual(want, have) {
-				t.Fatalf("unexpected NFS stats:\nwant:\n%v\nhave:\n%v", want, have)
+			if diff := cmp.Diff(tt.stats, stats); diff != "" {
+				t.Fatalf("unexpected NFS stats (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/nfs/parse_nfsd_test.go
+++ b/nfs/parse_nfsd_test.go
@@ -14,9 +14,10 @@
 package nfs_test
 
 import (
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/prometheus/procfs/nfs"
 )
@@ -629,8 +630,8 @@ wdeleg_getattr 765432`,
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if want, have := tt.stats, stats; !reflect.DeepEqual(want, have) {
-				t.Fatalf("unexpected NFS stats:\nwant:\n%v\nhave:\n%v", want, have)
+			if diff := cmp.Diff(tt.stats, stats); diff != "" {
+				t.Fatalf("unexpected NFS stats (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/proc_cgroup_test.go
+++ b/proc_cgroup_test.go
@@ -14,8 +14,9 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseCgroupString(t *testing.T) {
@@ -85,8 +86,8 @@ func TestParseCgroupString(t *testing.T) {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 		}
 
-		if want, have := test.cgroup, cgroup; !reflect.DeepEqual(want, have) {
-			t.Errorf("cgroup:\nwant:\n%+v\nhave:\n%+v", want, have)
+		if diff := cmp.Diff(test.cgroup, cgroup); diff != "" {
+			t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 		}
 	}
 

--- a/proc_cgroups_test.go
+++ b/proc_cgroups_test.go
@@ -14,8 +14,9 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestParseCgroupSummaryString(t *testing.T) {
@@ -56,9 +57,8 @@ func TestParseCgroupSummaryString(t *testing.T) {
 			t.Errorf("%s: unexpected error: %v", test.name, err)
 		}
 
-		if want, have := test.CgroupSummary, CgroupSummary; !reflect.DeepEqual(want, have) {
-			t.Errorf("cgroup:\nwant:\n%+v\nhave:\n%+v", want, have)
+		if diff := cmp.Diff(test.CgroupSummary, CgroupSummary); diff != "" {
+			t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 		}
 	}
-
 }

--- a/proc_interrupts_test.go
+++ b/proc_interrupts_test.go
@@ -14,8 +14,9 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestProcInterrupts(t *testing.T) {
@@ -83,8 +84,8 @@ func TestProcInterrupts(t *testing.T) {
 				if value.Devices != test.want.Devices {
 					t.Errorf("devices: want %s, have %s", test.want.Devices, value.Devices)
 				}
-				if !reflect.DeepEqual(value.Values, test.want.Values) {
-					t.Errorf("values: want %v, have %v", test.want.Values, value.Values)
+				if diff := cmp.Diff(test.want.Values, value.Values); diff != "" {
+					t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 				}
 			} else {
 				t.Errorf("IRQ %s not found", test.irq)

--- a/proc_status_test.go
+++ b/proc_status_test.go
@@ -14,8 +14,9 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestProcStatus(t *testing.T) {
@@ -135,8 +136,10 @@ func TestCpusAllowedList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want, have := []uint64{0, 1, 2, 3, 4, 5, 6, 7}, s.CpusAllowedList; !reflect.DeepEqual(want, have) {
-		t.Errorf("want CpusAllowedList %v, have %v", want, have)
+	want := []uint64{0, 1, 2, 3, 4, 5, 6, 7}
+
+	if diff := cmp.Diff(want, s.CpusAllowedList); diff != "" {
+		t.Fatalf("unexpected CpusAllowedList (-want +got):\n%s", diff)
 	}
 }
 
@@ -151,7 +154,9 @@ func TestNsPids(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want, have := []uint64{26235, 1}, s.NSpids; !reflect.DeepEqual(want, have) {
-		t.Errorf("want NsPids %v, have %v", want, have)
+	want := []uint64{26235, 1}
+
+	if diff := cmp.Diff(want, s.NSpids); diff != "" {
+		t.Fatalf("unexpected NsPids (-want +got):\n%s", diff)
 	}
 }

--- a/proc_test.go
+++ b/proc_test.go
@@ -17,6 +17,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSelf(t *testing.T) {
@@ -66,8 +68,8 @@ func TestCmdLine(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(tt.want, c1) {
-			t.Errorf("want cmdline %v, have %v", tt.want, c1)
+		if diff := cmp.Diff(tt.want, c1); diff != "" {
+			t.Fatalf("unexpected cmdline (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -88,8 +90,8 @@ func TestWchan(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(tt.want, c1) {
-			t.Errorf("want wchan %v, have %v", tt.want, c1)
+		if diff := cmp.Diff(tt.want, c1); diff != "" {
+			t.Fatalf("unexpected wchan (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -110,8 +112,8 @@ func TestComm(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(tt.want, c1) {
-			t.Errorf("want comm %v, have %v", tt.want, c1)
+		if diff := cmp.Diff(tt.want, c1); diff != "" {
+			t.Fatalf("unexpected comm (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -132,8 +134,8 @@ func TestExecutable(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(tt.want, exe) {
-			t.Errorf("want absolute path to exe %v, have %v", tt.want, exe)
+		if diff := cmp.Diff(tt.want, exe); diff != "" {
+			t.Fatalf("unexpected absolute path to exe (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -156,12 +158,12 @@ func TestCwd(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(tt.want, wd) {
+		if diff := cmp.Diff(tt.want, wd); diff != "" {
 			if wd == "" && tt.brokenLink {
 				// Allow the result to be empty when can't os.Readlink broken links
 				continue
 			}
-			t.Errorf("want absolute path to cwd %v, have %v", tt.want, wd)
+			t.Fatalf("unexpected absolute path to cwd (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -184,12 +186,12 @@ func TestRoot(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(tt.want, rdir) {
+		if diff := cmp.Diff(tt.want, rdir); diff != "" {
 			if rdir == "" && tt.brokenLink {
 				// Allow the result to be empty when can't os.Readlink broken links
 				continue
 			}
-			t.Errorf("want absolute path to rootdir %v, have %v", tt.want, rdir)
+			t.Fatalf("unexpected absolute path to rootdir (-want +got):\n%s", diff)
 		}
 	}
 }
@@ -226,8 +228,8 @@ func TestFileDescriptorTargets(t *testing.T) {
 		"../../symlinktargets/uvw",
 		"../../symlinktargets/xyz",
 	}
-	if !reflect.DeepEqual(want, fds) {
-		t.Errorf("want fds %v, have %v", want, fds)
+	if diff := cmp.Diff(want, fds); diff != "" {
+		t.Fatalf("unexpected fds (-want +got):\n%s", diff)
 	}
 }
 
@@ -266,8 +268,8 @@ func TestFileDescriptorsInfo(t *testing.T) {
 		ProcFDInfo{FD: "2", Pos: "0", Flags: "02004002", MntID: "9", InotifyInfos: nil},
 		ProcFDInfo{FD: "3", Pos: "0", Flags: "02004002", MntID: "9", InotifyInfos: nil},
 	}
-	if !reflect.DeepEqual(want, fdinfos) {
-		t.Errorf("want fdinfos %+v, have %+v", want, fdinfos)
+	if diff := cmp.Diff(want, fdinfos); diff != "" {
+		t.Fatalf("unexpected fdinfos (-want +got):\n%s", diff)
 	}
 }
 

--- a/swaps_test.go
+++ b/swaps_test.go
@@ -14,8 +14,9 @@
 package procfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSwaps(t *testing.T) {
@@ -105,8 +106,8 @@ func TestParseSwapString(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			if !reflect.DeepEqual(tt.swap, swap) {
-				t.Errorf("swap:\nwant:\n%+v\nhave:\n%+v", tt.swap, swap)
+			if diff := cmp.Diff(tt.swap, swap); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/sysfs/class_cooling_device_test.go
+++ b/sysfs/class_cooling_device_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestClassCoolingDeviceStats(t *testing.T) {
@@ -47,7 +48,7 @@ func TestClassCoolingDeviceStats(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(classCoolingDeviceStats, coolingDeviceTest) {
-		t.Errorf("Result not correct: want %v, have %v", classCoolingDeviceStats, coolingDeviceTest)
+	if diff := cmp.Diff(classCoolingDeviceStats, coolingDeviceTest); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/sysfs/class_drm_amdgpu_test.go
+++ b/sysfs/class_drm_amdgpu_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestClassDRMCardAMDGPUStats(t *testing.T) {
@@ -58,7 +59,7 @@ func TestClassDRMCardAMDGPUStats(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(classDRMCardStats, drmTest) {
-		t.Errorf("Result not correct: want %v, have %v", classDRMCardStats, drmTest)
+	if diff := cmp.Diff(classDRMCardStats, drmTest); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/sysfs/class_thermal_test.go
+++ b/sysfs/class_thermal_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/prometheus/procfs/internal/util"
 )
@@ -56,7 +57,7 @@ func TestClassThermalZoneStats(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(classThermalZoneStats, thermalTest) {
-		t.Errorf("Result not correct: want %v, have %v", classThermalZoneStats, thermalTest)
+	if diff := cmp.Diff(classThermalZoneStats, thermalTest); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/sysfs/clocksource_test.go
+++ b/sysfs/clocksource_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestNewClocksource(t *testing.T) {
@@ -40,7 +41,7 @@ func TestNewClocksource(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(clocksources, c) {
-		t.Errorf("Result not correct: want %v, have %v", clocksources, c)
+	if diff := cmp.Diff(clocksources, c); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/sysfs/net_class_aer_test.go
+++ b/sysfs/net_class_aer_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAerCountersByIface(t *testing.T) {
@@ -105,7 +106,7 @@ func TestAerCounters(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(aerCounters, ac) {
-		t.Errorf("Result not correct: want %v, have %v", aerCounters, ac)
+	if diff := cmp.Diff(aerCounters, ac); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/sysfs/net_class_ecn_test.go
+++ b/sysfs/net_class_ecn_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestEcnByIface(t *testing.T) {
@@ -96,7 +97,7 @@ func TestEcnDevices(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(ed, allEcnDevices) {
-		t.Errorf("Result not correct: want %v, have %v", allEcnDevices, ed)
+	if diff := cmp.Diff(ed, allEcnDevices); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/sysfs/net_class_test.go
+++ b/sysfs/net_class_test.go
@@ -17,8 +17,9 @@
 package sysfs
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestNewNetClassDevices(t *testing.T) {
@@ -125,7 +126,7 @@ func TestNetClass(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(netClass, nc) {
-		t.Errorf("Result not correct: want %v, have %v", netClass, nc)
+	if diff := cmp.Diff(netClass, nc); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -19,8 +19,9 @@ package sysfs
 import (
 	"errors"
 	"os"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func makeUint64(v uint64) *uint64 {
@@ -191,8 +192,8 @@ func TestSystemCpufreq(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(systemCpufreq, c) {
-		t.Errorf("Result not correct: want %v, have %v", systemCpufreq, c)
+	if diff := cmp.Diff(systemCpufreq, c); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 }
 
@@ -219,8 +220,8 @@ func TestIsolatedParsingCPU(t *testing.T) {
 	for _, params := range testParams {
 		t.Run("blabla", func(t *testing.T) {
 			res, err := parseCPURange(params.in)
-			if !reflect.DeepEqual(res, params.res) {
-				t.Fatalf("should have %v result: got %v", params.res, res)
+			if diff := cmp.Diff(res, params.res); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 			}
 			if err != nil && params.err != nil && err.Error() != params.err.Error() {
 				t.Fatalf("should have '%v' error: got '%v'", params.err, err)
@@ -239,8 +240,8 @@ func TestIsolatedCPUs(t *testing.T) {
 	}
 	isolated, err := fs.IsolatedCPUs()
 	expected := []uint16{1, 2, 3, 4, 5, 6, 7, 9}
-	if !reflect.DeepEqual(isolated, expected) {
-		t.Errorf("Result not correct: want %v, have %v", expected, isolated)
+	if diff := cmp.Diff(isolated, expected); diff != "" {
+		t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 	}
 	if err != nil {
 		t.Errorf("Error not correct: want %v, have %v", nil, err)

--- a/sysfs/vulnerability_test.go
+++ b/sysfs/vulnerability_test.go
@@ -18,8 +18,9 @@ package sysfs
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestFS_CPUVulnerabilities(t *testing.T) {
@@ -54,8 +55,8 @@ func TestFS_CPUVulnerabilities(t *testing.T) {
 			if !ok && !tt.wantErr {
 				t.Errorf("CPUVulnerabilities() vulnerability %s not found", tt.vulnerabilityName)
 			}
-			if !reflect.DeepEqual(gotVulnerability, tt.want) {
-				t.Errorf("CPUVulnerabilities() gotVulnerability = %v, want %v", gotVulnerability, tt.want)
+			if diff := cmp.Diff(gotVulnerability, tt.want); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/thread_test.go
+++ b/thread_test.go
@@ -18,6 +18,8 @@ import (
 	"sort"
 	"strconv"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 var (
@@ -33,13 +35,13 @@ func TestAllThreads(t *testing.T) {
 	}
 	sort.Sort(threads)
 	for i, tid := range testTIDS {
-		if wantTID, haveTID := tid, threads[i].PID; wantTID != haveTID {
-			t.Errorf("want TID %d, have %d", wantTID, haveTID)
+		if diff := cmp.Diff(tid, threads[i].PID); diff != "" {
+			t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 		}
 		wantFS := fixFS.proc.Path(strconv.Itoa(testPID), "task")
 		haveFS := string(threads[i].fs.proc)
-		if wantFS != haveFS {
-			t.Errorf("want fs %q, have %q", wantFS, haveFS)
+		if diff := cmp.Diff(wantFS, haveFS); diff != "" {
+			t.Fatalf("unexpected diff (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/xfs/parse_test.go
+++ b/xfs/parse_test.go
@@ -14,9 +14,10 @@
 package xfs_test
 
 import (
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/prometheus/procfs/xfs"
 )
@@ -748,8 +749,8 @@ func TestParseStats(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 
-		if want, have := tt.stats, stats; !reflect.DeepEqual(want, have) {
-			t.Errorf("unexpected XFS stats:\nwant:\n%v\nhave:\n%v", want, have)
+		if diff := cmp.Diff(tt.stats, stats); diff != "" {
+			t.Fatalf("unexpected XFS stats (-want +got):\n%s", diff)
 		}
 	}
 }


### PR DESCRIPTION
Migrate the majority of diff tests from `reflect.DeepEqual()` to `cmp.Diff()` to improve the test failure readability.