### PR TITLE
test: split proc stat limit coverage by architecture

### DIFF
--- a/proc_stat_limits32_test.go
+++ b/proc_stat_limits32_test.go
@@ -1,0 +1,25 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris) && (386 || arm || mips || mipsle)
+
+package procfs
+
+import (
+	"math"
+	"testing"
+)
+
+func TestProcStatLimits(t *testing.T) {
+	testProcStatLimits(t, int(math.MinInt32), int(math.MaxInt32))
+}

--- a/proc_stat_limits64_test.go
+++ b/proc_stat_limits64_test.go
@@ -1,0 +1,25 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris) && !386 && !arm && !mips && !mipsle
+
+package procfs
+
+import (
+	"math"
+	"testing"
+)
+
+func TestProcStatLimits(t *testing.T) {
+	testProcStatLimits(t, int(math.MinInt64), int(math.MaxInt64))
+}

--- a/proc_stat_limits_test.go
+++ b/proc_stat_limits_test.go
@@ -1,0 +1,74 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+const procStatLimitsTemplate = "26231 (vim) R 5392 7446 5392 34835 7446 4218880 32533 309516 26 82 1677 44 %d %d 20 0 1 0 82375 56274944 1981 18446744073709551615 4194304 6294284 140736914091744 140736914087944 139965136429984 0 0 12288 1870679807 0 0 0 17 0 0 0 31 0 0 8391624 8481048 16420864 140736914093252 140736914093279 140736914093279 140736914096107 0\n"
+
+func testProcStatLimits(t *testing.T, minInt, maxInt int) {
+	t.Helper()
+
+	p := writeProcStatLimitFixture(t, fmt.Sprintf(procStatLimitsTemplate, minInt, maxInt))
+
+	s, err := p.Stat()
+	if err != nil {
+		t.Fatalf("want no error, have %s", err)
+	}
+
+	for _, test := range []struct {
+		name string
+		want int
+		have int
+	}{
+		{name: "waited for children user time", want: minInt, have: s.CUTime},
+		{name: "waited for children system time", want: maxInt, have: s.CSTime},
+	} {
+		if test.want != test.have {
+			t.Errorf("want %s %d, have %d", test.name, test.want, test.have)
+		}
+	}
+}
+
+func writeProcStatLimitFixture(t *testing.T, stat string) Proc {
+	t.Helper()
+
+	const pid = 26231
+
+	root := t.TempDir()
+	procDir := filepath.Join(root, strconv.Itoa(pid))
+	if err := os.MkdirAll(procDir, 0o755); err != nil {
+		t.Fatalf("create proc fixture dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(procDir, "stat"), []byte(stat), 0o644); err != nil {
+		t.Fatalf("write stat fixture: %v", err)
+	}
+
+	fs, err := NewFS(root)
+	if err != nil {
+		t.Fatalf("create pseudo fs: %v", err)
+	}
+	p, err := fs.Proc(pid)
+	if err != nil {
+		t.Fatalf("open proc fixture: %v", err)
+	}
+
+	return p
+}

--- a/proc_stat_test.go
+++ b/proc_stat_test.go
@@ -14,7 +14,6 @@
 package procfs
 
 import (
-	"math"
 	"os"
 	"testing"
 )
@@ -74,32 +73,6 @@ func TestProcStat(t *testing.T) {
 		{name: "processor", want: 0, have: s.Processor},
 		{name: "rt_priority", want: 0, have: s.RTPriority},
 		{name: "policy", want: 0, have: s.Policy},
-	} {
-		if test.want != test.have {
-			t.Errorf("want %s %d, have %d", test.name, test.want, test.have)
-		}
-	}
-}
-
-func TestProcStatLimits(t *testing.T) {
-	p, err := getProcFixtures(t).Proc(26232)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	s, err := p.Stat()
-	if err != nil {
-		t.Errorf("want not error, have %s", err)
-	}
-
-	// max values of stat int fields
-	for _, test := range []struct {
-		name string
-		want int
-		have int
-	}{
-		{name: "waited for children user time", want: math.MinInt64, have: s.CUTime},
-		{name: "waited for children system time", want: math.MaxInt64, have: s.CSTime},
 	} {
 		if test.want != test.have {
 			t.Errorf("want %s %d, have %d", test.name, test.want, test.have)


### PR DESCRIPTION
Fixes #432.

This keeps the `ProcStat` limit coverage architecture-aware without relying on the shared 64-bit fixture values in `testdata/fixtures.ttar`.

### What changed
- move `TestProcStatLimits` out of `proc_stat_test.go`
- add 32-bit and 64-bit test entry points with the same build-tag split pattern used by `proc_maps*_test.go`
- generate a tiny temporary `/proc/<pid>/stat` fixture per architecture, so the parsed `CUTime` / `CSTime` values match the native `int` width of that build target

### Why this shape
The earlier `math.MinInt` / `math.MaxInt` constant-only approach still leaves a mismatch with the shipped fixture data, which encodes 64-bit extrema for those fields. On 32-bit architectures that means the test can compile but the parsed values are still not representable as native `int`s.

Using a temporary `stat` fixture keeps the test focused on the parser behavior we want to validate on each target architecture, while leaving the shared repository fixtures unchanged.

I did not run `go test` here; this patch is based on the issue discussion and static review only.
