### PR TITLE
blockdevice: add SysBlockDeviceRotational for targeted rotational reads

### DIFF
--- a/blockdevice/stats.go
+++ b/blockdevice/stats.go
@@ -492,6 +492,15 @@ func (fs FS) SysBlockDeviceSize(device string) (uint64, error) {
 	return procfs.SectorSize * size, nil
 }
 
+// SysBlockDeviceRotational returns the rotational value for the block device
+// from /sys/block/<device>/queue/rotational.
+// A value of 1 indicates a rotational device (HDD), 0 indicates a
+// non-rotational device (SSD, NVMe). An error is returned if the file
+// cannot be read or does not contain a valid integer.
+func (fs FS) SysBlockDeviceRotational(device string) (uint64, error) {
+	return util.ReadUintFromFile(fs.sys.Path(sysBlockPath, device, sysBlockQueue, "rotational"))
+}
+
 // SysBlockDeviceIO returns stats for the block device io counters
 // IO done count: /sys/block/<disk>/device/iodone_cnt
 // IO error count: /sys/block/<disk>/device/ioerr_cnt.

--- a/blockdevice/stats_test.go
+++ b/blockdevice/stats_test.go
@@ -241,3 +241,29 @@ func TestSysBlockDeviceSize(t *testing.T) {
 		t.Errorf("Incorrect BlockDeviceSize, expected: \n%+v, got: \n%+v", size9Expected, size9)
 	}
 }
+
+func TestSysBlockDeviceRotational(t *testing.T) {
+	blockdevice, err := NewFS("testdata/fixtures/proc", "testdata/fixtures/sys")
+	if err != nil {
+		t.Fatalf("failed to access blockdevice fs: %v", err)
+	}
+	devices, err := blockdevice.SysBlockDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// devices[9] is "sda" in the fixtures — a rotational HDD (value: 1).
+	rotational9, err := blockdevice.SysBlockDeviceRotational(devices[9])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rotational9 != 1 {
+		t.Errorf("Incorrect rotational value for %s: expected 1, got %d", devices[9], rotational9)
+	}
+
+	// devices[0] is "dm-0" — no queue/rotational file; expect an error.
+	_, err = blockdevice.SysBlockDeviceRotational(devices[0])
+	if err == nil {
+		t.Errorf("expected error reading rotational for %s (no queue dir), got nil", devices[0])
+	}
+}


### PR DESCRIPTION
## What

Add `FS.SysBlockDeviceRotational(device string) (uint64, error)` — a targeted
single-file reader for `/sys/block/<device>/queue/rotational`.

## Why

Required by `node_exporter`'s diskstats collector to fix a **10× scrape-latency
regression** on systems with many block devices
(prometheus/node_exporter#3282).

The previous implementation called `SysBlockDeviceQueueStats()` which reads
**~30 sysfs files per device** to populate a full `BlockQueueStats` struct,
consuming only the `Rotational` field. On systems with 1,000+ devices this
caused 30,000+ unnecessary file reads per scrape.

`SysBlockDeviceRotational` reduces this to **exactly 1 read per device**.

## How

Follows the same single-file read pattern as `SysBlockDeviceSize()` using
`util.ReadUintFromFile`. Returns `1` for rotational (HDD), `0` for
non-rotational (SSD/NVMe).

A unit test (`TestSysBlockDeviceRotational`) is included, using the existing
`sda` fixture (rotational=1) and verifying error behaviour for devices without
a `queue/rotational` file.

## Related

- node_exporter PR: prometheus/node_exporter#3686
- Regression issue: prometheus/node_exporter#3282
