### PR TITLE
fix: handle 'delayed' state in sync_completed parsing

### DIFF
--- a/sysfs/mdraid.go
+++ b/sysfs/mdraid.go
@@ -166,7 +166,7 @@ func (fs FS) Mdraids() ([]Mdraid, error) {
 			}
 
 			if val, err := util.SysReadFile(filepath.Join(path, "sync_completed")); err == nil {
-				if val != "none" {
+				if val != "none" && val != "delayed" {
 					var a, b uint64
 
 					// File contains two values representing the fraction of number of completed

--- a/sysfs/mdraid_test.go
+++ b/sysfs/mdraid_test.go
@@ -155,3 +155,26 @@ func TestMdraidStats(t *testing.T) {
 		t.Fatalf("unexpected Mdraid (-want +got):\n%s", diff)
 	}
 }
+func TestMdraidDelayedSyncCompleted(t *testing.T) {
+	fs, err := NewFS("testdata/fixtures/sys/issue770")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mdraids, err := fs.Mdraids()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mdraids) != 1 {
+		t.Fatalf("expected 1 mdraid, got %d", len(mdraids))
+	}
+
+	md := mdraids[0]
+	if md.SyncCompleted != 0 {
+		t.Fatalf("expected SyncCompleted=0 for 'delayed' state, got %f", md.SyncCompleted)
+	}
+	if md.SyncAction != "resync" {
+		t.Fatalf("expected SyncAction='resync', got '%s'", md.SyncAction)
+	}
+}

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -19494,6 +19494,95 @@ Lines: 1
 extent_alloc 2 0 0 0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/issue770
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/issue770/block
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/issue770/block/md127
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/issue770/block/md127/md
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/array_state
+Lines: 1
+clean
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/chunk_size
+Lines: 1
+524288
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/degraded
+Lines: 1
+0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/issue770/block/md127/md/dev-sdaa
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/dev-sdaa/state
+Lines: 1
+spare
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/issue770/block/md127/md/dev-sdn
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/dev-sdn/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/issue770/block/md127/md/dev-sdo
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/dev-sdo/state
+Lines: 1
+in_sync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/issue770/block/md127/md/dev-sdp
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/dev-sdp/state
+Lines: 1
+faulty
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/level
+Lines: 1
+raid1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/metadata_version
+Lines: 1
+1.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/raid_disks
+Lines: 1
+3
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/sync_action
+Lines: 1
+resync
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/sync_completed
+Lines: 1
+delayed
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/issue770/block/md127/md/uuid
+Lines: 1
+7615b98d-f2ba-4d99-bee8-6202d8e130b9
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/kernel
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
## Summary
- Handle `delayed` as a special value in sync_completed parsing (similar to `none`)
- When multiple MD RAID arrays share physical devices and a check/resync is triggered for more than one, the kernel delays the action on all but one device
- In this case, `sync_completed` contains `delayed` instead of `none` or `N / M`

## Problem
The current code fails when `sync_completed` contains `delayed`:
```
error parsing mdraids: expected integer
```

## Solution
Add `delayed` to the list of special values that should not be parsed as integers.

## Testing
- Tested with manual test cases: `none`, `delayed`, `123 / 456`, `invalid`
- All cases handled correctly

Fixes #770
Related: prometheus/node_exporter#3500