### PR TITLE
fix(mdstat): parse (W), (J) and (R) component device flags

### DIFF
--- a/mdstat.go
+++ b/mdstat.go
@@ -27,7 +27,7 @@ var (
 	recoveryLinePctRE    = regexp.MustCompile(`= (.+)%`)
 	recoveryLineFinishRE = regexp.MustCompile(`finish=(.+)min`)
 	recoveryLineSpeedRE  = regexp.MustCompile(`speed=(.+)[A-Z]`)
-	componentDeviceRE    = regexp.MustCompile(`(.*)\[(\d+)\](\([SF]+\))?`)
+	componentDeviceRE    = regexp.MustCompile(`(.*)\[(\d+)\]((?:\([FJRSW]\))+)?`)
 	personalitiesPrefix  = "Personalities : "
 )
 

--- a/mdstat_test.go
+++ b/mdstat_test.go
@@ -369,3 +369,31 @@ md127 : active raid1 sdi2[0] sdj2[X]
 		}
 	}
 }
+func TestEvalComponentDevicesFlags(t *testing.T) {
+	// Flags as printed by the kernel, one per parenthesis group:
+	// https://github.com/torvalds/linux/blob/7ec462100ef9142344ddbf86f2c3008b97acddbe/drivers/md/md.c#L8376-L8392
+	devices, err := evalComponentDevices([]string{
+		"sda1[0](F)",
+		"sdb1[1](W)",
+		"sdc1[2](J)",
+		"sdd1[3](R)",
+		"sde1[4](W)(F)",
+		"sdg1[6](S)",
+		"sdf1[5]",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	want := []MDStatComponent{
+		{Name: "sda1", DescriptorIndex: 0, Faulty: true},
+		{Name: "sdb1", DescriptorIndex: 1, WriteMostly: true},
+		{Name: "sdc1", DescriptorIndex: 2, Journal: true},
+		{Name: "sdd1", DescriptorIndex: 3, Replacement: true},
+		{Name: "sde1", DescriptorIndex: 4, WriteMostly: true, Faulty: true},
+		{Name: "sdg1", DescriptorIndex: 6, Spare: true},
+		{Name: "sdf1", DescriptorIndex: 5},
+	}
+	if diff := cmp.Diff(want, devices); diff != "" {
+		t.Errorf("unexpected component devices (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
`evalComponentDevices` fills the WriteMostly/Journal/Replacement fields from `match[3]`, but `componentDeviceRE` only captures `(\([SF]+\))?`, so `(W)`, `(J)` and `(R)` never match and those fields are always false. Combined flags break too: the kernel prints each flag as its own parenthesis group and `(F)` can follow `(W)`, so for `sde1[4](W)(F)` the old group matches nothing and even `Faulty` is lost.

The kernel emits `(W)`, `(J)`, `(F)`, `(S)`, `(R)` one group per flag (the md.c lines already linked in `evalComponentDevices`), so the group now captures a run of them: `((?:\([FJRSW]\))+)?`.

Added `TestEvalComponentDevicesFlags` covering each flag plus the `(W)(F)` combination — it fails before this change (`WriteMostly`/`Journal`/`Replacement` stay false, and `Faulty` is false in the combined case) and passes after. This covers the WriteMostly/Journal/Replacement entries of the TODO at the top of `mdstat_test.go`.

Checked: `go test ./...`, `go vet ./...`, `gofmt -l` (the unrelated `TestFileDescriptorsLen` fails on this non-Linux machine with and without the change).