### PR TITLE
Add support for cpuinfo_avg_freq

### DIFF
--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -53,6 +53,7 @@ type CPUThermalThrottle struct {
 type SystemCPUCpufreqStats struct {
 	Name                     string
 	CpuinfoCurrentFrequency  *uint64
+	CpuinfoAverageFrequency  *uint64
 	CpuinfoMinimumFrequency  *uint64
 	CpuinfoMaximumFrequency  *uint64
 	CpuinfoTransitionLatency *uint64
@@ -269,6 +270,7 @@ func (fs FS) SystemCpufreq() ([]SystemCPUCpufreqStats, error) {
 func parseCpufreqCpuinfo(cpuPath string) (*SystemCPUCpufreqStats, error) {
 	uintFiles := []string{
 		"cpuinfo_cur_freq",
+		"cpuinfo_avg_freq",
 		"cpuinfo_max_freq",
 		"cpuinfo_min_freq",
 		"cpuinfo_transition_latency",
@@ -380,12 +382,13 @@ func parseCpufreqCpuinfo(cpuPath string) (*SystemCPUCpufreqStats, error) {
 
 	return &SystemCPUCpufreqStats{
 		CpuinfoCurrentFrequency:          uintOut[0],
-		CpuinfoMaximumFrequency:          uintOut[1],
-		CpuinfoMinimumFrequency:          uintOut[2],
-		CpuinfoTransitionLatency:         uintOut[3],
-		ScalingCurrentFrequency:          uintOut[4],
-		ScalingMaximumFrequency:          uintOut[5],
-		ScalingMinimumFrequency:          uintOut[6],
+		CpuinfoAverageFrequency:          uintOut[1],
+		CpuinfoMaximumFrequency:          uintOut[2],
+		CpuinfoMinimumFrequency:          uintOut[3],
+		CpuinfoTransitionLatency:         uintOut[4],
+		ScalingCurrentFrequency:          uintOut[5],
+		ScalingMaximumFrequency:          uintOut[6],
+		ScalingMinimumFrequency:          uintOut[7],
 		AvailableGovernors:               stringOut[0],
 		Driver:                           stringOut[1],
 		Governor:                         stringOut[2],

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -140,6 +140,7 @@ func TestSystemCpufreq(t *testing.T) {
 		{
 			Name:                             "0",
 			CpuinfoCurrentFrequency:          nil,
+			CpuinfoAverageFrequency:          makeUint64(3184097),
 			CpuinfoMinimumFrequency:          makeUint64(800000),
 			CpuinfoMaximumFrequency:          makeUint64(2400000),
 			CpuinfoTransitionLatency:         makeUint64(0),
@@ -163,11 +164,13 @@ func TestSystemCpufreq(t *testing.T) {
 			},
 		},
 		// The following files are missing for the second CPU:
+		// * `cpuinfo_avg_freq`
 		// * `scaling_cur_freq`
 		// * `trans_table`
 		{
 			Name:                     "1",
 			CpuinfoCurrentFrequency:  makeUint64(1200195),
+			CpuinfoAverageFrequency:  nil,
 			CpuinfoMinimumFrequency:  makeUint64(1200000),
 			CpuinfoMaximumFrequency:  makeUint64(3300000),
 			CpuinfoTransitionLatency: makeUint64(4294967295),

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -17915,6 +17915,11 @@ Lines: 1
 0
 Mode: 444
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/cpufreq/policy0/cpuinfo_avg_freq
+Lines: 1
+3184097
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/devices/system/cpu/cpufreq/policy0/cpuinfo_max_freq
 Lines: 1
 2400000


### PR DESCRIPTION
This fixes #822 by adding support for the cpuinfo_avg_freq file from /sys/devices/system/cpu/cpu[0-9]*/cpufreq/ including testing data.