### PR TITLE
Update sysfs/class_thermal: continue on EINVAL in parseClassThermalZone to ignore only invalid thermal zones which raise "invalid argument"

### DIFF
--- a/sysfs/class_thermal.go
+++ b/sysfs/class_thermal.go
@@ -51,7 +51,8 @@ func (fs FS) ClassThermalZoneStats() ([]ClassThermalZoneStats, error) {
 	for _, zone := range zones {
 		zoneStats, err := parseClassThermalZone(zone)
 		if err != nil {
-			if errors.Is(err, syscall.ENODATA) || errors.As(err, new(*fsp.PathError)) || errors.Is(err, syscall.EAGAIN) {
+			if errors.Is(err, syscall.ENODATA) || errors.As(err, new(*fsp.PathError)) || errors.Is(err, syscall.EAGAIN) ||
+				errors.Is(err, syscall.EINVAL) {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
Sum-up: ignore invalid thermal zones to avoid discharding of all thermal zone metric.

Reading sysfs entries in the thermal zone may return EINVAL if the underlying data is not yet available or is in an inconsistent state. Continue on EINVAL allows metrics collection to continue successfully for other valid thermal zones.

Example of error log: time=2025-11-05T15:26:06.536+01:00 level=ERROR source=collector.go:168 msg="collector failed" name=thermal_zone duration_seconds=0.171564844 err="invalid argument"