### PR TITLE
sysfs: add InfiniBandDevice API

### DIFF
--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -159,6 +159,12 @@ func (fs FS) InfiniBandClass() (InfiniBandClass, error) {
 	return ibc, nil
 }
 
+// InfiniBandDevice returns info for a single InfiniBand device read from
+// /sys/class/infiniband/<Name>.
+func (fs FS) InfiniBandDevice(name string) (*InfiniBandDevice, error) {
+	return fs.parseInfiniBandDevice(name)
+}
+
 // Parse one InfiniBand device.
 // Refer to https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-infiniband
 func (fs FS) parseInfiniBandDevice(name string) (*InfiniBandDevice, error) {

--- a/sysfs/class_infiniband_test.go
+++ b/sysfs/class_infiniband_test.go
@@ -344,3 +344,25 @@ func TestInfiniBandClass(t *testing.T) {
 		t.Fatalf("unexpected InfiniBand class (-want +got):\n%s", diff)
 	}
 }
+
+func TestInfiniBandDevice(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	class, err := fs.InfiniBandClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.InfiniBandDevice("mlx5_0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := class["mlx5_0"]
+	if diff := cmp.Diff(want, *got); diff != "" {
+		t.Fatalf("unexpected InfiniBand device (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Summary
- add `FS.InfiniBandDevice(name)` as a public per-device parser
- keep `InfiniBandClass()` unchanged
- add regression coverage that the single-device API matches the corresponding `InfiniBandClass()` entry

## Why
Issue #823 describes environments where callers need to filter InfiniBand devices before reading per-port counters. Today `InfiniBandClass()` eagerly parses every device, so callers have no way to skip known-problematic devices before counter reads happen.

This patch takes the additive route proposed in the issue: expose the existing per-device parser as a small public API. Existing callers keep using `InfiniBandClass()` unchanged, while new callers can now:

1. list `/sys/class/infiniband` themselves
2. filter devices using their own policy
3. call `fs.InfiniBandDevice(name)` only for devices they actually want parsed

That keeps the change narrow and avoids adding filter semantics to `InfiniBandClass()` itself.

Fixes #823