### PR TITLE
netstat: model legacy TcpExt counters removed from recent kernels

### DIFF
--- a/proc_netstat.go
+++ b/proc_netstat.go
@@ -146,6 +146,20 @@ type TcpExt struct { // nolint:revive
 	TCPMTUPFail               *float64
 	TCPMTUPSuccess            *float64
 	TCPWqueueTooBig           *float64
+
+	// Legacy TcpExt counters dropped from recent kernels' TcpExt table;
+	// modeled so consumers retain metric parity with older kernels that
+	// still print them in /proc/net/netstat.
+	TCPLoss                   *float64
+	PAWSPassive               *float64
+	TCPForwardRetrans         *float64
+	TCPSchedulerFailed        *float64
+	TCPPrequeued              *float64
+	TCPDirectCopyFromBacklog  *float64
+	TCPDirectCopyFromPrequeue *float64
+	TCPPrequeueDropped        *float64
+	TCPFACKReorder            *float64
+	TCPHPHitsToUser           *float64
 }
 
 type IpExt struct { // nolint:revive
@@ -396,6 +410,26 @@ func parseProcNetstat(r io.Reader, fileName string) (ProcNetstat, error) {
 					procNetstat.TCPMTUPSuccess = &value
 				case "TCPWqueueTooBig":
 					procNetstat.TCPWqueueTooBig = &value
+				case "TCPLoss":
+					procNetstat.TCPLoss = &value
+				case "PAWSPassive":
+					procNetstat.PAWSPassive = &value
+				case "TCPForwardRetrans":
+					procNetstat.TCPForwardRetrans = &value
+				case "TCPSchedulerFailed":
+					procNetstat.TCPSchedulerFailed = &value
+				case "TCPPrequeued":
+					procNetstat.TCPPrequeued = &value
+				case "TCPDirectCopyFromBacklog":
+					procNetstat.TCPDirectCopyFromBacklog = &value
+				case "TCPDirectCopyFromPrequeue":
+					procNetstat.TCPDirectCopyFromPrequeue = &value
+				case "TCPPrequeueDropped":
+					procNetstat.TCPPrequeueDropped = &value
+				case "TCPFACKReorder":
+					procNetstat.TCPFACKReorder = &value
+				case "TCPHPHitsToUser":
+					procNetstat.TCPHPHitsToUser = &value
 				}
 			case "IpExt":
 				switch key {

--- a/proc_netstat_test.go
+++ b/proc_netstat_test.go
@@ -14,6 +14,7 @@
 package procfs
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -46,5 +47,60 @@ func TestProcNetstat(t *testing.T) {
 		if test.want != test.have {
 			t.Errorf("want %s %f, have %f", test.name, test.want, test.have)
 		}
+	}
+}
+
+// TestParseProcNetstatLegacyFields covers TcpExt counters that are no longer
+// part of the kernel's TcpExt table but were still printed by older kernels.
+func TestParseProcNetstatLegacyFields(t *testing.T) {
+	payload := `TcpExt: SyncookiesSent PAWSPassive TCPPrequeued TCPDirectCopyFromBacklog TCPDirectCopyFromPrequeue TCPPrequeueDropped TCPLoss TCPFACKReorder TCPForwardRetrans TCPHPHitsToUser TCPSchedulerFailed
+TcpExt: 1 2 3 4 5 6 7 8 9 10 11
+IpExt: InNoRoutes OutOctets
+IpExt: 12 13`
+
+	procNetstat, err := parseProcNetstat(strings.NewReader(payload), "net/netstat")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		want float64
+		have float64
+	}{
+		{name: "TcpExt:SyncookiesSent", want: 1, have: *procNetstat.SyncookiesSent},
+		{name: "TcpExt:PAWSPassive", want: 2, have: *procNetstat.PAWSPassive},
+		{name: "TcpExt:TCPPrequeued", want: 3, have: *procNetstat.TCPPrequeued},
+		{name: "TcpExt:TCPDirectCopyFromBacklog", want: 4, have: *procNetstat.TCPDirectCopyFromBacklog},
+		{name: "TcpExt:TCPDirectCopyFromPrequeue", want: 5, have: *procNetstat.TCPDirectCopyFromPrequeue},
+		{name: "TcpExt:TCPPrequeueDropped", want: 6, have: *procNetstat.TCPPrequeueDropped},
+		{name: "TcpExt:TCPLoss", want: 7, have: *procNetstat.TCPLoss},
+		{name: "TcpExt:TCPFACKReorder", want: 8, have: *procNetstat.TCPFACKReorder},
+		{name: "TcpExt:TCPForwardRetrans", want: 9, have: *procNetstat.TCPForwardRetrans},
+		{name: "TcpExt:TCPHPHitsToUser", want: 10, have: *procNetstat.TCPHPHitsToUser},
+		{name: "TcpExt:TCPSchedulerFailed", want: 11, have: *procNetstat.TCPSchedulerFailed},
+		{name: "IpExt:InNoRoutes", want: 12, have: *procNetstat.InNoRoutes},
+		{name: "IpExt:OutOctets", want: 13, have: *procNetstat.OutOctets},
+	} {
+		if test.want != test.have {
+			t.Errorf("want %s %f, have %f", test.name, test.want, test.have)
+		}
+	}
+
+	modern := `TcpExt: SyncookiesSent
+TcpExt: 1
+IpExt: InNoRoutes
+IpExt: 12`
+
+	pn, err := parseProcNetstat(strings.NewReader(modern), "net/netstat")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pn.SyncookiesSent == nil || *pn.SyncookiesSent != 1 {
+		t.Error("want TcpExt:SyncookiesSent 1")
+	}
+	if pn.TCPPrequeued != nil {
+		t.Error("TCPPrequeued should be nil when the kernel does not report it")
 	}
 }


### PR DESCRIPTION
## What

Add 10 legacy `TcpExt` counters to the `/proc/net/netstat` model and parser:
`PAWSPassive`, `TCPPrequeued`, `TCPDirectCopyFromBacklog`,
`TCPDirectCopyFromPrequeue`, `TCPPrequeueDropped`, `TCPLoss`,
`TCPFACKReorder`, `TCPForwardRetrans`, `TCPHPHitsToUser`,
`TCPSchedulerFailed`.

## Why

These counters are absent from the current kernel's `TcpExt` table (none of
them are in linus/master `include/uapi/linux/snmp.h`), but older kernels still
print them in `/proc/net/netstat`. node_exporter is switching its netstat
collector to these parsers (prometheus/node_exporter#3796), and would
otherwise silently drop these metrics for users whose
`--collector.netstat.fields` regex selects them.

## Behavior

- Purely additive: the fields are `*float64` and stay `nil` when the kernel
  does not print them (all modern kernels), matching the optional-field
  semantics from #464.
- Tests cover both the "older kernel prints them" and "modern kernel doesn't"
  cases.

## Out of scope

- `IcmpMsg` / `Icmp6Msg` per-type counters: the kernel only prints non-zero
  `InTypeN`/`OutTypeN` entries, so the set is host-dependent and open-ended —
  a fixed struct can't cover it (a map, like `NetDev`, or an unknown-keys
  escape hatch would). Separate follow-up.
- The `StatValue` refactor floated in prometheus/node_exporter#3796: changing
  all netstat/snmp field types would be a breaking API change for existing
  consumers; separate discussion.


Note on scope: this PR closes the *backward* gap (counters older kernels print that
were never modeled). procfs's `TcpExt` also lags the *current* kernel in the other
direction (e.g. `TCPDelivered`, `TCPAckCompressed`, `TCPZeroWindowDrop`,
`TCPBacklogCoalesce`, `BeyondWindow`, `TCPTimeoutRehash`, `TCPDSACKRecvSegs`,
`TCPMigrateReq*`, `TCPAO*` are printed by modern kernels but not modeled). That
forward lag is procfs's ordinary upkeep, pre-exists this change, and affects all
consumers; it is deliberately out of scope here rather than bundled in.
