### PR TITLE
nvme: Fix namespace parsing

### DIFF
--- a/sysfs/class_nvme.go
+++ b/sysfs/class_nvme.go
@@ -27,7 +27,7 @@ import (
 
 const nvmeClassPath = "class/nvme"
 
-var nvmeNamespacePattern = regexp.MustCompile(`nvme\d+c\d+n(\d+)`)
+var nvmeNamespacePattern = regexp.MustCompile(`nvme\d+n(\d+)`)
 
 // NVMeNamespace contains info from files in /sys/class/nvme/<device>/<namespace>.
 type NVMeNamespace struct {

--- a/sysfs/class_nvme_test.go
+++ b/sysfs/class_nvme_test.go
@@ -96,7 +96,7 @@ func TestNVMeNamespaceParsingWithMockData(t *testing.T) {
 	}
 
 	// Create mock namespace directory and files
-	namespaceDir := filepath.Join(deviceDir, "nvme0c0n1")
+	namespaceDir := filepath.Join(deviceDir, "nvme0n1")
 	err = os.MkdirAll(filepath.Join(namespaceDir, "queue"), 0o755)
 	if err != nil {
 		t.Fatal(err)
@@ -205,8 +205,8 @@ func TestNVMeMultipleNamespaces(t *testing.T) {
 		anaState  string
 		blockSize string
 	}{
-		{"nvme1c0n1", "1", "100000", "2000000000", "optimized", "4096"},
-		{"nvme1c0n2", "2", "50000", "1000000000", "active", "512"},
+		{"nvme1n1", "1", "100000", "2000000000", "optimized", "4096"},
+		{"nvme1n2", "2", "50000", "1000000000", "active", "512"},
 	}
 
 	for _, ns := range namespaces {
@@ -344,7 +344,7 @@ func TestNVMeNamespaceMissingFiles(t *testing.T) {
 	}
 
 	// Create namespace directory but with missing files
-	namespaceDir := filepath.Join(deviceDir, "nvme2c0n1")
+	namespaceDir := filepath.Join(deviceDir, "nvme2n1")
 	err = os.MkdirAll(filepath.Join(namespaceDir, "queue"), 0o755)
 	if err != nil {
 		t.Fatal(err)

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -6832,28 +6832,28 @@ Lines: 1
 Samsung SSD 970 PRO 512GB               
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: fixtures/sys/class/nvme/nvme0/nvme0c0n0
+Directory: fixtures/sys/class/nvme/nvme0/nvme0n0
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/nvme/nvme0/nvme0c0n0/ana_state
+Path: fixtures/sys/class/nvme/nvme0/nvme0n0/ana_state
 Lines: 1
 optimized
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/nvme/nvme0/nvme0c0n0/nuse
+Path: fixtures/sys/class/nvme/nvme0/nvme0n0/nuse
 Lines: 1
 488281250
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Directory: fixtures/sys/class/nvme/nvme0/nvme0c0n0/queue
+Directory: fixtures/sys/class/nvme/nvme0/nvme0n0/queue
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/nvme/nvme0/nvme0c0n0/queue/logical_block_size
+Path: fixtures/sys/class/nvme/nvme0/nvme0n0/queue/logical_block_size
 Lines: 1
 4096
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-Path: fixtures/sys/class/nvme/nvme0/nvme0c0n0/size
+Path: fixtures/sys/class/nvme/nvme0/nvme0n0/size
 Lines: 1
 3906250000
 Mode: 644


### PR DESCRIPTION
This PR fixes the namespace parsing bug introduced by #765 as the regex on L30 in class_nvme.go explicitly looks for nvme0c0n0.

Standard nvme devices will not have the c0 identifier, from what I gather that is only applicable in some multipath setups, it will just be nvme0n1 for example.

Noticed this following node_exporter upgrade that promised nvme metrics which were missing on all updated systems.

```
>> running all tests
go test -race  ./...
ok  	github.com/prometheus/procfs	1.132s
ok  	github.com/prometheus/procfs/bcache	1.017s
ok  	github.com/prometheus/procfs/bcachefs	1.013s
ok  	github.com/prometheus/procfs/blockdevice	1.020s
ok  	github.com/prometheus/procfs/btrfs	1.016s
?   	github.com/prometheus/procfs/ext4	[no test files]
ok  	github.com/prometheus/procfs/internal/fs	1.016s
ok  	github.com/prometheus/procfs/internal/util	(cached)
ok  	github.com/prometheus/procfs/iscsi	1.023s
ok  	github.com/prometheus/procfs/nfs	(cached)
ok  	github.com/prometheus/procfs/selinuxfs	1.015s
ok  	github.com/prometheus/procfs/sysfs	1.054s
ok  	github.com/prometheus/procfs/xfs	1.027s
```