### PR TITLE
Fix crypto parsing panic

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -48,11 +48,13 @@ type Crypto struct {
 	Walksize    *uint64
 }
 
+var cryptoFile = "crypto"
+
 // Crypto parses an crypto-file (/proc/crypto) and returns a slice of
 // structs containing the relevant info.  More information available here:
 // https://kernel.readthedocs.io/en/sphinx-samples/crypto-API.html
 func (fs FS) Crypto() ([]Crypto, error) {
-	path := fs.proc.Path("crypto")
+	path := fs.proc.Path(cryptoFile)
 	b, err := util.ReadFileNoStat(path)
 	if err != nil {
 		return nil, fmt.Errorf("%w: Cannot read file %v: %w", ErrFileRead, b, err)
@@ -80,6 +82,10 @@ func parseCrypto(r io.Reader) ([]Crypto, error) {
 			out = append(out, Crypto{})
 		case text == "":
 			continue
+		}
+
+		if len(out) == 0 {
+			return nil, fmt.Errorf("%w: parsed invalid line before name parsed: %q", ErrFileParse, text)
 		}
 
 		kv := strings.Split(text, ":")

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -14,6 +14,7 @@
 package procfs
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -118,6 +119,20 @@ func TestFS_Crypto(t *testing.T) {
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatalf("unexpected crypto entry (-want +got):\n%s", diff)
 		}
+	}
+}
+
+func TestFS_CryptoCorrupted(t *testing.T) {
+	cryptoFile = "crypto_corrupted"
+	fs := getProcFixtures(t)
+	crypto, err := fs.Crypto()
+
+	if !errors.Is(err, ErrFileParse) {
+		t.Fatalf("expected ErrFileParse error, got: %s", err)
+	}
+
+	if crypto != nil {
+		t.Fatalf("expected empty crypto result")
 	}
 }
 

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -2265,6 +2265,23 @@ max keysize  : 32
 Mode: 444
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/crypto_corrupted
+Lines: 13
+driver       : ccm_base(ctr(aes-aesni),cbcmac(aes-aesni))
+name         : ccm(aes)
+module       : ccm
+priority     : 300
+refcnt       : 4
+selftest     : passed
+internal     : no
+type         : aead
+async        : no
+blocksize    : 1
+ivsize       : 16
+maxauthsize  : 16
+geniv        : <none>
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/diskstats
 Lines: 52
    1       0 ram0 0 0 0 0 0 0 0 0 0 0 0


### PR DESCRIPTION
Make sure that we don't panic when parsing invalid crypto files that have entries that don't start with a `name`.
* Continuation of https://github.com/prometheus/procfs/pull/745