### PR TITLE
Add support for `/sys/class/mei/mei0`

### DIFF
--- a/sysfs/class_mei.go
+++ b/sysfs/class_mei.go
@@ -1,3 +1,18 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
 package sysfs
 
 import (

--- a/sysfs/class_mei.go
+++ b/sysfs/class_mei.go
@@ -45,9 +45,7 @@ func (fs FS) MEIClass() (*MEIClass, error) {
 		filename := filepath.Join(path, name)
 		value, err := util.SysReadFile(filename)
 		if err != nil {
-			if os.IsPermission(err) {
-				continue
-			}
+			// no check for perms since all files (well apart from tx_queue_limit) are 0444
 			return nil, fmt.Errorf("failed to read file %q: %w", filename, err)
 		}
 

--- a/sysfs/class_mei.go
+++ b/sysfs/class_mei.go
@@ -37,7 +37,7 @@ type MEIClass struct {
 	TxQueueLimit  *string
 }
 
-// MEIClass returns Management Engine Interface (DMI) information read from /sys/class/mei/.
+// MEIClass returns Management Engine Interface (MEI) information read from /sys/class/mei/.
 func (fs FS) MEIClass() (*MEIClass, error) {
 	path := fs.sys.Path(meiClassPath)
 

--- a/sysfs/class_mei.go
+++ b/sysfs/class_mei.go
@@ -1,0 +1,77 @@
+package sysfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+const meiClassPath = "class/mei/mei0"
+
+type MEIClass struct {
+	Dev           *string
+	DevState      *string
+	FWStatus      *string
+	FWVersion     *string
+	HBMVersion    *string
+	HBMVersionDrv *string
+	Kind          *string
+	Trc           *string
+	TxQueueLimit  *string
+}
+
+// MEIClass returns Management Engine Interface (DMI) information read from /sys/class/mei/.
+func (fs FS) MEIClass() (*MEIClass, error) {
+	path := fs.sys.Path(meiClassPath)
+
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %q: %w", path, err)
+	}
+
+	var mei MEIClass
+	for _, f := range files {
+		if !f.Type().IsRegular() {
+			continue
+		}
+
+		name := f.Name()
+		if name == "uevent" {
+			continue
+		}
+
+		filename := filepath.Join(path, name)
+		value, err := util.SysReadFile(filename)
+		if err != nil {
+			if os.IsPermission(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read file %q: %w", filename, err)
+		}
+
+		switch name {
+		case "dev":
+			mei.Dev = &value
+		case "dev_state":
+			mei.DevState = &value
+		case "fw_status":
+			mei.FWStatus = &value
+		case "fw_ver":
+			mei.FWVersion = &value
+		case "hbm_ver":
+			mei.HBMVersion = &value
+		case "hbm_ver_drv":
+			mei.HBMVersionDrv = &value
+		case "kind":
+			mei.Kind = &value
+		case "trc":
+			mei.Trc = &value
+		case "tx_queue_limit":
+			mei.TxQueueLimit = &value
+		}
+	}
+
+	return &mei, nil
+}

--- a/sysfs/class_mei.go
+++ b/sysfs/class_mei.go
@@ -23,9 +23,10 @@ import (
 	"github.com/prometheus/procfs/internal/util"
 )
 
-const meiClassPath = "class/mei/mei0"
+const meiClassPath = "class/mei"
 
-type MEIClass struct {
+type MEIDev struct {
+	Name          *string
 	Dev           *string
 	DevState      *string
 	FWStatus      *string
@@ -37,16 +38,41 @@ type MEIClass struct {
 	TxQueueLimit  *string
 }
 
+type MEIClass map[string]MEIDev
+
 // MEIClass returns Management Engine Interface (MEI) information read from /sys/class/mei/.
 func (fs FS) MEIClass() (*MEIClass, error) {
 	path := fs.sys.Path(meiClassPath)
+
+	subdirs, err := os.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list MEI devices at %q: %w", path, err)
+	}
+
+	mei := make(MEIClass, len(subdirs))
+	for _, d := range subdirs {
+		dev, err := fs.parseMEI(d.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		mei[*dev.Name] = *dev
+	}
+
+	return &mei, nil
+}
+
+func (fs FS) parseMEI(meiDev string) (*MEIDev, error) {
+	path := fs.sys.Path(meiClassPath, meiDev)
 
 	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read directory %q: %w", path, err)
 	}
 
-	var mei MEIClass
+	var mei MEIDev
+	mei.Name = &meiDev
+
 	for _, f := range files {
 		if !f.Type().IsRegular() {
 			continue
@@ -60,7 +86,10 @@ func (fs FS) MEIClass() (*MEIClass, error) {
 		filename := filepath.Join(path, name)
 		value, err := util.SysReadFile(filename)
 		if err != nil {
-			// no check for perms since all files (well apart from tx_queue_limit) are 0444
+			if os.IsPermission(err) {
+				continue
+			}
+
 			return nil, fmt.Errorf("failed to read file %q: %w", filename, err)
 		}
 

--- a/sysfs/class_mei.go
+++ b/sysfs/class_mei.go
@@ -26,7 +26,6 @@ import (
 const meiClassPath = "class/mei"
 
 type MEIDev struct {
-	Name          *string
 	Dev           *string
 	DevState      *string
 	FWStatus      *string
@@ -56,22 +55,21 @@ func (fs FS) MEIClass() (*MEIClass, error) {
 			return nil, err
 		}
 
-		mei[*dev.Name] = *dev
+		mei[d.Name()] = dev
 	}
 
 	return &mei, nil
 }
 
-func (fs FS) parseMEI(meiDev string) (*MEIDev, error) {
+func (fs FS) parseMEI(meiDev string) (MEIDev, error) {
 	path := fs.sys.Path(meiClassPath, meiDev)
+
+	var mei MEIDev
 
 	files, err := os.ReadDir(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read directory %q: %w", path, err)
+		return mei, fmt.Errorf("failed to read directory %q: %w", path, err)
 	}
-
-	var mei MEIDev
-	mei.Name = &meiDev
 
 	for _, f := range files {
 		if !f.Type().IsRegular() {
@@ -90,7 +88,7 @@ func (fs FS) parseMEI(meiDev string) (*MEIDev, error) {
 				continue
 			}
 
-			return nil, fmt.Errorf("failed to read file %q: %w", filename, err)
+			return mei, fmt.Errorf("failed to read file %q: %w", filename, err)
 		}
 
 		switch name {
@@ -115,5 +113,5 @@ func (fs FS) parseMEI(meiDev string) (*MEIDev, error) {
 		}
 	}
 
-	return &mei, nil
+	return mei, nil
 }

--- a/sysfs/class_mei_test.go
+++ b/sysfs/class_mei_test.go
@@ -32,6 +32,7 @@ func TestMEIClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	name := "mei0"
 	dev := "244:0"
 	devState := "ENABLED"
 	fwStatus := "90000245\n00110500\n00000020\n00000000\n02F41F03\n40000000"
@@ -43,15 +44,18 @@ func TestMEIClass(t *testing.T) {
 	txQueueLimit := "50"
 
 	want := &MEIClass{
-		Dev:           &dev,
-		DevState:      &devState,
-		FWStatus:      &fwStatus,
-		FWVersion:     &fwVer,
-		HBMVersion:    &hbmVer,
-		HBMVersionDrv: &hbmVerDrv,
-		Kind:          &kind,
-		Trc:           &trc,
-		TxQueueLimit:  &txQueueLimit,
+		"mei0": MEIDev{
+			Name:          &name,
+			Dev:           &dev,
+			DevState:      &devState,
+			FWStatus:      &fwStatus,
+			FWVersion:     &fwVer,
+			HBMVersion:    &hbmVer,
+			HBMVersionDrv: &hbmVerDrv,
+			Kind:          &kind,
+			Trc:           &trc,
+			TxQueueLimit:  &txQueueLimit,
+		},
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {

--- a/sysfs/class_mei_test.go
+++ b/sysfs/class_mei_test.go
@@ -55,6 +55,6 @@ func TestMEIClass(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("unexpected DMI class (-want +got):\n%s", diff)
+		t.Fatalf("unexpected MEI class (-want +got):\n%s", diff)
 	}
 }

--- a/sysfs/class_mei_test.go
+++ b/sysfs/class_mei_test.go
@@ -1,0 +1,60 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package sysfs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMEIClass(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.MEIClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dev := "244:0"
+	devState := "ENABLED"
+	fwStatus := "90000245\n00110500\n00000020\n00000000\n02F41F03\n40000000"
+	fwVer := "0:18.0.5.2098\n0:18.0.5.2098\n0:18.0.5.2098"
+	hbmVer := "2.2"
+	hbmVerDrv := "2.2"
+	kind := "mei"
+	trc := "00000889"
+	txQueueLimit := "50"
+
+	want := &MEIClass{
+		Dev:           &dev,
+		DevState:      &devState,
+		FWStatus:      &fwStatus,
+		FWVersion:     &fwVer,
+		HBMVersion:    &hbmVer,
+		HBMVersionDrv: &hbmVerDrv,
+		Kind:          &kind,
+		Trc:           &trc,
+		TxQueueLimit:  &txQueueLimit,
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected DMI class (-want +got):\n%s", diff)
+	}
+}

--- a/sysfs/class_mei_test.go
+++ b/sysfs/class_mei_test.go
@@ -32,28 +32,41 @@ func TestMEIClass(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	name := "mei0"
-	dev := "244:0"
+	dev0 := "244:0"
+	dev1 := "243:0"
 	devState := "ENABLED"
-	fwStatus := "90000245\n00110500\n00000020\n00000000\n02F41F03\n40000000"
-	fwVer := "0:18.0.5.2098\n0:18.0.5.2098\n0:18.0.5.2098"
+	fwStatus0 := "90000245\n00110500\n00000020\n00000000\n02F41F03\n40000000"
+	fwStatus1 := "90000245\n00110500\n00000020\n00000004\n02F61F03\n40000000"
+	fwVer0 := "0:18.0.5.2098\n0:18.0.5.2098\n0:18.0.5.2098"
+	fwVer1 := "0:18.1.18.2595\n0:18.1.18.2595\n0:18.1.18.2599"
 	hbmVer := "2.2"
 	hbmVerDrv := "2.2"
 	kind := "mei"
-	trc := "00000889"
+	trc0 := "00000889"
+	trc1 := "00000879"
 	txQueueLimit := "50"
 
 	want := &MEIClass{
 		"mei0": MEIDev{
-			Name:          &name,
-			Dev:           &dev,
+			Dev:           &dev0,
 			DevState:      &devState,
-			FWStatus:      &fwStatus,
-			FWVersion:     &fwVer,
+			FWStatus:      &fwStatus0,
+			FWVersion:     &fwVer0,
 			HBMVersion:    &hbmVer,
 			HBMVersionDrv: &hbmVerDrv,
 			Kind:          &kind,
-			Trc:           &trc,
+			Trc:           &trc0,
+			TxQueueLimit:  &txQueueLimit,
+		},
+		"mei1": MEIDev{
+			Dev:           &dev1,
+			DevState:      &devState,
+			FWStatus:      &fwStatus1,
+			FWVersion:     &fwVer1,
+			HBMVersion:    &hbmVer,
+			HBMVersionDrv: &hbmVerDrv,
+			Kind:          &kind,
+			Trc:           &trc1,
 			TxQueueLimit:  &txQueueLimit,
 		},
 	}

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -6486,6 +6486,71 @@ Lines: 1
 4: ACTIVE
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/mei
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/mei/mei0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/dev
+Lines: 1
+244:0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/dev_state
+Lines: 1
+ENABLEDEOF
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/fw_status
+Lines: 6
+90000245
+00110500
+00000020
+00000000
+02F41F03
+40000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/fw_ver
+Lines: 3
+0:18.0.5.2098
+0:18.0.5.2098
+0:18.0.5.2098
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/hbm_ver
+Lines: 1
+2.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/hbm_ver_drv
+Lines: 1
+2.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/kind
+Lines: 1
+mei
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/trc
+Lines: 1
+00000889
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/tx_queue_limit
+Lines: 1
+50
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei0/uevent
+Lines: 3
+MAJOR=244
+MINOR=0
+DEVNAME=mei0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/net
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -6551,6 +6551,68 @@ MINOR=0
 DEVNAME=mei0
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: fixtures/sys/class/mei/mei1
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/dev
+Lines: 1
+243:0
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/dev_state
+Lines: 1
+ENABLED
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/fw_status
+Lines: 6
+90000245
+00110500
+00000020
+00000004
+02F61F03
+40000000
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/fw_ver
+Lines: 3
+0:18.1.18.2595
+0:18.1.18.2595
+0:18.1.18.2599
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/hbm_ver
+Lines: 1
+2.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/hbm_ver_drv
+Lines: 1
+2.2
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/kind
+Lines: 1
+mei
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/trc
+Lines: 1
+00000879
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/tx_queue_limit
+Lines: 1
+50
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/class/mei/mei1/uevent
+Lines: 3
+MAJOR=243
+MINOR=0
+DEVNAME=mei1
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: fixtures/sys/class/net
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -6499,7 +6499,7 @@ Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/class/mei/mei0/dev_state
 Lines: 1
-ENABLEDEOF
+ENABLED
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/class/mei/mei0/fw_status


### PR DESCRIPTION
The structure is based on `sysfs/class_dmi.go`. 

Assumes `mei0` instead of checking for `meiN` since in practice (afaik), there are never more than one ME interfaces. But I am happy to get rid of that assumption if needed. 