### PR TITLE
sysfs: add InfiniBand device listing and per-device parsing

### DIFF
--- a/sysfs/class_infiniband.go
+++ b/sysfs/class_infiniband.go
@@ -136,9 +136,9 @@ type InfiniBandDevice struct {
 // The map keys are the names of the InfiniBand devices.
 type InfiniBandClass map[string]InfiniBandDevice
 
-// InfiniBandClass returns info for all InfiniBand devices read from
-// /sys/class/infiniband.
-func (fs FS) InfiniBandClass() (InfiniBandClass, error) {
+// InfiniBandClassDevices returns the names of the InfiniBand devices found in
+// /sys/class/infiniband without reading any device attributes or counters.
+func (fs FS) InfiniBandClassDevices() ([]string, error) {
 	path := fs.sys.Path(infinibandClassPath)
 
 	dirs, err := os.ReadDir(path)
@@ -146,9 +146,25 @@ func (fs FS) InfiniBandClass() (InfiniBandClass, error) {
 		return nil, err
 	}
 
-	ibc := make(InfiniBandClass, len(dirs))
+	devices := make([]string, 0, len(dirs))
 	for _, d := range dirs {
-		device, err := fs.parseInfiniBandDevice(d.Name())
+		devices = append(devices, d.Name())
+	}
+
+	return devices, nil
+}
+
+// InfiniBandClass returns info for all InfiniBand devices read from
+// /sys/class/infiniband.
+func (fs FS) InfiniBandClass() (InfiniBandClass, error) {
+	devices, err := fs.InfiniBandClassDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	ibc := make(InfiniBandClass, len(devices))
+	for _, name := range devices {
+		device, err := fs.InfiniBandDevice(name)
 		if err != nil {
 			return nil, err
 		}
@@ -157,6 +173,12 @@ func (fs FS) InfiniBandClass() (InfiniBandClass, error) {
 	}
 
 	return ibc, nil
+}
+
+// InfiniBandDevice returns info for a single InfiniBand device read from
+// /sys/class/infiniband/<Name>.
+func (fs FS) InfiniBandDevice(name string) (*InfiniBandDevice, error) {
+	return fs.parseInfiniBandDevice(name)
 }
 
 // Parse one InfiniBand device.

--- a/sysfs/class_infiniband_test.go
+++ b/sysfs/class_infiniband_test.go
@@ -16,10 +16,36 @@
 package sysfs
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestInfiniBandClassDevicesDoesNotReadDevice(t *testing.T) {
+	sysPath := t.TempDir()
+	for _, name := range []string{"mlx5_6", "mlx5_5"} {
+		if err := os.MkdirAll(filepath.Join(sysPath, "class", "infiniband", name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fs, err := NewFS(sysPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.InfiniBandClassDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"mlx5_5", "mlx5_6"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected InfiniBand device names (-want +got):\n%s", diff)
+	}
+}
 
 func TestParseSlowRate(t *testing.T) {
 	tests := []struct {
@@ -342,5 +368,27 @@ func TestInfiniBandClass(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("unexpected InfiniBand class (-want +got):\n%s", diff)
+	}
+}
+
+func TestInfiniBandDevice(t *testing.T) {
+	fs, err := NewFS(sysTestFixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	class, err := fs.InfiniBandClass()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fs.InfiniBandDevice("mlx5_0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := class["mlx5_0"]
+	if diff := cmp.Diff(want, *got); diff != "" {
+		t.Fatalf("unexpected InfiniBand device (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary

Add APIs that allow callers to enumerate InfiniBand device names without
reading device attributes or counters, and then parse selected devices
individually:

- `FS.InfiniBandClassDevices()` lists device names under
  `/sys/class/infiniband` without parsing them.
- `FS.InfiniBandDevice(name)` parses one selected device.
- `FS.InfiniBandClass()` is refactored to compose these APIs while preserving
  its existing behavior.

## Motivation

`InfiniBandClass()` currently parses every device eagerly. This prevents
callers such as node_exporter from applying device filters before sysfs
counter reads occur.

On NVIDIA systems with Fabric Manager-managed or otherwise restricted
Mellanox PFs, merely reading some counters can trigger repeated
`ACCESS_REG(0x805)` firmware errors. Filtering the returned
`InfiniBandClass` is too late because the reads have already happened.

Separating enumeration from parsing lets callers:

1. enumerate device names;
2. apply their own include/exclude policy;
3. parse only accepted devices.

The existing `InfiniBandClass()` API and default behavior remain unchanged.

## Tests

- Verify that device names can be enumerated even when the device directories
  do not contain readable attributes or counters.
- Verify that `InfiniBandDevice(name)` returns the same data as the
  corresponding `InfiniBandClass()` entry.
- Linux test package cross-compiles successfully.

Related to #823 and prometheus/node_exporter#3434.

## Existing work

#839 already proposes the additive `InfiniBandDevice(name)` API. This change
includes that capability and additionally provides list-only enumeration so
callers do not need to reproduce procfs sysfs path handling outside this
package.