### PR TITLE
fix(sysfs): accept delayed mdraid sync_completed state

### DIFF
--- a/sysfs/mdraid.go
+++ b/sysfs/mdraid.go
@@ -166,7 +166,7 @@ func (fs FS) Mdraids() ([]Mdraid, error) {
 			}
 
 			if val, err := util.SysReadFile(filepath.Join(path, "sync_completed")); err == nil {
-				if val != "none" {
+				if val != "none" && val != "delayed" {
 					var a, b uint64
 
 					// File contains two values representing the fraction of number of completed

--- a/sysfs/mdraid_test.go
+++ b/sysfs/mdraid_test.go
@@ -16,6 +16,8 @@
 package sysfs
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -148,6 +150,77 @@ func TestMdraidStats(t *testing.T) {
 			UUID:       "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
 			ChunkSize:  524288,
 			SyncAction: "reshape",
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected Mdraid (-want +got):\n%s", diff)
+	}
+}
+
+func TestMdraidsIgnoresDelayedSyncCompleted(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	symlink := func(target, rel string) {
+		t.Helper()
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFile("block/md1/md/level", "raid1\n")
+	writeFile("block/md1/md/array_state", "clean\n")
+	writeFile("block/md1/md/metadata_version", "1.2\n")
+	writeFile("block/md1/md/raid_disks", "2\n")
+	writeFile("block/md1/md/uuid", "test-md1-uuid\n")
+	writeFile("block/md1/md/degraded", "0\n")
+	writeFile("block/md1/md/sync_action", "resync\n")
+	writeFile("block/md1/md/sync_completed", "delayed\n")
+	writeFile("block/md1/md/dev-sda/state", "in_sync\n")
+	writeFile("block/md1/md/dev-sdb/state", "in_sync\n")
+	symlink("dev-sda", "block/md1/md/rd0")
+	symlink("dev-sdb", "block/md1/md/rd1")
+
+	fs, err := NewFS(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.Mdraids()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []Mdraid{
+		{
+			Device:          "md1",
+			Level:           "raid1",
+			ArrayState:      "clean",
+			MetadataVersion: "1.2",
+			Disks:           func(v uint64) *uint64 { return &v }(2),
+			Components: []MdraidComponent{
+				{Device: "sda", State: "in_sync"},
+				{Device: "sdb", State: "in_sync"},
+			},
+			UUID:          "test-md1-uuid",
+			DegradedDisks: 0,
+			SyncAction:    "resync",
+			SyncCompleted: 0,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- treat `sync_completed=delayed` as a valid mdraid state instead of failing the entire `Mdraids()` parse
- keep numeric progress parsing unchanged for the normal `a / b` form
- add a focused regression test that builds a minimal mdraid sysfs tree with `sync_completed=delayed`

## Why
When multiple md arrays share physical devices, Linux can expose `sync_completed` as `delayed` while a check or resync is deferred. The current parser only accepts `none` or `a / b`, so one delayed array causes `sysfs.Mdraids()` to fail outright.

This change treats `delayed` like the existing non-progress sentinel `none`: there is no numeric completion fraction to parse yet, but callers still get the rest of the array metadata.

Closes #770