### PR TITLE
Fix invalid format strings

### DIFF
--- a/net_wireless.go
+++ b/net_wireless.go
@@ -114,47 +114,47 @@ func parseWireless(r io.Reader) ([]*Wireless, error) {
 
 		qlink, err := strconv.Atoi(strings.TrimSuffix(stats[1], "."))
 		if err != nil {
-			return nil, fmt.Errorf("%w: parse Quality:link as integer %q: %w", ErrFileParse, qlink, err)
+			return nil, fmt.Errorf("%w: parse Quality:link as integer %q: %w", ErrFileParse, stats[1], err)
 		}
 
 		qlevel, err := strconv.Atoi(strings.TrimSuffix(stats[2], "."))
 		if err != nil {
-			return nil, fmt.Errorf("%w: Quality:level as integer %q: %w", ErrFileParse, qlevel, err)
+			return nil, fmt.Errorf("%w: Quality:level as integer %q: %w", ErrFileParse, stats[2], err)
 		}
 
 		qnoise, err := strconv.Atoi(strings.TrimSuffix(stats[3], "."))
 		if err != nil {
-			return nil, fmt.Errorf("%w: Quality:noise as integer %q: %w", ErrFileParse, qnoise, err)
+			return nil, fmt.Errorf("%w: Quality:noise as integer %q: %w", ErrFileParse, stats[3], err)
 		}
 
 		dnwid, err := strconv.Atoi(stats[4])
 		if err != nil {
-			return nil, fmt.Errorf("%w: Discarded:nwid as integer %q: %w", ErrFileParse, dnwid, err)
+			return nil, fmt.Errorf("%w: Discarded:nwid as integer %q: %w", ErrFileParse, stats[4], err)
 		}
 
 		dcrypt, err := strconv.Atoi(stats[5])
 		if err != nil {
-			return nil, fmt.Errorf("%w: Discarded:crypt as integer %q: %w", ErrFileParse, dcrypt, err)
+			return nil, fmt.Errorf("%w: Discarded:crypt as integer %q: %w", ErrFileParse, stats[5], err)
 		}
 
 		dfrag, err := strconv.Atoi(stats[6])
 		if err != nil {
-			return nil, fmt.Errorf("%w: Discarded:frag as integer %q: %w", ErrFileParse, dfrag, err)
+			return nil, fmt.Errorf("%w: Discarded:frag as integer %q: %w", ErrFileParse, stats[6], err)
 		}
 
 		dretry, err := strconv.Atoi(stats[7])
 		if err != nil {
-			return nil, fmt.Errorf("%w: Discarded:retry as integer %q: %w", ErrFileParse, dretry, err)
+			return nil, fmt.Errorf("%w: Discarded:retry as integer %q: %w", ErrFileParse, stats[7], err)
 		}
 
 		dmisc, err := strconv.Atoi(stats[8])
 		if err != nil {
-			return nil, fmt.Errorf("%w: Discarded:misc as integer %q: %w", ErrFileParse, dmisc, err)
+			return nil, fmt.Errorf("%w: Discarded:misc as integer %q: %w", ErrFileParse, stats[8], err)
 		}
 
 		mbeacon, err := strconv.Atoi(stats[9])
 		if err != nil {
-			return nil, fmt.Errorf("%w: Missed:beacon as integer %q: %w", ErrFileParse, mbeacon, err)
+			return nil, fmt.Errorf("%w: Missed:beacon as integer %q: %w", ErrFileParse, stats[9], err)
 		}
 
 		w := &Wireless{

--- a/nfs/parse.go
+++ b/nfs/parse.go
@@ -19,7 +19,7 @@ import (
 
 func parseReplyCache(v []uint64) (ReplyCache, error) {
 	if len(v) != 3 {
-		return ReplyCache{}, fmt.Errorf("invalid ReplyCache line %q", v)
+		return ReplyCache{}, fmt.Errorf("invalid ReplyCache line %v", v)
 	}
 
 	return ReplyCache{
@@ -31,7 +31,7 @@ func parseReplyCache(v []uint64) (ReplyCache, error) {
 
 func parseFileHandles(v []uint64) (FileHandles, error) {
 	if len(v) != 5 {
-		return FileHandles{}, fmt.Errorf("invalid FileHandles, line %q", v)
+		return FileHandles{}, fmt.Errorf("invalid FileHandles, line %v", v)
 	}
 
 	return FileHandles{
@@ -45,7 +45,7 @@ func parseFileHandles(v []uint64) (FileHandles, error) {
 
 func parseInputOutput(v []uint64) (InputOutput, error) {
 	if len(v) != 2 {
-		return InputOutput{}, fmt.Errorf("invalid InputOutput line %q", v)
+		return InputOutput{}, fmt.Errorf("invalid InputOutput line %v", v)
 	}
 
 	return InputOutput{
@@ -56,7 +56,7 @@ func parseInputOutput(v []uint64) (InputOutput, error) {
 
 func parseThreads(v []uint64) (Threads, error) {
 	if len(v) != 2 {
-		return Threads{}, fmt.Errorf("invalid Threads line %q", v)
+		return Threads{}, fmt.Errorf("invalid Threads line %v", v)
 	}
 
 	return Threads{
@@ -67,7 +67,7 @@ func parseThreads(v []uint64) (Threads, error) {
 
 func parseReadAheadCache(v []uint64) (ReadAheadCache, error) {
 	if len(v) != 12 {
-		return ReadAheadCache{}, fmt.Errorf("invalid ReadAheadCache line %q", v)
+		return ReadAheadCache{}, fmt.Errorf("invalid ReadAheadCache line %v", v)
 	}
 
 	return ReadAheadCache{
@@ -79,7 +79,7 @@ func parseReadAheadCache(v []uint64) (ReadAheadCache, error) {
 
 func parseNetwork(v []uint64) (Network, error) {
 	if len(v) != 4 {
-		return Network{}, fmt.Errorf("invalid Network line %q", v)
+		return Network{}, fmt.Errorf("invalid Network line %v", v)
 	}
 
 	return Network{
@@ -92,7 +92,7 @@ func parseNetwork(v []uint64) (Network, error) {
 
 func parseServerRPC(v []uint64) (ServerRPC, error) {
 	if len(v) != 5 {
-		return ServerRPC{}, fmt.Errorf("invalid RPC line %q", v)
+		return ServerRPC{}, fmt.Errorf("invalid RPC line %v", v)
 	}
 
 	return ServerRPC{
@@ -106,7 +106,7 @@ func parseServerRPC(v []uint64) (ServerRPC, error) {
 
 func parseClientRPC(v []uint64) (ClientRPC, error) {
 	if len(v) != 3 {
-		return ClientRPC{}, fmt.Errorf("invalid RPC line %q", v)
+		return ClientRPC{}, fmt.Errorf("invalid RPC line %v", v)
 	}
 
 	return ClientRPC{
@@ -119,7 +119,7 @@ func parseClientRPC(v []uint64) (ClientRPC, error) {
 func parseV2Stats(v []uint64) (V2Stats, error) {
 	values := int(v[0])
 	if len(v[1:]) != values || values < 18 {
-		return V2Stats{}, fmt.Errorf("invalid V2Stats line %q", v)
+		return V2Stats{}, fmt.Errorf("invalid V2Stats line %v", v)
 	}
 
 	return V2Stats{
@@ -147,7 +147,7 @@ func parseV2Stats(v []uint64) (V2Stats, error) {
 func parseV3Stats(v []uint64) (V3Stats, error) {
 	values := int(v[0])
 	if len(v[1:]) != values || values < 22 {
-		return V3Stats{}, fmt.Errorf("invalid V3Stats line %q", v)
+		return V3Stats{}, fmt.Errorf("invalid V3Stats line %v", v)
 	}
 
 	return V3Stats{
@@ -179,7 +179,7 @@ func parseV3Stats(v []uint64) (V3Stats, error) {
 func parseClientV4Stats(v []uint64) (ClientV4Stats, error) {
 	values := int(v[0])
 	if len(v[1:]) != values {
-		return ClientV4Stats{}, fmt.Errorf("invalid ClientV4Stats line %q", v)
+		return ClientV4Stats{}, fmt.Errorf("invalid ClientV4Stats line %v", v)
 	}
 
 	// This function currently supports mapping 59 NFS v4 client stats.  Older
@@ -257,7 +257,7 @@ func parseClientV4Stats(v []uint64) (ClientV4Stats, error) {
 func parseServerV4Stats(v []uint64) (ServerV4Stats, error) {
 	values := int(v[0])
 	if len(v[1:]) != values || values != 2 {
-		return ServerV4Stats{}, fmt.Errorf("invalid V4Stats line %q", v)
+		return ServerV4Stats{}, fmt.Errorf("invalid V4Stats line %v", v)
 	}
 
 	return ServerV4Stats{
@@ -269,7 +269,7 @@ func parseServerV4Stats(v []uint64) (ServerV4Stats, error) {
 func parseV4Ops(v []uint64) (V4Ops, error) {
 	values := int(v[0])
 	if len(v[1:]) != values || values < 39 {
-		return V4Ops{}, fmt.Errorf("invalid V4Ops line %q", v)
+		return V4Ops{}, fmt.Errorf("invalid V4Ops line %v", v)
 	}
 
 	// nfs v2.5.x 39field and >=v2.6.x 40 field;

--- a/proc_cgroup.go
+++ b/proc_cgroup.go
@@ -60,7 +60,7 @@ func parseCgroupString(cgroupStr string) (*Cgroup, error) {
 	}
 	cgroup.HierarchyID, err = strconv.Atoi(fields[0])
 	if err != nil {
-		return nil, fmt.Errorf("%w: hierarchy ID: %q", ErrFileParse, cgroup.HierarchyID)
+		return nil, fmt.Errorf("%w: hierarchy ID: %q", ErrFileParse, fields[0])
 	}
 	if fields[1] != "" {
 		ssNames := strings.Split(fields[1], ",")


### PR DESCRIPTION
Fix invalid format strings reported by current Go vet.

This changes []uint64 error diagnostics to use %v instead of %q, and reports the original string field for parse errors in net_wireless and proc_cgroup instead of formatting the parsed integer zero value.

Tested:
- make test