### PR TITLE
mountinfo: read the full file instead of capping at 1 MiB

### DIFF
--- a/mountinfo.go
+++ b/mountinfo.go
@@ -17,10 +17,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 	"strings"
-
-	"github.com/prometheus/procfs/internal/util"
 )
 
 // A MountInfo is a type that describes the details, options
@@ -160,9 +160,19 @@ func mountOptionsParser(mountOptions string) map[string]string {
 	return opts
 }
 
+// readMountInfo reads a full mountinfo file (no 1 MiB cap, unlike util.ReadFileNoStat).
+func readMountInfo(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
 // GetMounts retrieves mountinfo information from `/proc/self/mountinfo`.
 func GetMounts() ([]*MountInfo, error) {
-	data, err := util.ReadFileNoStat("/proc/self/mountinfo")
+	data, err := readMountInfo("/proc/self/mountinfo")
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +181,7 @@ func GetMounts() ([]*MountInfo, error) {
 
 // GetProcMounts retrieves mountinfo information from a processes' `/proc/<pid>/mountinfo`.
 func GetProcMounts(pid int) ([]*MountInfo, error) {
-	data, err := util.ReadFileNoStat(fmt.Sprintf("/proc/%d/mountinfo", pid))
+	data, err := readMountInfo(fmt.Sprintf("/proc/%d/mountinfo", pid))
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +190,7 @@ func GetProcMounts(pid int) ([]*MountInfo, error) {
 
 // GetMounts retrieves mountinfo information from `/proc/self/mountinfo`.
 func (fs FS) GetMounts() ([]*MountInfo, error) {
-	data, err := util.ReadFileNoStat(fs.proc.Path("self/mountinfo"))
+	data, err := readMountInfo(fs.proc.Path("self/mountinfo"))
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +199,7 @@ func (fs FS) GetMounts() ([]*MountInfo, error) {
 
 // GetProcMounts retrieves mountinfo information from a processes' `/proc/<pid>/mountinfo`.
 func (fs FS) GetProcMounts(pid int) ([]*MountInfo, error) {
-	data, err := util.ReadFileNoStat(fs.proc.Path(fmt.Sprintf("%d/mountinfo", pid)))
+	data, err := readMountInfo(fs.proc.Path(fmt.Sprintf("%d/mountinfo", pid)))
 	if err != nil {
 		return nil, err
 	}

--- a/mountinfo_readfull_test.go
+++ b/mountinfo_readfull_test.go
@@ -1,0 +1,71 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package procfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/procfs/internal/util"
+)
+
+// TestReadMountInfoExceeds1MiB verifies that a mountinfo file larger than 1 MiB
+// is read and parsed in full. The util.ReadFileNoStat helper caps reads at
+// 1 MiB, which truncates and corrupts mountinfo on hosts with a very large
+// number of mounts (e.g. busy container hosts), so the mountinfo helpers must
+// not use it.
+func TestReadMountInfoExceeds1MiB(t *testing.T) {
+	const n = 20000
+
+	var b strings.Builder
+	for i := range n {
+		fmt.Fprintf(&b, "%d 35 98:0 /mnt%d /mnt%d rw,noatime shared:1 - ext3 /dev/root rw,errors=continue\n", i, i, i)
+	}
+	content := b.String()
+	if len(content) <= 1024*1024 {
+		t.Fatalf("test fixture must exceed 1 MiB, got %d bytes", len(content))
+	}
+
+	path := filepath.Join(t.TempDir(), "mountinfo")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := readMountInfo(path)
+	if err != nil {
+		t.Fatalf("readMountInfo: %v", err)
+	}
+	if len(data) != len(content) {
+		t.Fatalf("readMountInfo truncated the file: got %d bytes, want %d", len(data), len(content))
+	}
+
+	mounts, err := parseMountInfo(data)
+	if err != nil {
+		t.Fatalf("parseMountInfo returned error: %v", err)
+	}
+	if len(mounts) != n {
+		t.Fatalf("parsed %d mounts, want %d", len(mounts), n)
+	}
+
+	// Guard the regression: util.ReadFileNoStat caps at 1 MiB and would truncate.
+	capped, err := util.ReadFileNoStat(path)
+	if err != nil {
+		t.Fatalf("ReadFileNoStat: %v", err)
+	}
+	if len(capped) >= len(content) {
+		t.Fatalf("expected ReadFileNoStat to cap the read below %d bytes, got %d", len(content), len(capped))
+	}
+}


### PR DESCRIPTION
### What

`GetMounts` / `GetProcMounts` read `/proc/<pid>/mountinfo` via
`util.ReadFileNoStat`, which caps reads at 1 MiB (`io.LimitReader`). On hosts
with many mounts the file is larger than 1 MB, so it is truncated mid-line.
`parseMountInfoString` then fails on the corrupted last line
(`Too few fields in mount string` / `couldn't find separator`) and
`parseMountInfo` returns that error — so **no mounts are returned at all**.

A node running a few hundred containers is enough to cross the limit: e.g.
~380 Kubernetes pods produce ~1800 mount entries and a mountinfo of ~1.2 MB,
and it only grows from there.

### Why not just raise the cap

The 1 MiB limit was already bumped once for exactly this reason —
f74c35e *"Bump max buffer size to 1024kb to handle larger mountinfo files"*
(512 KiB → 1 MiB). Raising it again only moves the ceiling. `mountinfo` has no
meaningful upper size bound, and `ReadFileNoStat`'s own doc comment says
*"For files larger than this, a scanner should be used."* So this reads the
file in full instead.

### Change

- Add a `readMountInfo` helper that reads the whole file (`os.Open` +
  `io.ReadAll`), and switch the four mountinfo accessors (`GetMounts`,
  `GetProcMounts`, `FS.GetMounts`, `FS.GetProcMounts`) to it.
- `util.ReadFileNoStat` is left unchanged for its other (small pseudo-file)
  callers.
- Add a regression test that a >1 MiB mountinfo is read and parsed in full
  (and that `ReadFileNoStat` would truncate it).

### Downstream impact

Surfaced via prometheus/node_exporter#3530. node_exporter ≥ 1.10.1 delegates
mountinfo parsing to this package (since prometheus/node_exporter#3452), so its
filesystem collector drops **all** `node_filesystem_*` metrics on nodes whose
mountinfo exceeds 1 MB.

### Note

`readMountInfo` reads the file into a `[]byte` so the existing
`parseMountInfo([]byte)` is reused unchanged. Streaming the `*os.File` straight
into the scanner would also work; I kept the `[]byte` path for a minimal diff.
