### PR TITLE
sysfs: handle cpufreq files with <unknown> values

### DIFF
--- a/sysfs/system_cpu.go
+++ b/sysfs/system_cpu.go
@@ -16,6 +16,7 @@
 package sysfs
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -284,6 +285,14 @@ func parseCpufreqCpuinfo(cpuPath string) (*SystemCPUCpufreqStats, error) {
 		v, err := parsers.ReadUintFromFile(filepath.Join(cpuPath, f))
 		if err != nil {
 			if os.IsNotExist(err) || os.IsPermission(err) {
+				continue
+			}
+			// The kernel writes the sentinel "<unknown>" to some cpufreq
+			// files (e.g. scaling_cur_freq) when the current frequency
+			// cannot be sampled. Treat it like a missing file and leave the
+			// value nil, instead of failing the whole read.
+			var numErr *strconv.NumError
+			if errors.As(err, &numErr) && numErr.Num == "<unknown>" {
 				continue
 			}
 			return &SystemCPUCpufreqStats{}, err

--- a/sysfs/system_cpu_test.go
+++ b/sysfs/system_cpu_test.go
@@ -165,8 +165,9 @@ func TestSystemCpufreq(t *testing.T) {
 		},
 		// The following files are missing for the second CPU:
 		// * `cpuinfo_avg_freq`
-		// * `scaling_cur_freq`
 		// * `trans_table`
+		// `scaling_cur_freq` contains the sentinel "<unknown>", which must be
+		// treated as an unavailable value (nil), not a parse error.
 		{
 			Name:                     "1",
 			CpuinfoCurrentFrequency:  makeUint64(1200195),

--- a/testdata/fixtures.ttar
+++ b/testdata/fixtures.ttar
@@ -18212,6 +18212,11 @@ Lines: 1
 performance powersave
 Mode: 644
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/sys/devices/system/cpu/cpu1/cpufreq/scaling_cur_freq
+Lines: 1
+<unknown>
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/sys/devices/system/cpu/cpu1/cpufreq/scaling_driver
 Lines: 1
 intel_pstate


### PR DESCRIPTION
Fixes #304

## Description

The kernel can write the sentinel `<unknown>` to cpufreq files (e.g. `scaling_cur_freq`) when the current frequency cannot be sampled (reported in #304, with the downstream symptom in prometheus/node_exporter#1710: the whole cpufreq collector stops exporting when a single CPU hits the sentinel).

Currently `parseCpufreqCpuinfo` treats that as a parse error and fails the whole read, so `SystemCpufreq()` returns an error and consumers lose **all** cpufreq metrics, not just the one unavailable value.

This change treats the exact `<unknown>` sentinel like a missing file: the affected `*uint64` field is left `nil`, which is the established contract for unavailable values in `SystemCPUCpufreqStats` (e.g. `cpuinfo_cur_freq` is only readable as root, so absent files already produce `nil`, and consumers check for `nil`).

Detection mirrors the `errors.As` idiom already used in `net_class.go` for `EINVAL`: only a `*strconv.NumError` whose input is exactly `<unknown>` is skipped, so any other malformed value still returns an error.

## Testing

- `TestSystemCpufreq` now covers the sentinel: the `cpu1` fixture's `scaling_cur_freq` contains `<unknown>` and must parse to `ScalingCurrentFrequency: nil` (the missing-file path is still covered by `cpu0`'s absent `cpuinfo_cur_freq`).
- Verified locally with `GOOS=linux go build ./...`, `go vet`, `go test -c`, `gofmt`, and by extracting the modified `fixtures.ttar` with `./ttar -x`. The Linux-only sysfs tests themselves can't run on my macOS dev machine — looking forward to the CI results.
