### PR TITLE
fix: skip FileDescriptorsLen fast path on non-Linux/FreeBSD platforms

### DIFF
--- a/fs_statfs_notype.go
+++ b/fs_statfs_notype.go
@@ -15,8 +15,8 @@
 
 package procfs
 
-// isRealProc returns true on architectures that don't have a Type argument
+// isRealProc returns false on architectures that don't have a Type argument
 // in their Statfs_t struct.
 func isRealProc(_ string) (bool, error) {
-	return true, nil
+	return false, nil
 }


### PR DESCRIPTION
## Summary

Fix `Proc.FileDescriptorsLen()` returning incorrect values on macOS and other non-Linux/FreeBSD platforms where `isRealProc()` was incorrectly returning `true`.

## Problem

On macOS, `Proc.FileDescriptorsLen()` returns incorrect values because the fast path (introduced in Linux v6.2) relies on `stat.Size()` semantics that are only valid on Linux. For example, on macOS with test fixtures, this caused:

```--- FAIL: TestFileDescriptorsLen (0.00s)
proc_test.go:246: want fds 5, have 224
```

The fast path uses `stat.Size()` to get the directory entry count, which on macOS returns directory metadata (e.g., inode count or block size) instead of the actual number of file descriptors.

This happened because `isRealProc()` in `fs_statfs_notype.go` was returning `true` on non-Linux/FreeBSD platforms, causing the fast path to be incorrectly applied.

## Changes

- Update `isRealProc()` in `fs_statfs_notype.go` to return `false, nil` instead of `true, nil`

This ensures that on platforms without `Statfs_t.Type` (macOS, etc.), the fast path is skipped and the correct result from `len(fds)` is returned.

The fast path relying on `stat.Size()` semantics for directory block counts is only valid on Linux and FreeBSD, so returning `false` on other platforms is semantically correct.

## Impact

- **Linux/FreeBSD**: No change in behavior — `fs_statfs_type.go` continues to check `PROC_SUPER_MAGIC`
- **macOS and other platforms**: `FileDescriptorsLen()` now returns the correct file descriptor count instead of directory metadata values