### PR TITLE
kernel_tainted: use linux build tag instead of !windows

### DIFF
--- a/kernel_tainted.go
+++ b/kernel_tainted.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
+//go:build linux
 
 package procfs
 

--- a/kernel_tainted_test.go
+++ b/kernel_tainted_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
+//go:build linux
 
 package procfs
 


### PR DESCRIPTION
`util.SysReadUintFromFile` is defined in `internal/util/sysreadfile.go`
with a `//go:build linux` constraint. The previous `!windows` tag caused
build failures on OpenBSD and other non-Linux, non-Windows platforms
(seen in node_exporter crossbuild CI).

`/proc/sys/kernel/tainted` is Linux-specific, so `linux` is the correct
build constraint.

Fixes: #844 follow-up