### PR TITLE
sysfs: tolerate EFBIG when reading cpufreq stats/trans_table

### DIFF
--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -16,11 +16,13 @@
 package sysfs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"golang.org/x/sync/errgroup"
 
@@ -350,10 +352,14 @@ func parseCpufreqCpuinfo(cpuPath string) (*SystemCPUCpufreqStats, error) {
 	}
 
 	// "trans_table" contains information about all the CPU frequency transitions.
+	// The kernel disables its export with EFBIG when the table exceeds PAGE_SIZE
+	// ("cpufreq transition table exceeds PAGE_SIZE. Disabling"), which happens on
+	// CPUs with many frequency states (e.g. NVIDIA Jetson / Tegra) — treat that
+	// like an absent file instead of failing the whole cpufreq read.
 	var cpuinfoTransitionTable *[][]uint64
 	cpuinfoTransitionTableString, err := util.ReadFileNoStat(filepath.Join(cpuPath, "stats", "trans_table"))
 	if err != nil {
-		if !os.IsNotExist(err) && !os.IsPermission(err) {
+		if !os.IsNotExist(err) && !os.IsPermission(err) && !errors.Is(err, syscall.EFBIG) {
 			return &SystemCPUCpufreqStats{}, err
 		}
 	} else {


### PR DESCRIPTION
The kernel disables the export of `stats/trans_table` when the rendered table exceeds `PAGE_SIZE`, and reads then fail with `EFBIG` (`drivers/cpufreq/cpufreq_stats.c`, `show_trans_table`). This is the normal state on CPUs with many frequency states, e.g. NVIDIA Jetson/Tegra. `SystemCpufreq()` tolerates only `ENOENT`/`EPERM` at this read, so it fails wholesale on such hardware — downstream, node_exporter's cpufreq collector fails on every scrape (`collector failed … trans_table: file too large`) and all cpufreq metrics for the node are lost. Same root cause as grafana/alloy#6132.

Fix: treat `EFBIG` like an absent file, matching the existing `ENOENT`/`EPERM` tolerance for this optional stats file.

Verified on a Jetson Orin Nano: `SystemCpufreq()` fails with `file too large` before this change and returns all 6 policy entries after. `go test ./sysfs/` passes. No new unit test: `EFBIG` is a kernel-runtime error that can't be represented by the fixture files — this takes the same branch as the existing `ENOENT`/`EPERM` handling.

cc @SuperQ